### PR TITLE
Give each corner picture its own grade

### DIFF
--- a/design/plate/build-plate.py
+++ b/design/plate/build-plate.py
@@ -1,15 +1,14 @@
 #!/usr/bin/env python3
 """Rebuild the graded corner pictures — one file per rung of OUT_WIDTHS and per
-theme in GRADES, for whichever of PICTURES is named.
+theme in the picture's own `grades`, for whichever of PICTURES is named.
 
     python design/plate/build-plate.py <source.rw2 | source.png> [plate | car]
 
 Two pictures, one pipeline — see PICTURES. `plate` is St Paul's over the
 rooftops in the page's bottom-left corner and is the default; `car` is a cable
-car hanging off its pylon in the top-right. They share every constant below,
-which is the point rather than an economy: the two are meant to read as one
-paper stock the column is printed on, and a grade tuned on one and eyeballed
-onto the other is exactly how that comes apart. Each is built on its own run,
+car hanging off its pylon in the top-right. They share every stage of the
+pipeline and none of its numbers: each carries its own Grade per theme, so the
+four blocks under THE GRADE are the four answers. Each is built on its own run,
 because each has its own source frame and only one of them is usually moving.
 
 Writes the ladder from either of two sources. Deterministic: same input,
@@ -68,8 +67,8 @@ colonnade are spread right across the frame, so any ramp wide enough to hide an
 edge is also on top of the subject. What makes the plate recede is
 `--plate-opacity` in the stylesheet.
 
-ONE LADDER PER THEME
---------------------
+A GRADE PER PICTURE, A LADDER PER THEME
+---------------------------------------
 `--plate-opacity` was for a long time the whole of the difference between the
 plate on white and the plate on black, and one baked file served both. Opacity
 alone can only ever do one thing, though: mix the picture further into the page.
@@ -79,22 +78,43 @@ on paper the plate is a grey building on white and on black it is the same grey
 building with nothing under it, and the two want different endpoints rather than
 different amounts of one set.
 
-So GRADES holds a Grade per theme and main() bakes a ladder for each. What the
+So a Picture holds a Grade per theme and main() bakes a ladder for each. What the
 stylesheet still owns is placement and opacity; what the file owns is the grade,
 per theme, which is the same division as before with the theme axis added.
 
-The theme axis crosses the picture axis rather than competing with it: GRADES is
-shared by both pictures for the same reason every other constant is, so a run
-writes one ladder per theme for the one stem it was given. The two ladders are
-named `<stem>-<width>.webp` and `<stem>-dark-<width>.webp`, matching how
-styles.css already declares `--plate-opacity` — once in `:root` and again in
-`:root[data-theme="dark"]`. Light is the unsuffixed one because it is the page's
-default and because that is the name the plate has always had.
+The grade is per PICTURE as well, and that half arrived second. One set of
+numbers ran over both frames for a while, deliberately: the two are meant to read
+as one paper stock the column is printed on, and the fear was that a grade tuned
+on one and eyeballed onto the other is how that comes apart. What actually
+happened is that they are two photographs. The plate is a hazy backlit dome that
+fills its frame; the car is a gondola on a wire with a gantry cut across the top
+of it, shot in different light on a different day. SHADOW and HIGHLIGHT are
+absolute — they say where black and white LAND, in output units — so one pair
+cannot be right for both frames, and there was no knob that could say so:
+--car-opacity mixes the car further into the page and moves neither endpoint,
+which is the same thing --plate-opacity could not do across the themes.
 
-When a theme's Grade is identical to light's, its ladder is not written at all
-and portfolio/index.html falls back to the light file. That is a designed state
-and not a missing one: two byte-identical ladders on disk would be pure cost, so
-the dark files exist exactly when dark has been tuned to something of its own.
+Sharing them was also never what made the two read as one stock. The pipeline is
+what does that — percentile exposure, the same shoulder, the same desaturation
+toward the same tint — and that is still shared, stage for stage. What is per
+picture is only where each frame's ends are pinned.
+
+So the grade axes are picture × theme, four Grades, and the tuner has both
+switches: the theme button swaps which grade you are dragging AND which paper it
+stands on, the plate/car button swaps which grade you are dragging AND which
+frame it runs over. A run bakes one ladder per theme for the one stem it was
+given. The two ladders are named `<stem>-<width>.webp` and
+`<stem>-dark-<width>.webp`, matching how styles.css already declares
+`--plate-opacity` — once in `:root` and again in `:root[data-theme="dark"]`.
+Light is the unsuffixed one because it is the page's default and because that is
+the name the plate has always had.
+
+When a picture's dark Grade is identical to its own light one, its dark ladder is
+not written at all and portfolio/index.html falls back to the light file. That is
+a designed state and not a missing one: two byte-identical ladders on disk would
+be pure cost, so a picture's dark files exist exactly when its dark has been
+tuned to something of its own. The comparison is within one picture — the plate
+having tuned its dark says nothing about whether the car needs to.
 
 The one thing alpha is used for is the sky, and it is a matte rather than a crop.
 No sky is wanted, only the building. Cropping it out was tried first and cannot
@@ -108,7 +128,8 @@ sky_matte().
 THE GRADE
 ---------
 Order matters; this is the pipeline, and every stage is a field of Grade below —
-so every stage is also a thing the two themes can disagree about.
+so every stage is also a thing the two themes, and the two pictures, can disagree
+about. The pipeline itself is shared by all four; only its numbers are not.
 
 1. Develop linear (`gamma=(1, 1)`, `no_auto_bright=True`). Grading multiplicative
    things — exposure, desaturation — in linear light is the difference between
@@ -155,12 +176,15 @@ loud the plate is: everything before them shapes a 0..1 ramp, and they say what
 0 and 1 mean in ink. They are the first place to reach for, and the reason the
 tuner has an "overall level" slider that drives both at once.
 
-They are also the pair with the most obviously theme-dependent answer, which is
-what ONE LADDER PER THEME above is about. The plate has to stay quieter than the
-type at both ends — a half-page image that is louder than the words becomes the
-thing you look at first — and "quieter than the type" is measured against the
-paper and ink of the theme it is standing in (styles.css `:root` and
-`:root[data-theme="dark"]`), which are inverted between the two.
+They are also the pair whose answer depends most obviously on both axes, which is
+what A GRADE PER PICTURE, A LADDER PER THEME above is about. Either picture has to
+stay quieter than the type at both ends — a half-page image that is louder than
+the words becomes the thing you look at first — and "quieter than the type" is
+measured against the paper and ink of the theme it is standing in (styles.css
+`:root` and `:root[data-theme="dark"]`), which are inverted between the two. It is
+measured against the frame as well: the plate spreads a dome across half the page
+and the car hangs a gondola in a corner, so the same HIGHLIGHT that reads as
+recessive stone on one can be the brightest thing on the screen on the other.
 
 NEUTRAL SOURCE
 --------------
@@ -202,7 +226,8 @@ from scipy import ndimage
 
 # ---- the grade ------------------------------------------------------------
 class Grade(NamedTuple):
-    """One theme's worth of the pipeline in THE GRADE above, stage by stage.
+    """One picture's worth of the pipeline in THE GRADE above, in one theme,
+    stage by stage.
 
     The fields are SHOUTED because they are the constants — these are the names
     design/plate/plate-tuner.html prints in the block you paste back, and they
@@ -219,7 +244,17 @@ class Grade(NamedTuple):
     GRAIN_SIGMA: float                  # in output units, 0..1
 
 
-GRADE_LIGHT = Grade(
+# Four Grades, named <STEM>_<THEME> — which is the name design/plate/plate-tuner.html
+# prints over each block it asks you to paste, so the block and the call it
+# replaces are found by the same word. Each is spelled out in full, and none is
+# written as another's name, on purpose: the whole point of splitting them is that
+# a number moved on one frame reaches nothing else, and `CAR_LIGHT = PLATE_LIGHT`
+# would quietly re-bake the car out of a session spent looking at the plate.
+#
+# They open on identical numbers, because that is what shipped while there was one
+# grade for everything, so this commit changes no pixel of either picture. What it
+# changes is that moving one of them now moves one of them.
+PLATE_LIGHT = Grade(
     EXPOSURE_PCT=99.0,
     EXPOSURE_TARGET=0.34,
     SAT_KEEP=0.24,
@@ -230,27 +265,46 @@ GRADE_LIGHT = Grade(
     GRAIN_SIGMA=0.0075,
 )
 
-# Dark opens as light itself, which is deliberately the least interesting thing
-# it could be: identical means main() writes no dark ladder at all, the page
-# falls back to the light file, and the plate on black is exactly what it is
-# today. Nothing about the picture changes until somebody moves a number — and
-# the way to move one is in the tuner, on the dark preview, where the question
-# "is this too loud on black" is actually visible.
+# A picture's dark opens as its OWN light, which is deliberately the least
+# interesting thing it could be: identical means main() writes no dark ladder for
+# it at all, the page falls back to its light file, and the picture on black is
+# exactly what it is today. Nothing changes until somebody moves a number — and
+# the way to move one is in the tuner, on the dark preview, where the question "is
+# this too loud on black" is actually visible.
 #
-# The tuner prints this as a Grade(...) of its own rather than as a second name
-# for light's, so pasting its answer is what ends the aliasing. Until then, a
-# hand edit to GRADE_LIGHT does move both, which is the right default for two
-# grades that are meant to be the same picture.
-GRADE_DARK = GRADE_LIGHT
+# The tuner prints this as a Grade(...) of its own rather than as a second name for
+# light's, so pasting its answer is what ends the aliasing. Until then a hand edit
+# to PLATE_LIGHT does move both, which is the right default for two grades that are
+# meant to be the same picture on two papers. It does NOT reach the car.
+PLATE_DARK = PLATE_LIGHT
 
-# Light first: it is the page's default, and out_path() spells it unsuffixed.
-GRADES = {"light": GRADE_LIGHT, "dark": GRADE_DARK}
+CAR_LIGHT = Grade(
+    EXPOSURE_PCT=99.0,
+    EXPOSURE_TARGET=0.34,
+    SAT_KEEP=0.24,
+    CONTRAST=0.36,
+    HIGHLIGHT_PUSH=1.34,
+    SHADOW=(0x00, 0x00, 0x00),      # pure black
+    HIGHLIGHT=(0x5c, 0x5c, 0x5c),   # mid grey
+    GRAIN_SIGMA=0.0075,
+)
+
+CAR_DARK = CAR_LIGHT
+
+# Light first in each: it is the page's default, and out_path() spells it
+# unsuffixed. Hung off the Picture below rather than held in a second dict keyed
+# by stem, so there is no pair of tables to drift apart.
+PLATE_GRADES = {"light": PLATE_LIGHT, "dark": PLATE_DARK}
+CAR_GRADES = {"light": CAR_LIGHT, "dark": CAR_DARK}
 
 GRAIN_SEED = 20250615      # the frame's own date; any constant would do
-# One seed for both themes, and not a field of Grade: the grain is the frame's
-# own, so the two ladders wear the SAME grain at whatever strength each asks for.
-# Two streams would make flipping the theme move every grain in the picture, on
-# top of the change you meant.
+# One seed for every grade, and not a field of Grade: the grain is the frame's
+# own, so a picture's two ladders wear the SAME grain at whatever strength each
+# asks for. Two streams would make flipping the theme move every grain in the
+# picture, on top of the change you meant. Sharing it across the two PICTURES
+# costs nothing either way — they are different frames, so the same stream lands
+# on different pixels — and it keeps the seed what it is, a constant rather than a
+# decision.
 
 # ---- the sky matte --------------------------------------------------------
 # Brightness alone separates this frame, and it has to: the sky is a hazy backlit
@@ -338,13 +392,17 @@ OUT_DIR = REPO / "portfolio" / "img"
 # for the ladder, <stem>-source.webp and .json beside this script for the tuner,
 # and --<stem>-* for the custom properties in styles.css that place it.
 #
-# The theme is NOT in here. GRADES is shared, like every other constant above, so
-# the theme axis lives on out_path() and nowhere else in this class.
+# The grade IS in here, one Grade per theme, because it is a property of the frame
+# like everything else on this class — see A GRADE PER PICTURE, A LADDER PER THEME.
+# The theme axis is the one thing that stays outside it: `grades` is keyed by theme
+# and out_path() spells the theme into the filename, and those two are the whole of
+# it.
 @dataclass(frozen=True)
 class Picture:
     stem: str
     corner: str
     mirror: bool
+    grades: dict[str, Grade]
 
     @property
     def neutral_path(self) -> Path:
@@ -355,15 +413,18 @@ class Picture:
         return HERE / f"{self.stem}-source.json"
 
     def out_path(self, width: int, theme: str) -> Path:
-        """Light is unsuffixed — see ONE LADDER PER THEME. portfolio/index.html
-        builds these same two names; keep the two spellings together."""
+        """Light is unsuffixed — see A GRADE PER PICTURE, A LADDER PER THEME.
+        portfolio/index.html builds these same two names; keep the two spellings
+        together."""
         return OUT_DIR / (f"{self.stem}-{width}.webp" if theme == "light"
                           else f"{self.stem}-{theme}-{width}.webp")
 
 
 PICTURES = {
-    "plate": Picture(stem="plate", corner="bottom-left", mirror=True),
-    "car":   Picture(stem="car",   corner="top-right",   mirror=False),
+    "plate": Picture(stem="plate", corner="bottom-left", mirror=True,
+                     grades=PLATE_GRADES),
+    "car":   Picture(stem="car",   corner="top-right",   mirror=False,
+                     grades=CAR_GRADES),
 }
 DEFAULT_PICTURE = "plate"
 
@@ -622,10 +683,11 @@ def write_neutral(pic: Picture, lin: np.ndarray, alpha_f: np.ndarray, computed: 
         "width": img.width,
         "height": img.height,
         "outWidths": list(OUT_WIDTHS),
-        # Keyed by theme, because the grade is. The tuner files each theme's
-        # numbers under its own key and shows you the one you are looking at —
-        # the same shape its per-theme placement rows already use.
-        "grade": {theme: grade_json(g) for theme, g in GRADES.items()},
+        # Keyed by theme, because the grade is. The picture axis needs no key: this
+        # file IS one picture's, so <stem>-source.json holding its own two themes is
+        # the whole of per-picture on this end. The tuner files each theme's numbers
+        # under its own key and shows you the one you are looking at.
+        "grade": {theme: grade_json(g) for theme, g in pic.grades.items()},
         "matte": {
             "SKY_LUMA_MIN": SKY_LUMA_MIN,
             "SKY_LUMA_LOW": SKY_LUMA_LOW,
@@ -670,12 +732,12 @@ def main() -> int:
           f"({'cut here' if computed else 'matte supplied'})")
 
     written = set()
-    for theme, g in GRADES.items():
-        # A theme that has not been tuned away from light writes nothing: the
-        # page falls back to the light file, so a second identical ladder would
-        # be a megabyte of duplicate on disk and in the repo, bought with
-        # nothing. See ONE LADDER PER THEME.
-        if theme != "light" and g == GRADES["light"]:
+    for theme, g in pic.grades.items():
+        # A theme that has not been tuned away from THIS PICTURE's light writes
+        # nothing: the page falls back to the light file, so a second identical
+        # ladder would be a megabyte of duplicate on disk and in the repo, bought
+        # with nothing. See A GRADE PER PICTURE, A LADDER PER THEME.
+        if theme != "light" and g == pic.grades["light"]:
             print(f"{theme}: same grade as light — no ladder "
                   f"(portfolio/index.html falls back to the light file)")
             continue

--- a/design/plate/plate-tuner.html
+++ b/design/plate/plate-tuner.html
@@ -155,12 +155,13 @@
      script writes for exactly this purpose — so that a slider answers in a frame
      instead of in a forty-second re-develop of a 19 MB raw. The answer you keep
      is a block of Python to paste back.
-     The grade is TWO sets of numbers, one per theme, because the script bakes a
-     ladder for each — a picture on black wants its own endpoints rather than
-     more of light's, and opacity cannot say that. The theme button therefore
-     swaps which grade you are dragging as well as which paper it stands on. The
-     matte is not per theme and should not become so: it is the shape of the
-     building, which is one photograph either way.
+     The grade is FOUR sets of numbers — picture × theme — because the script
+     bakes a ladder per theme out of a Grade per picture. A picture on black
+     wants its own endpoints rather than more of light's, and opacity cannot say
+     that; the car wants its own rather than the plate's, and nothing in the
+     stylesheet can say that either. So both switches in the top bar swap which
+     grade you are dragging. The matte is not per theme and should not become so:
+     it is the shape of the building, which is one photograph either way.
    * THE PLACEMENT is a handful of custom properties in portfolio/styles.css, and
      those are live: the preview is the real page in an iframe with the regraded
      picture dropped into it, so what moves under the type here moves there.
@@ -168,20 +169,35 @@
      screen and is the datum both pictures are scaled to rather than a placement,
      which is why there is no slider for it here.
 
-   ONE GRADE, TWO FRAMES. build-plate.py has one block of grade constants per
-   THEME, and runs whichever the theme asks for over both pictures, deliberately —
-   the two are meant to read as one paper stock, and a grade tuned on one and
-   eyeballed onto the other is exactly how that comes apart. So the two switches
-   in the top bar do different things: the `plate`/`car` one changes which frame
-   you are LOOKING at, not which numbers you are dragging, while the theme one
-   changes both. The sliders are the same sliders across the pictures, and the
-   point of that switch is to check that an answer found on one frame survives the
-   other before you paste it.
+   A GRADE PER FRAME, PER THEME. build-plate.py has one block of grade constants
+   per picture per theme — PLATE_LIGHT, PLATE_DARK, CAR_LIGHT, CAR_DARK — so the
+   two switches in the top bar now do the same KIND of thing: each swaps which of
+   the four grades the sliders are pointed at, and each also swaps what you are
+   judging it against. The theme button changes the paper under the frame; the
+   `plate`/`car` button changes the frame. The Grade panel says which picture it
+   is holding, in its heading, because the whole of the confusion this replaces
+   was a slider that looked like it applied to what you were looking at and did
+   not.
+
+   One set of numbers ran over both frames until this, on the theory that the two
+   should read as one paper stock. They still should, and the thing that makes
+   them is the pipeline — the same percentile exposure, the same shoulder, the
+   same desaturation toward the same tint — which is still one pipeline. What is
+   per picture is only where each frame's black and white are pinned, and those
+   are absolute: one pair of endpoints cannot be right for a dome that fills its
+   frame and a gondola on a wire.
 
    The picture you have switched to is the one regraded live in the preview. The
    other stays exactly as it shipped — it is whatever the last run of the script
    put in portfolio/img/, which is the honest thing for it to be while you are
-   not looking at it, and it means the frame only ever carries one canvas.
+   not looking at it, and it means the frame only ever carries one canvas. Which
+   is also why the grade rows swap rather than doubling up into two panels: a
+   grade you cannot see regraded is not one you can judge, and this tool's whole
+   premise is that you judge it on the page.
+
+   Both pictures' grades are read on boot, though, not just the one on screen, so
+   a session that tunes the plate and then the car exports both blocks. See
+   loadGrades().
 
    You cannot judge the grade without the placement. A grade read at 100% on a
    white field is a different photograph from the same grade at 0.12 behind a
@@ -305,18 +321,18 @@ var CAR = [
 var MATTE_GROUP = { name: "Sky matte", rows: MATTE, py: true,
   note: "No sky is wanted, only the building — the page's own paper is the sky. Watch this one in the matte view." };
 var GROUPS = [
-  /* `dark` on the GROUP and not on a row: the whole grade is per-theme, because
-     build-plate.py bakes a ladder for each and a picture on black wants its own
-     endpoints rather than more of light's. So every row below is held, previewed
-     and exported twice, and the theme button decides which of the two you are
-     dragging. The matte is NOT — it is the shape of the building, which is one
-     photograph in both themes and would only be two chances to cut it
-     differently.
-     Per theme and NOT per picture, which are the two axes this tool keeps apart:
-     the same grade runs over both frames, so the plate/car switch changes the
-     frame under these rows and never the rows themselves. */
-  { name: "Grade", rows: GRADE, py: true, dark: true,
-    note: "Per theme, shared by both pictures, and baked into every <stem>-*.webp. Flip the theme button to tune the other one; re-run build-plate.py, once per picture, to ship a change." },
+  /* `dark` and `pic` on the GROUP and not on a row: the whole grade varies on both
+     axes, because build-plate.py holds a Grade per picture and bakes a ladder per
+     theme out of it. A picture on black wants its own endpoints rather than more of
+     light's, and the car wants its own rather than the plate's. So every row below
+     is held, previewed and exported FOUR times, and the two buttons in the top bar
+     decide which of the four you are dragging.
+     The matte is neither — it is the shape of the building, which is one photograph
+     in both themes, and per picture only in the sense that each source file brings
+     its own (and both bring a cut one today, so the panel hides itself). */
+  { name: "Grade", rows: GRADE, py: true, dark: true, pic: true,
+    head: function () { return "Grade — the " + picture().label + ", " + picture().corner; },
+    note: "Per picture AND per theme: four blocks in build-plate.py, baked into <stem>-*.webp. The two buttons up top choose which one these rows are pointed at. Re-run build-plate.py, once per picture, to ship a change." },
   MATTE_GROUP,
   { name: "Placement — the plate, bottom-left", rows: PLACE, css: true,
     note: "portfolio/styles.css, live in the frame." },
@@ -326,9 +342,12 @@ var GROUPS = [
 var ROWS = [];
 GROUPS.forEach(function (g) { g.rows.forEach(function (r) {
   r.group = g;
-  /* A per-theme group makes every row in it per-theme. Placement stays the other
-     way round — one row there carries `dark`, the rest are shared. */
+  /* A per-theme group makes every row in it per-theme, and likewise per-picture.
+     Placement stays the other way round — one row there carries `dark`, the rest
+     are shared — and no placement group is `pic`, because the two pictures have
+     separate placement ROWS rather than one set that swaps. */
   if (g.dark) r.dark = true;
+  if (g.pic) r.pic = true;
   ROWS.push(r);
 }); });
 /* Every row that is CSS rather than Python: what probe() reads off the live page
@@ -339,17 +358,29 @@ var CSS_ROWS = ROWS.filter(function (r) { return r.group.css; });
    applyLevel. Looked up rather than written twice, so the table above stays the
    only place a row is declared. */
 var LEVEL_ROW = ROWS.filter(function (r) { return r.k === "LEVEL"; })[0];
+/* The two it drives, looked up the same way. applyLevel wants the ROWS and not
+   the names, so that the key it writes comes out of keyOf() like every other and
+   there is no second place that knows how a grade key is spelled. */
+var END_ROWS = ROWS.filter(function (r) { return r.k === "SHADOW" || r.k === "HIGHLIGHT"; });
 
 /* ---- the two pictures ---------------------------------------------------- */
 /* `stem` is what build-plate.py names everything after — the source pair beside
    this file and the ladder in portfolio/img — and `sel` is what paints it in
    styles.css, which is what inject() has to override to put a live regrade under
    the type. Two different kinds of selector because the plate had body::after
-   spare and the car did not; see the .car block in that sheet. */
+   spare and the car did not; see the .car block in that sheet.
+   `corner` is this tool's own copy of what build-plate.py's PICTURES says, and is
+   spelled here rather than read off <stem>-source.json because the Grade panel's
+   heading wants it before any fetch has landed — the same reason the placement
+   groups have their corners written into their names. */
 var SOURCES = [
-  { k: "plate", label: "plate", stem: "plate", sel: "body::after" },
-  { k: "car",   label: "car",   stem: "car",   sel: ".car" }
+  { k: "plate", label: "plate", stem: "plate", sel: "body::after", corner: "bottom-left" },
+  { k: "car",   label: "car",   stem: "car",   sel: ".car",        corner: "top-right" }
 ];
+/* The picture keys in the order the switch shows them, for everything that has to
+   answer for both at once — the export, the badge, the four LEVEL bases. */
+var PIC_KEYS = SOURCES.map(function (s) { return s.k; });
+var THEMES = ["light", "dark"];
 function picture() {
   return SOURCES.filter(function (s) { return s.k === state.pic; })[0] || SOURCES[0];
 }
@@ -368,8 +399,14 @@ function picture() {
    the other's fix, so neither is safe to read here. Nothing in a store is worth
    migrating (it is a scratchpad over values that live in styles.css and
    build-plate.py), so the version is bumped past both and the old keys are left
-   to rot rather than read and converted. */
-var KEY = "plate-tuner-v3";
+   to rot rather than read and converted.
+
+   v4 for the third of exactly that: the grade went per PICTURE as well, so every
+   one of its values moved again, from `SHADOW@light` to `SHADOW@plate@light`. Same
+   failure mode as the v2 one — the old keys are never looked up, so a panel a
+   previous session had left dragged comes back reading unmoved with its numbers
+   sitting in the store — and the same answer, which is to bump past them. */
+var KEY = "plate-tuner-v4";
 var state = { vals: {}, place: {}, theme: "light", view: "page", preset: "frame", pic: "plate", w: 0, h: 0, shut: {} };
 try {
   var saved = JSON.parse(localStorage.getItem(KEY) || "null");
@@ -399,16 +436,42 @@ function save() { try { localStorage.setItem(KEY, JSON.stringify(state)); } catc
    does show that theme, so an edit to styles.css still lands. */
 var base = {};
 Object.keys(state.place).forEach(function (k) { base[k] = state.place[k]; });
-/* The third place, and the only one that is written down here: a tool-only row
-   has no line in any file to read a default off, so 1 — "the endpoints exactly as
-   the file has them" — is its own base. Once per theme, since the endpoints it
-   drives are per theme and "exactly as the file has them" is now two answers. */
-base["LEVEL@light"] = 1;
-base["LEVEL@dark"] = 1;
+/* The key a row's value is filed under. A row carries the axes it varies on, in
+   this order, and nothing else: per-picture rows carry the picture, per-theme rows
+   the theme, so flipping either switch genuinely swaps which number you are
+   dragging. This is the only place the shape of a key is spelled — keyAt() below
+   and readGrade() both come through it, so the store, the bases and the export
+   cannot disagree about it. */
+function axisKey(k, pic, theme) {
+  return k + (pic ? "@" + pic : "") + (theme ? "@" + theme : "");
+}
+/* One row's key at a NAMED picture and theme rather than at the ones on screen —
+   what the export and the badge ask, since they have to answer for all four. Axes
+   the row does not vary on are dropped, so a shared row has one key however this
+   is called. */
+function keyAt(r, pic, theme) {
+  return axisKey(r.k, r.pic ? pic : null, r.dark ? theme : null);
+}
+function keyOf(r) { return keyAt(r, state.pic, state.theme); }
 
-/* The key a row's value is filed under. Per-theme rows carry the theme in the
-   key, so flipping the toggle genuinely swaps which number you are dragging. */
-function keyOf(r) { return r.dark ? r.k + "@" + state.theme : r.k; }
+/* Every (picture, theme) a row is actually held under: one pair for a shared row,
+   two for a per-theme one, four for the grade. Written once here so that adding an
+   axis to a group is the whole of adding it — the badge, the export and the LEVEL
+   bases all count through this rather than each spelling out the combinations. */
+function combos(r) {
+  var out = [];
+  (r.pic ? PIC_KEYS : [state.pic]).forEach(function (p) {
+    (r.dark ? THEMES : [state.theme]).forEach(function (t) { out.push([p, t]); });
+  });
+  return out;
+}
+
+/* The third place a base comes from, and the only one that is written down here: a
+   tool-only row has no line in any file to read a default off, so 1 — "the
+   endpoints exactly as the file has them" — is its own base. Once per picture per
+   theme, since the endpoints it drives are, and "exactly as the file has them" is
+   now four answers. */
+combos(LEVEL_ROW).forEach(function (c) { base[keyAt(LEVEL_ROW, c[0], c[1])] = 1; });
 function baseOf(r) { return base[keyOf(r)]; }
 function val(r) { var v = state.vals[keyOf(r)]; return v == null ? baseOf(r) : v; }
 function changed(r) {
@@ -416,12 +479,13 @@ function changed(r) {
   return v != null && b != null && String(v) !== String(b);
 }
 function changedRows() { return ROWS.filter(changed); }
-/* changed() answers for the theme you are looking at, which is what a row's own
-   highlight wants. Everything that leaves this tool — the export, the badge over
-   it — has to answer for both, or a number moved on white would vanish from the
-   block the moment you flipped to black to check it. */
+/* changed() answers for the picture and theme you are looking at, which is what a
+   row's own highlight wants. Everything that leaves this tool — the export, the
+   badge over it — has to answer for all four, or a number moved on the plate in
+   white would vanish from the block the moment you flipped to the car, or to
+   black, to check it. */
 function movedAnywhere(r) {
-  return r.dark ? (changedIn(r, "light") || changedIn(r, "dark")) : changed(r);
+  return combos(r).some(function (c) { return changedAt(r, c[0], c[1]); });
 }
 function changeCount() {
   var n = 0;
@@ -429,9 +493,9 @@ function changeCount() {
     /* The badge counts lines to paste, and a tool-only row is not one of them —
        it is counted by the two endpoint rows it has already moved. */
     if (r.tool) return;
-    if (!r.dark) { if (changed(r)) n++; return; }
-    if (changedIn(r, "light")) n++;
-    if (changedIn(r, "dark")) n++;
+    /* Once per combination it moved in, because that is how many numbers in
+       build-plate.py and styles.css it is asking you to change. */
+    combos(r).forEach(function (c) { if (changedAt(r, c[0], c[1])) n++; });
   });
   return n;
 }
@@ -949,13 +1013,12 @@ function pyBlock() {
     return "# nothing in the grade or the matte has moved";
   }
   /* This block's own count, and not the badge's: the badge counts every line to
-     paste anywhere, placement included, and those leave in the CSS block. A
-     per-theme row counts once per theme it moved in, because that is how many
+     paste anywhere, placement included, and those leave in the CSS block. A grade
+     row counts once per picture-and-theme it moved in, because that is how many
      numbers in build-plate.py it is asking you to change. */
   var n = matteMoved.length;
   gradeMoved.forEach(function (r) {
-    if (changedIn(r, "light")) n++;
-    if (changedIn(r, "dark")) n++;
+    combos(r).forEach(function (c) { if (changedAt(r, c[0], c[1])) n++; });
   });
   var out = [];
   out.push("# " + Array(72).join("─"));
@@ -965,18 +1028,30 @@ function pyBlock() {
   out.push("# against the raw. Nothing changes on the site until you do.");
   out.push("# " + Array(72).join("─"));
   if (gradeMoved.length) {
-    /* Both themes, in full, even when only one of them moved — and the whole
-       call rather than the lines that changed. Two reasons, and they are the
-       same reason twice: the file's GRADE_DARK may be written as light's, in
-       which case a light-only edit would silently drag dark along with it and
-       the preview you approved on black would not be what shipped; and a bare
-       `SHADOW = ...` line no longer says which of the two grades it belongs to.
-       Spelling both out costs a few lines of paste and removes both questions.
-       Emitting them identical is harmless — build-plate.py compares them by
-       value, so an untuned dark still writes no ladder. */
-    out.push(gradeCall("GRADE_LIGHT", "light"));
-    out.push("");
-    out.push(gradeCall("GRADE_DARK", "dark"));
+    /* A picture that moved is printed in BOTH themes, in full, even when only one
+       of them moved — and the whole call rather than the lines that changed. Two
+       reasons, and they are the same reason twice: the file's PLATE_DARK may be
+       written as its light's, in which case a light-only edit would silently drag
+       dark along with it and the preview you approved on black would not be what
+       shipped; and a bare `SHADOW = ...` line does not say which of the four grades
+       it belongs to. Spelling the calls out costs a few lines of paste and removes
+       both questions. Emitting the two identical is harmless — build-plate.py
+       compares them by value, so an untuned dark still writes no ladder.
+       A picture that did NOT move is left out entirely, which is the difference the
+       picture axis makes: the two are separate calls in the file now, with neither
+       written as the other's name, so there is nothing for an untouched car to be
+       dragged along by and no reason to hand you its block to paste. */
+    PIC_KEYS.forEach(function (p) {
+      var movedHere = gradeMoved.some(function (r) {
+        return THEMES.some(function (t) { return changedAt(r, p, t); });
+      });
+      if (!movedHere) return;
+      out.push("");
+      THEMES.forEach(function (t, i) {
+        if (i) out.push("");
+        out.push(gradeCall(p, t));
+      });
+    });
   }
   if (matteMoved.length) {
     /* The matte is shared, so it stays a line at a time — there is only one of
@@ -991,14 +1066,17 @@ function pyBlock() {
   return out.join("\n");
 }
 
-/* One theme's Grade(...) as build-plate.py spells it. Rows that have moved carry
-   a `# was`; the rest are printed at the value the file already has, so the call
-   is complete and can be pasted over the old one whole. */
-function gradeCall(name, theme) {
-  var lines = [name + " = Grade("];
+/* One picture's Grade(...) in one theme, as build-plate.py spells it. Rows that
+   have moved carry a `# was`; the rest are printed at the value the file already
+   has, so the call is complete and can be pasted over the old one whole.
+   The name is built from the two axes rather than passed in — <STEM>_<THEME>, which
+   is what build-plate.py calls its four constants — so the block and the call it
+   replaces are named by the same rule at both ends. */
+function gradeCall(pic, theme) {
+  var lines = [pic.toUpperCase() + "_" + theme.toUpperCase() + " = Grade("];
   GRADE.forEach(function (r) {
     if (r.tool) return;
-    var kk = r.k + "@" + theme;
+    var kk = keyAt(r, pic, theme);
     var b = base[kk];
     var v = state.vals[kk];
     if (v == null) v = b;
@@ -1025,8 +1103,11 @@ function cssBlock() {
      belongs in its own block — so it is emitted once per theme it moved in. */
   moved.forEach(function (r) {
     if (r.dark) {
-      ["light", "dark"].forEach(function (t) {
-        if (!changedIn(r, t)) return;
+      THEMES.forEach(function (t) {
+        /* state.pic, because no CSS row is per-picture — the two pictures have
+           their own placement rows rather than one set that swaps — so the picture
+           passed here is ignored by keyAt() and only has to be a valid one. */
+        if (!changedAt(r, state.pic, t)) return;
         bySel[t === "dark" ? '[data-theme="dark"]' : ":root"].push(decl(r, t));
       });
     } else {
@@ -1042,12 +1123,15 @@ function cssBlock() {
   });
   return out.join("\n");
 }
-function changedIn(r, theme) {
-  var kk = r.k + "@" + theme, v = state.vals[kk], b = base[kk];
+/* changed(), asked about a named picture and theme instead of the ones on screen.
+   Through keyAt() rather than by building the key here, so a row that varies on
+   only one of the two axes is asked the right question. */
+function changedAt(r, pic, theme) {
+  var kk = keyAt(r, pic, theme), v = state.vals[kk], b = base[kk];
   return v != null && b != null && String(v) !== String(b);
 }
 function decl(r, theme) {
-  var kk = theme ? r.k + "@" + theme : r.k;
+  var kk = axisKey(r.k, null, theme);   /* no CSS row is per-picture; see cssBlock */
   var line = "  " + r.k + ": " + tidy(num(state.vals[kk], r.dp)) + r.unit + ";";
   while (line.length < 34) line += " ";
   return line + "/* was " + tidy(num(base[kk], r.dp)) + r.unit + " */";
@@ -1065,7 +1149,12 @@ function buildPanel() {
     var box = document.createElement("div");
     box.className = "g" + (state.shut[g.name] ? " shut" : "");
     var head = document.createElement("button");
-    head.type = "button"; head.className = "ghead"; head.textContent = g.name;
+    head.type = "button"; head.className = "ghead";
+    /* `head` when a group's title depends on what it is currently pointed at, which
+       the Grade one does now that its rows swap with the picture. `name` stays the
+       stable identity underneath — it is what state.shut is keyed on, so a panel you
+       collapsed does not spring open when you switch pictures. */
+    head.textContent = g.head ? g.head() : g.name;
     head.addEventListener("click", function () {
       state.shut[g.name] = !state.shut[g.name];
       box.classList.toggle("shut"); save();
@@ -1185,11 +1274,12 @@ function paintDerived() {
    swatches move under the slider as it goes, so it is never a silent one. */
 function applyLevel() {
   var f = +val(LEVEL_ROW);
-  /* The theme on screen only, and anchored on that theme's own two colours: the
-     slider is itself per-theme, so dragging it on black is a statement about the
-     dark grade and must not reach into the light one. */
-  ["SHADOW", "HIGHLIGHT"].forEach(function (k) {
-    var kk = k + "@" + state.theme;
+  /* The picture and theme on screen only, and anchored on THAT grade's own two
+     colours: the slider is itself per-picture and per-theme, so dragging it on the
+     car in black is a statement about CAR_DARK and must reach none of the other
+     three. keyOf() rather than a key built here, so it follows the rows. */
+  END_ROWS.forEach(function (r) {
+    var kk = keyOf(r);
     state.vals[kk] = "#" + rgbOf(base[kk]).map(function (c) {
       c = Math.round(c * f);
       return ("0" + (c < 0 ? 0 : c > 255 ? 255 : c).toString(16)).slice(-2);
@@ -1267,6 +1357,12 @@ chips(document.getElementById("pics"), SOURCES,
   function (it) {
     if (it.k === state.pic) return;
     state.pic = it.k; save();
+    /* Straight away, not on the fetch loadPicture() is about to do: the rows have
+       already swapped to this picture's grade — keyOf() reads state.pic — and the
+       heading that says which picture they are is the whole point of the switch
+       being visible. loadPicture() builds the panel again when it knows whether the
+       matte half exists; this is the half that must not wait for a round trip. */
+    buildPanel();
     paintChrome();
     loadPicture(it.k);
   });
@@ -1312,28 +1408,54 @@ frame.addEventListener("load", function () { probe(); inject(); paintDerived(); 
 function warn(html) { document.getElementById("warn").innerHTML = html; }
 
 /* A <stem>-source.json keys its grade by theme, because build-plate.py bakes one
-   per theme. A file written by an older build has no `light` key and carries a
-   single flat grade instead — that one becomes the base for BOTH themes here,
-   which is exactly what its single ladder was on the page. Worth the four lines:
-   the JSON is a build artefact and is not always regenerated in the same commit
-   that changes the script, so the tuner would otherwise open on a panel of
-   undefineds any time the two were briefly out of step. */
-function readGrade(g) {
+   per theme. The picture is not a key inside the file — the FILE is the picture —
+   so which one it belongs to is passed in, and that is where the second half of
+   the key comes from.
+   A file written by an older build has no `light` key and carries a single flat
+   grade instead — that one becomes the base for BOTH themes here, which is exactly
+   what its single ladder was on the page. Worth the four lines: the JSON is a build
+   artefact and is not always regenerated in the same commit that changes the
+   script, so the tuner would otherwise open on a panel of undefineds any time the
+   two were briefly out of step. plate-source.json is in exactly that state as this
+   lands, being older than the per-theme grade it predates. */
+function readGrade(pic, g) {
   var perTheme = (g && g.light) ? g : { light: g, dark: g };
-  ["light", "dark"].forEach(function (t) {
+  THEMES.forEach(function (t) {
     var src = perTheme[t] || perTheme.light;
     if (!src) return;
-    Object.keys(src).forEach(function (k) { base[k + "@" + t] = src[k]; });
+    Object.keys(src).forEach(function (k) { base[axisKey(k, pic, t)] = src[k]; });
   });
+}
+
+/* Both pictures' grades, on boot, whichever one you are looking at.
+   The export and the badge have to answer for all four grades at once — a session
+   that tunes the plate, switches to the car and tunes that has two blocks to paste
+   — and `changed` is a comparison against a base, so a grade with no base loaded
+   can neither show as moved nor reach the export. Reading only the picture on
+   screen would therefore drop the other one's edits out of the block the moment you
+   switched, which is the per-picture version of the bug the per-theme bases were
+   held for.
+   Failures are swallowed: this is the export's completeness and not the tool's
+   ability to run, loadPicture() reports the missing file for the picture that
+   actually needs one, and one absent car-source.json should not stop you grading
+   the plate. */
+function loadGrades() {
+  return Promise.all(SOURCES.map(function (s) {
+    return fetch(s.stem + "-source.json?" + Date.now()).then(function (r) {
+      return r.ok ? r.json() : null;
+    }).then(function (meta) {
+      if (meta) readGrade(s.k, meta.grade);
+    }).catch(function () {});
+  }));
 }
 
 /* One picture's source pair, fetched and decoded. Called on boot and again on
    every switch, which is why it puts the panel back together each time: whether
    the matte half exists at all is a property of the source that just arrived, not
-   of the tool. The grade constants are re-read too — both themes' — and they are
-   the same numbers either way, because build-plate.py writes one block per theme
-   into both files, so this is a no-op that keeps being true rather than a second
-   source of them. */
+   of the tool, and the Grade panel's heading names the picture that just became
+   the current one. This picture's grade constants are re-read too — both themes' —
+   which loadGrades() has already done once on boot; doing it again here is what
+   makes an edit to the JSON land on a switch rather than only on a reload. */
 function loadPicture(k) {
   var stem = (SOURCES.filter(function (s) { return s.k === k; })[0] || SOURCES[0]).stem;
   warn("");
@@ -1342,7 +1464,7 @@ function loadPicture(k) {
     return r.json();
   }).then(function (meta) {
     META = meta;
-    readGrade(meta.grade);
+    readGrade(k, meta.grade);
     /* null when the source arrived cut. The rows then have no base to be `was`,
        which is also why they cannot show as moved and cannot reach the export. */
     hasOwnMatte = !meta.matte;
@@ -1376,7 +1498,12 @@ function boot() {
   buildPanel();
   paintView();
   loadFrame();
-  loadPicture(state.pic);
+  /* The other picture's grade is wanted for the export and the badge, and the
+     current one's is wanted before anything can be drawn — so the four bases are
+     read first and the frame that needs one is loaded after. Ordered rather than
+     fired together because both write `base`, and loadPicture()'s pass for the
+     picture on screen should be the one that wins. */
+  loadGrades().then(function () { loadPicture(state.pic); });
 }
 
 boot();


### PR DESCRIPTION
The grade was one set of numbers for both photographs, and the plate/car
switch in the tuner changed which frame you were looking at without changing
which numbers you were dragging. So every slider in the Grade panel edited
the bottom-left picture and nothing edited the top-right one, and there was
no way to say so — the panel looked like it applied to whatever was on
screen.

Sharing them was deliberate, on the theory that the two should read as one
paper stock the column is printed on. They should, and the thing that makes
them is the pipeline — the same percentile exposure, the same shoulder, the
same desaturation toward the same tint — which is still one pipeline, shared
stage for stage. What cannot be shared is where each frame's ends are
pinned. SHADOW and HIGHLIGHT say where black and white LAND, in output
units, so one pair cannot be right for a hazy backlit dome that fills its
frame and a gondola on a wire shot in different light. --car-opacity mixes
the car further into the page and moves neither endpoint, which is the same
thing --plate-opacity could not do across the two themes.

So the grade axes are picture x theme, four Grades. build-plate.py holds
PLATE_LIGHT, PLATE_DARK, CAR_LIGHT and CAR_DARK, hung off the Picture that
owns them rather than in a second table keyed by stem, and main() bakes a
ladder per theme out of the one it was given. Each picture's dark still opens
as its OWN light, so identical still means no dark ladder is written and the
page still falls back to the light file; the comparison is within a picture
now, so the plate having tuned its dark says nothing about the car. None of
the four is written as another's name: `CAR_LIGHT = PLATE_LIGHT` would
quietly re-bake the car out of a session spent looking at the plate, which
is the bug this is meant to end. Filenames are unchanged, so index.html and
styles.css are untouched and no ?v= moves.

In the tuner the Grade group carries both axes, and the two buttons in the
top bar now do the same kind of thing: each swaps which of the four grades
the rows point at, and each also swaps what you judge it against — the theme
button the paper, the plate/car button the frame. The panel's heading names
the picture it is holding, which is the part that was actually missing. Keys
gained the picture, SHADOW@light becoming SHADOW@plate@light, spelled in one
place (axisKey) that the store, the bases and the export all come through;
combos() replaces the hand-written pairs of theme cases, so the badge and
the export count every combination a row is held under without knowing which
they are. The store bumps to v4 for the same reason it bumped to v3: the old
keys are never looked up again, so a panel left dragged would come back
reading unmoved.

The export prints both themes of a picture that moved, in full, and leaves a
picture that did not move out entirely — there is nothing for an untouched
car to be dragged along by now, so there is no reason to hand you its block.
Both pictures' grades are read on boot rather than only the one on screen,
because `changed` is a comparison against a base and a grade with no base
loaded can neither show as moved nor reach the block to paste.

Both grades open on the numbers that shipped, so this changes no pixel of
either picture. What it changes is that moving one of them moves one of them.
