### PR TITLE
Commit launch.json so every worktree can run the preview

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,19 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "static",
+      "runtimeExecutable": "python",
+      "runtimeArgs": ["-m", "http.server", "4173"],
+      "port": 4173,
+      "url": "http://localhost:4173"
+    },
+    {
+      "name": "static-alt",
+      "runtimeExecutable": "python",
+      "runtimeArgs": ["-m", "http.server", "4174"],
+      "port": 4174,
+      "url": "http://localhost:4174"
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,12 @@
-# local tooling / editor. `.claude/` is ignored except the three files that carry the
-# worktree-per-change rule: the hook has to exist inside every worktree as well as the
-# main checkout, and a worktree only gets a file if git puts it there.
+# local tooling / editor. `.claude/` is ignored except the four files every worktree
+# needs: the three that carry the worktree-per-change rule, and the launch config the
+# preview starts the static server from. A worktree only gets a file if git puts it
+# there, so anything ignored here is missing from the tree every change is made in.
 .claude/*
 !.claude/settings.json
 !.claude/worktree-per-change.json
 !.claude/hooks/
+!.claude/launch.json
 .openai/
 .agents/
 .codex/


### PR DESCRIPTION
Follow-up to the worktree-per-change rule. A worktree is a fresh checkout of tracked files only, so `.claude/launch.json` being ignored meant no worktree had it and `preview_start` had nothing to launch — which reads as broken tooling rather than a missing file.

It names two `python -m http.server` ports and nothing machine-specific, so committing it is the honest fix rather than `.worktreeinclude`.