### PR TITLE
Let the whole resume block be moved off the page's centre

### DIFF
--- a/design/README.md
+++ b/design/README.md
@@ -175,6 +175,17 @@ as you drag — same trick as the lab, so nothing is cloned and it can't drift.
 This is the tool the current stack was chosen with; the four rows start on the
 stacks `portfolio/styles.css` declares today, marked `(ships)` in each list.
 
+**Page → shift right** is the one row that moves the CV rather than setting it:
+`.col { translate }`, the whole resume block off the page's centre line —
+masthead, intro, photo strip, work, education, contact and the toggle together,
+negative for left. A `translate` and not a margin, so the layout box stays put
+and nothing re-wraps at any offset, and the strip's full-bleed and edge fade
+travel with the text instead of being re-derived against a new centre. The cut
+title doesn't move (it is `.page`'s child, not `.col`'s) and neither do the two
+corner pictures, which is both the use of the row — judging the block against the
+plate and the car — and the alignment it costs. There is nothing to shift into on
+a phone, where the gutter is 1.35rem.
+
 ### The font lists
 
 **Whichever face the pointer is on is the face in the page**, so the way to

--- a/design/type-tuner.html
+++ b/design/type-tuner.html
@@ -543,7 +543,15 @@ var GROUPS = [
   { name: "Page", rows: [
     { sel: "body",  prop: "font-size",   unit: "px",  def: 15,   min: 11, max: 22, step: 0.25, label: "base size",   hi: ".col" },
     { sel: "body",  prop: "line-height", unit: "",    def: 1.55,                    label: "base leading",           hi: ".col" },
-    { sel: ":root", prop: "--col",       unit: "rem", def: 27,   min: 16, max: 44, step: 0.25, label: "column width", hi: ".col" }
+    { sel: ":root", prop: "--col",       unit: "rem", def: 27,   min: 16, max: 44, step: 0.25, label: "column width", hi: ".col" },
+
+    /* The one row here that moves the CV rather than setting it: the whole block
+       off the page's centre line. Outline and no tint, like the edge fade — a
+       wash of orange over the entire column hides everything being judged. */
+    { sel: ".col",  prop: "translate",   unit: "rem", def: null, min: -14, max: 14, step: 0.05,
+      label: "shift right", hi: ".col", hiLine: true,
+      note: "not declared today — the column is centred by `margin: 0 auto auto`",
+      tip: "The whole resume block, off centre: masthead, intro, photo strip, work, education, contact and the toggle all move together, because all of them are .col. Negative moves it left.\n`translate` rather than a margin, deliberately. The layout box stays where it was and only the paint moves, so nothing re-wraps at any offset and the strip's full-bleed and its edge fade travel with the text instead of being re-derived against a new centre — which is what a margin would ask for.\nWhat does NOT move: the cut title (it is .page's own child, not .col's, so PROJECTS stays on the page's own axis) and the two corner pictures, which are painted on body. That is the point of the row — it is for judging the block against the plate and the car — and it is also what a shift takes out of alignment, so watch the title's left edge as well as the column's.\nOn a narrow window there is nothing to shift into: at 27rem the gutter is down to 1.35rem on a phone, and html and body clip overflow-x, so the text simply leaves the screen. Judge this at a real desktop size." }
   ] },
 
   /* hi: a custom property governs whatever reads it, so these point at the text


### PR DESCRIPTION
The tuner could set every measure in the column and not the one thing that is a composition decision rather than a typographic one: where the block stands against the plate in the bottom-left corner and the car in the top-right.

Page -> shift right is `.col { translate }`, so the layout box stays where it was and only the paint moves - nothing re-wraps at any offset, and the strip's full-bleed and its edge fade travel with the text instead of being re-derived against a new centre. The cut title and the corner pictures do not move, which is both the use of the row and the alignment it costs; the tip says so.
