### PR TITLE
Take the guard from the skill that now maintains it

### DIFF
--- a/.claude/hooks/worktree-guard.py
+++ b/.claude/hooks/worktree-guard.py
@@ -10,24 +10,38 @@ collide and a half-finished edit rides into someone else's commit.
 
 So the shape of every change is fixed:
 
-    EnterWorktree  ->  edit, commit  ->  push  ->  PR  ->  merge  ->  next change
+    EnterWorktree  ->  edit, commit  ->  push  ->  PR  ->  merge  ->  remove the tree
+                                                                     and the branch;
+                                                                     the next change
                                                                      gets a new one
 
-Three hooks hold the three ends of that:
+Three hooks hold the ends of that:
 
   * `PreToolUse` denies `Edit`/`Write`/`NotebookEdit` anywhere but a linked worktree,
     denies them in a worktree sitting on the integration branch, and denies them in a
     worktree whose PR has already merged — because "a new worktree every time" is only
     a real rule if reusing a spent one is refused.
   * `Stop` refuses to end a session that is walking away from committed-but-unlanded
-    work. A branch that only exists on this disk is not a delivered change.
+    work — a branch that only exists on this disk is not a delivered change — and
+    refuses just as much to end one sitting in a worktree whose PR *has* merged. The
+    teardown is the half that used to be nobody's: the change lands, the reply is
+    truthful, and a stale checkout plus a live push target stay behind for the next
+    session to work out the status of.
   * `SessionStart` states the protocol, so an agent knows it before its first denial
-    rather than after.
+    rather than after, and reports landed worktrees an earlier session left on disk.
 
 `git stash` is denied everywhere, worktree or not: `refs/stash` is a single stack for
 the whole repository, so a push in one worktree renumbers another's entries and a
 later `pop` in *either* takes the wrong one. It is the one hazard a worktree looks
 like it isolates and does not.
+
+Every rule is scoped to the tree the operation **targets**, not the directory the
+session happens to sit in — those differ constantly, and the session's own status is
+the wrong answer for every case where they do. So `cd ../other-repo && git add -A` is
+that repository's business and passes; a `git -C <main-checkout>` from a worktree is
+judged as the main checkout and does not; a write to an absolute path inside a linked
+worktree is judged as that worktree. A command that names no target means the
+session's own tree, which is what an ordinary command means anyway.
 
 It fails **open** on every question it cannot answer — no repo, unreadable git
 metadata, an unparseable payload. Blocking the only writer in a tree over state the
@@ -37,6 +51,11 @@ deleted.
   CLAUDE_WORKTREE_GATE=off        turns it off
   CLAUDE_WORKTREE_GATE=warn       reports instead of denying
   CLAUDE_INTEGRATION_BRANCH=x     overrides the branch changes merge into
+
+All three are read from the **hook's** environment, which is the Claude Code process's,
+so they are the operator's switches and not a session's: `CLAUDE_WORKTREE_GATE=off git
+add …` sets the variable for that command alone, and by then this hook has already run
+and denied it. Changing one takes effect for sessions started afterwards.
 """
 
 from __future__ import annotations
@@ -83,6 +102,18 @@ MUTATORS = {
     "mv",
 }
 
+# The characters a shell reads as operators rather than as part of a word. `\n` is in the
+# set deliberately, and `whitespace` is narrowed to match: shlex counts a newline as
+# whitespace, and whitespace is tested first, so leaving it there would erase the boundary
+# between two commands on separate lines and let a `cd` on the first leak into the second.
+_PUNCTUATION = "();<>|&\n"
+
+_GIT = {"git", "git.exe"}
+_CHDIR = {"cd", "pushd"}
+
+# The pre-tokenizer reading, kept for text the lexer cannot lex at all. It splits raw
+# characters, so it cannot tell a `&&` between two commands from one inside a quoted
+# argument — which is the false positive tokenizing first exists to remove.
 _SEGMENT = re.compile(r"&&|\|\||[;\n|]")
 
 # What "the change has landed" looks like on the command line. Seeing one of these
@@ -94,8 +125,15 @@ _MERGED = re.compile(r"\bgh\s+pr\s+merge\b", re.I)
 
 
 def key(path) -> str:
-    """A comparable spelling of a path. Case-insensitive where the filesystem is."""
-    return os.path.normcase(os.path.normpath(os.path.abspath(str(path))))
+    """A comparable spelling of a path. Case-insensitive where the filesystem is.
+
+    Symlinks are resolved, because the two paths being compared are frequently derived
+    from different sources and only one of them has been through git. Measured on macOS:
+    a repo under `/var/folders/…` records its worktrees' git dir as `/private/var/…`, so
+    an unresolved comparison reads one repository as two — which made the guard stand
+    down on the very tree it was protecting.
+    """
+    return os.path.normcase(os.path.realpath(str(path)))
 
 
 def find_tree(start: Path):
@@ -193,23 +231,128 @@ def spent_marker(common: Path, tree_root: Path) -> Path:
     return state_dir(common) / "spent" / f"{stem}.json"
 
 
-def mark_spent(common: Path, tree_root: Path, why: str) -> None:
+def mark_spent(common: Path, tree_root: Path, topic: str | None, why: str) -> None:
     path = spent_marker(common, tree_root)
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(
-            json.dumps({"tree": str(tree_root), "at": time.time(), "why": why}),
+            json.dumps(
+                {"tree": str(tree_root), "branch": topic, "at": time.time(), "why": why}
+            ),
             encoding="utf-8",
         )
     except OSError:
         pass
 
 
-def is_spent(common: Path, tree_root: Path) -> dict | None:
+def is_spent(common: Path, tree_root: Path, topic: str | None) -> dict | None:
+    """The marker saying this worktree's change has landed, if there is one.
+
+    What is spent is a *branch in a tree*, not a directory name. The marker file is named
+    after the worktree's leaf name — the only stable, filesystem-safe handle available —
+    so it has to confirm both fields before it applies. Two worktrees can share a leaf
+    name (`../hermes-dev-x` and `.claude/worktrees/hermes-dev-x`), and once cleanup is
+    routine a path gets *reused*: the same name, cut again off the integration branch, for
+    the next change. Trusting the filename alone would greet that fresh tree with "your
+    change has already landed", which is the most confusing denial this guard can produce.
+    """
     try:
-        return json.loads(spent_marker(common, tree_root).read_text(encoding="utf-8"))
+        marker = json.loads(spent_marker(common, tree_root).read_text(encoding="utf-8"))
     except (OSError, ValueError):
         return None
+    if not isinstance(marker, dict):
+        return None
+    recorded = marker.get("tree")
+    if isinstance(recorded, str) and key(recorded) != key(tree_root):
+        return None
+    # `branch` is absent from markers written before it was recorded. Those still mean
+    # what they said — the tree they name has merged — so a missing field matches.
+    was = marker.get("branch")
+    if isinstance(was, str) and topic is not None and was != topic:
+        return None
+    # An unfinished rebase or merge outranks the marker, because the marker is written
+    # before `gh pr merge` runs and a refused merge leaves the same one. Conflict
+    # resolution is a tree full of edits, every one of which this denial would refuse
+    # while telling the session its work was already delivered — and there is no remedy
+    # it could print, since the gate is the operator's and a fresh worktree abandons the
+    # conflict. Measured on 2026-08-13 against a `DIRTY` PR whose merge was refused.
+    #
+    # It does open a way past a *true* marker: start a rebase, then edit. That is a
+    # deliberate act, not an accident, and it sits with the redirect and the aliased
+    # `git` in "Limits" — the guard is here to stop a session continuing a merged branch
+    # by mistake, not to win against one determined to.
+    if mid_operation(tree_root):
+        return None
+    return marker
+
+
+def mid_operation(tree: Path) -> bool:
+    """Whether a rebase, merge or cherry-pick is unfinished in this worktree.
+
+    Stat-only, and deliberately so: this runs over every spent marker at SessionStart, and
+    the one thing the guard may not become is a `git` subprocess on a path it takes
+    routinely. Git records an in-progress operation as state inside the worktree's own git
+    dir, so its presence is the whole test.
+
+    What it is for: a tree in this condition cannot be a delivered change, whatever a
+    marker says about it. Conflict resolution is the work, and it is happening now.
+    """
+    try:
+        pointer = (tree / ".git").read_text(encoding="utf-8").strip()
+    except OSError:
+        return False
+    if not pointer.startswith("gitdir:"):
+        return False
+    git_dir = Path(pointer.split(":", 1)[1].strip())
+    return any(
+        (git_dir / name).exists()
+        for name in ("rebase-merge", "rebase-apply", "MERGE_HEAD", "CHERRY_PICK_HEAD")
+    )
+
+
+def sweep_spent(common: Path) -> list[str]:
+    """Landed worktrees still on disk, and a marker file dropped for each one that isn't.
+
+    Both halves are cleanup. The list is what a session inherits from one that crashed or
+    was killed between `gh pr merge` and taking its tree down, which nothing else reports:
+    a merged worktree is indistinguishable from an in-progress one to anybody reading
+    `git worktree list`.
+
+    Dropping the marker for a tree that is gone is not tidiness either. Markers are keyed
+    by the worktree's *leaf name*, so a stale one denies the first edit in the next
+    worktree that happens to be named the same — a fresh tree reported as already merged,
+    which is the most confusing denial this guard can produce.
+
+    A tree mid-rebase is left out of the list entirely, and its marker is left alone. The
+    marker is written *before* `gh pr merge` runs, so a merge that failed leaves exactly the
+    same file as one that landed; measured on 2026-08-13, a `DIRTY` PR whose merge was
+    refused had a spent marker, an unresolved rebase and ten modified files, and this sweep
+    named it to every new session as merged and asked for it to be removed. Being wrong in
+    that direction costs somebody else's conflict resolution, which is the most expensive
+    thing this hook could destroy, so the in-progress trees are the ones it stays quiet
+    about.
+    """
+    standing = []
+    try:
+        entries = sorted((state_dir(common) / "spent").iterdir())
+    except OSError:
+        return standing
+    for marker in entries:
+        try:
+            tree = json.loads(marker.read_text(encoding="utf-8")).get("tree")
+        except (OSError, ValueError, AttributeError):
+            continue
+        if not isinstance(tree, str) or not tree:
+            continue
+        if Path(tree).is_dir():
+            if not mid_operation(Path(tree)):
+                standing.append(tree)
+        else:
+            try:
+                marker.unlink()
+            except OSError:
+                pass
+    return standing
 
 
 def stop_blocks(common: Path, session: str, bump: bool = False) -> int:
@@ -231,32 +374,190 @@ def stop_blocks(common: Path, session: str, bump: bool = False) -> int:
 # ------------------------------------------------------------------- command parse
 
 
-def git_calls(command: str):
-    """Every git subcommand in a shell command, as (subcommand, args).
+def tokenize(command: str) -> list[str] | None:
+    """Shell tokens, quoting intact, operators as tokens of their own. None if unlexable.
 
-    Textual, and it never expands a variable: `git -C "$W" switch` is judged as a plain
-    `switch`. That is the guard being conservative rather than clever — the cost is
-    spelling a path out in full, and the alternative is trusting a shell expansion it
-    cannot evaluate.
+    Tokenizing *before* looking for command boundaries is the whole point of this
+    function. Splitting raw text on `&&`, `|` and newlines reads the inside of a quoted
+    argument as shell: measured on 2026-08-13, a `gh pr create --body "…"` whose body held
+    the line `cd ~/x && git add -A` and a markdown table of pipes was denied as a `git add`
+    in the main checkout. The lexer hands that body back as a single token, and a single
+    token is never a command.
+
+    `posix=False` — the default — is what keeps the quotes on, and they are exactly what
+    separates a quoted argument from a bare word. `unquote` takes them off again at the two
+    places that read a token as a path or as a command name, and nowhere else.
+    """
+    lexer = shlex.shlex(command, punctuation_chars=_PUNCTUATION)
+    lexer.whitespace_split = True
+    lexer.whitespace = " \t\r"
+    # `#` starts no comment, matching `shlex.split`, which turns comments off too. Dropping
+    # the rest of a line would hide whatever git call sits on it, and losing a call is the
+    # one direction this guard may not fail in.
+    lexer.commenters = ""
+    try:
+        return list(lexer)
+    except ValueError:
+        return None
+
+
+def unquote(token: str) -> str:
+    """A token with its shell quoting removed and nothing else touched.
+
+    Deliberately not `shlex.split`, which is POSIX-mode and consumes backslashes as well:
+    that would turn a PowerShell `C:\\Users\\x` into `C:Usersx` and hand the guard a path
+    resolving nowhere, on the one platform where `\\` is the separator.
+    """
+    out: list[str] = []
+    quote = ""
+    for character in token:
+        if quote:
+            if character == quote:
+                quote = ""
+            else:
+                out.append(character)
+        elif character in "'\"":
+            quote = character
+        else:
+            out.append(character)
+    return "".join(out)
+
+
+def names(token: str, commands: set[str]) -> bool:
+    """Whether a token is one of `commands` *as a command* — quoting allowed, prose not.
+
+    `"git"` counts: a shell runs it, so declining to read a quoted spelling would make the
+    whole guard one quote deep. A token holding whitespace does not count, and that is the
+    fix — `"cd ~/x && git add -A"` arrives from the lexer whole precisely so it can be told
+    apart from a command, and no command this guard cares about is spelled with a space.
+    """
+    bare = unquote(token)
+    if not bare or any(character.isspace() for character in bare):
+        return False
+    return Path(bare).name in commands
+
+
+def operator(token: str) -> bool:
+    """A token the lexer built out of punctuation alone — `&&`, `;`, `|`, a newline, a run
+    of them — which is where one command ends and the next begins."""
+    return bool(token) and all(character in _PUNCTUATION for character in token)
+
+
+def dir_token(token: str) -> str | None:
+    """A `cd` or `-C` argument as a directory, or None when it is not one to read.
+
+    `~` is expanded, because that expansion is deterministic and needs no shell. Anything
+    a shell would have to *evaluate* — `$VAR`, a backtick, a glob, `cd -` — is not, and
+    reads as None: guessing at it would be the guard trusting an expansion it cannot see.
+
+    The token still carries its quotes, because that is how the lexer marks an argument;
+    they come off first so that `cd "/tmp/a b"` reads as a path rather than as nothing.
+    """
+    token = unquote(token)
+    if not token or token.startswith("-"):
+        return None
+    if any(character in token for character in "$`*?"):
+        return None
+    return os.path.expanduser(token)
+
+
+def joined(base: str | None, token: str | None) -> str | None:
+    """`cd` and `-C` composed left to right, the way a shell and repeated `-C` compose.
+
+    None propagates: a leg this hook could not read makes the whole chain unreadable, and
+    an unreadable chain falls back to the session's own tree, which is the conservative
+    end (it is the tree the guard is there to protect).
+    """
+    if token is None:
+        return None
+    return os.path.join(base, token) if base else token
+
+
+def segments(command: str) -> list[list[str]]:
+    """The command as one token list per command, with every token's quoting still on.
+
+    Two readings, and the first is the one that runs. `tokenize` lexes the whole string
+    and hands back operators as tokens, so a `&&` or a `|` that is merely *inside* an
+    argument stays inside it. Only text the lexer refuses outright — an unbalanced quote,
+    and nothing else met in practice — falls back to splitting the raw characters.
+
+    The fallback over-reports boundaries, which costs a false denial; a parser that
+    declined to read such text at all would under-report them, which costs a missed one.
+    Only the first of those two is a failure a guard may have.
+    """
+    tokens = tokenize(command)
+    if tokens is None:
+        commands = []
+        for segment in _SEGMENT.split(command):
+            try:
+                commands.append(shlex.split(segment, posix=False))
+            except ValueError:
+                commands.append(segment.split())
+        return commands
+    commands, current = [], []
+    for token in tokens:
+        if operator(token):
+            commands.append(current)
+            current = []
+        else:
+            current.append(token)
+    commands.append(current)
+    return commands
+
+
+def git_calls(command: str):
+    """Every git subcommand in a shell command, as (subcommand, args, where).
+
+    `where` is the directory the call would run in as far as the *text* says: a `cd`
+    earlier in the chain, one or more `git -C`, or None when the command names none — or
+    names one this hook cannot read, `git -C "$W" switch` being the standing example.
+    Both spellings of None mean the same thing downstream, "the session's own tree",
+    which is what an ordinary command means and the conservative reading of one that
+    could not be parsed.
+
+    Every `git` in a segment is read, not only the first. A newline is an operator here
+    and a segment should therefore hold one command, but that rests on a lexer setting
+    rather than on anything structural, and stopping at the first `git` would turn a
+    change in that setting into silently missed calls — which is the failure this guard
+    is not allowed to have. Scanning on costs nothing when the assumption holds.
+
+    Still textual, and still never a shell: the cost is spelling a path out in full
+    instead of hiding it in a variable, and the alternative is trusting an expansion the
+    guard cannot evaluate.
     """
     calls = []
-    for segment in _SEGMENT.split(command):
-        try:
-            tokens = shlex.split(segment)
-        except ValueError:
-            tokens = segment.split()
+    chain = None
+    for tokens in segments(command):
         if not tokens:
             continue
-        try:
-            start = next(i for i, t in enumerate(tokens) if Path(t).name in {"git", "git.exe"})
-        except StopIteration:
+        if names(tokens[0], _CHDIR):
+            # A `cd` carries to every later segment, which is what `&&` and `;` do. It is
+            # read for its path only — whether the `cd` would have *succeeded* is not a
+            # question worth answering, since a command whose `cd` failed writes nothing.
+            chain = joined(chain, dir_token(tokens[1])) if len(tokens) > 1 else None
             continue
-        rest = tokens[start + 1 :]
         index = 0
-        while index < len(rest) and rest[index].startswith("-"):
-            index += 2 if rest[index] in {"-C", "-c"} else 1
-        if index < len(rest):
-            calls.append((rest[index], rest[index + 1 :]))
+        while index < len(tokens):
+            if not names(tokens[index], _GIT):
+                index += 1
+                continue
+            where = chain
+            index += 1
+            while index < len(tokens):
+                flag = unquote(tokens[index])
+                if not flag.startswith("-"):
+                    break
+                if flag == "-C":
+                    where = joined(
+                        where,
+                        dir_token(tokens[index + 1]) if index + 1 < len(tokens) else None,
+                    )
+                index += 2 if flag in {"-C", "-c"} else 1
+            if index < len(tokens):
+                calls.append(
+                    (unquote(tokens[index]), [unquote(t) for t in tokens[index + 1 :]], where)
+                )
+                index += 1
     return calls
 
 
@@ -271,19 +572,57 @@ PROTOCOL = (
 )
 
 BASE_NOTE = (
-    "If the change needs a base other than the repository's default branch — which it "
-    "does here, since changes integrate through `{branch}` — create the worktree with "
-    "git first and enter that path:\n"
-    "`git worktree add .claude/worktrees/<name> -b <branch> origin/{branch}` then "
-    "EnterWorktree with that path. `worktree.baseRef` only chooses between the default "
-    "branch and local HEAD, never a named branch, so a bare EnterWorktree cuts from the "
-    "wrong place and carries the divergence into your diff without complaining."
+    "The base is `origin/{branch}` — the FETCHED remote tip — and never local HEAD, never "
+    "whatever branch the main checkout is sitting on, and never an unfetched local ref. So "
+    "create the worktree with git first and enter that path:\n"
+    "`git fetch origin {branch} && git worktree add .claude/worktrees/<name> -b <branch> "
+    "origin/{branch}` then EnterWorktree with that path. `worktree.baseRef` never accepts a "
+    "branch name — it chooses between the repository's default branch and local HEAD, and "
+    "here BOTH are wrong — so a bare EnterWorktree cuts from the wrong place and carries "
+    "changes you did not make into your diff without complaining."
 )
 
 ESCAPE = (
-    "`/worktree-per-change` has the full protocol. Set CLAUDE_WORKTREE_GATE=off only if "
-    "the guard is provably wrong, and say in your reply that you did it and why."
+    "`/worktree-per-change` has the full protocol. **A session cannot turn this guard "
+    "off**, and reading otherwise wastes a turn finding out: `CLAUDE_WORKTREE_GATE` is "
+    "read from the hook's own environment, so a `CLAUDE_WORKTREE_GATE=off` prefix sets it "
+    "for that one command while the hook that denied the command has already run. Setting "
+    "it for the Claude Code process, or in a settings `env` block, is the operator's move "
+    "and takes a new session. So if this denial is provably wrong, the move that works is "
+    "to say so plainly in your reply — what you were doing, what it blocked, and why the "
+    "guard is wrong — and stop, rather than spending turns on a way around it."
 )
+
+
+def cleanup_steps(tree: Path | str, topic: str | None) -> str:
+    """How a landed worktree comes down, spelled out because two of the four steps trap.
+
+    `ExitWorktree` with `action: "remove"` is the one everybody reaches for, and it cannot
+    do this job: it removes only a worktree EnterWorktree *itself* created, where under this
+    protocol the tree is made with `git worktree add` and entered by path. Measured — it
+    refuses outright, saying the session does not own the worktree and to use `"keep"`. So
+    the cost is a wasted call rather than a tree that quietly stays, and asking for `"keep"`
+    up front is what turns four steps into four steps instead of five.
+    """
+    name = topic or "<branch>"
+    return (
+        f"1. `gh pr view <n> --json state --jq .state` — expect `MERGED`. Ask the forge, "
+        "not git: `git branch -d`, `--merged` and `merge-base --is-ancestor` all read a "
+        "squash-merged branch as unmerged, so under this protocol all three are false "
+        "negatives.\n"
+        '2. `ExitWorktree` with `action: "keep"` — it returns the session to the main '
+        'checkout. **Not `"remove"`**: that removes only a worktree EnterWorktree created '
+        "itself, and refuses on one it merely entered by path, so it cannot take this tree "
+        "down.\n"
+        f"3. `git worktree remove {tree}` — from the main checkout, which is where it is "
+        "allowed and the only place it can run. Nothing can remove the tree it is "
+        "standing in.\n"
+        f"4. `git branch -D {name}`, then `git fetch origin --prune && git branch -r` and "
+        f"`git push origin --delete {name}` if the remote branch is still listed. "
+        "`--delete-branch` deletes the local branch first and abandons the remote one when "
+        "that fails, which is the normal case here because your worktree still has the "
+        "branch checked out at merge time."
+    )
 
 
 def reason_main_checkout(what: str, branch: str) -> str:
@@ -400,7 +739,7 @@ def unlanded(tree: Path, branch: str) -> str | None:
     return " and ".join(parts)
 
 
-def block_stop(tree: Path, branch: str, holding: str) -> None:
+def block_stop(tree: Path, branch: str, topic: str | None, holding: str) -> None:
     emit(
         {
             "decision": "block",
@@ -414,10 +753,45 @@ def block_stop(tree: Path, branch: str, holding: str) -> None:
                 "`git add -A`.\n"
                 "2. `git push -u origin HEAD`\n"
                 f"3. `gh pr create --base {branch} --fill`\n"
-                "4. `gh pr merge --squash` (add `--admin` only if the repo's checks do "
-                "not apply here)\n\n"
-                "If the change is genuinely abandoned, say so plainly in your reply and "
-                "leave the worktree standing — do not delete it, and do not stash."
+                "4. `gh pr merge --squash --delete-branch` (add `--admin` only if the "
+                "repo's checks do not apply here)\n"
+                "5. Then take the worktree down — the four steps below.\n\n"
+                + cleanup_steps(tree, topic)
+                + "\n\nIf the change is genuinely abandoned, say so plainly in your reply "
+                "and leave the worktree standing — do not delete it, and do not stash."
+            ),
+        }
+    )
+
+
+def block_stop_cleanup(tree: Path, branch: str, topic: str | None, marker: dict) -> None:
+    """Refuse to end a session sitting in a worktree whose change has already landed.
+
+    Cleanup is the half of the protocol nothing used to hold. Delivery had a hook and a
+    denial each; the teardown had a paragraph in a doc, and the failure mode is silent —
+    the change is merged, the reply is truthful, and what is left behind is a directory
+    plus a branch that the *next* session has to establish the status of before it can
+    trust either. Handing the operator the two commands is not delivering the work; they
+    only have to run them because the session that knew the answer stopped first.
+    """
+    landed = marker.get("why") or "its PR merged"
+    emit(
+        {
+            "decision": "block",
+            "reason": (
+                f"This worktree recorded a merge ({landed}) and is still standing. Step 1 "
+                "below is what confirms it: the record is written before the merge runs, so "
+                "a merge the forge refused leaves the same one. If it did not land, finish "
+                "the change instead — do not take the tree down.\n\n"
+                "Otherwise, taking it down is part of finishing, not an errand to hand over: "
+                "a worktree with no live branch is a stale checkout, a merged branch is a "
+                "push target after the PR that reviewed it has closed, and either one left "
+                "behind costs the next session a status check before it can trust what it "
+                "is looking at.\n\n"
+                + cleanup_steps(tree, topic)
+                + "\n\nIf the operator asked for this tree to stay — to look at the diff, or "
+                "to keep a dev server on it — leave it and say so plainly in your reply, "
+                "with the path. That is the one reason to stop with it standing."
             ),
         }
     )
@@ -433,6 +807,36 @@ def target_paths(payload: dict, cwd: Path):
         return []
     candidate = Path(path)
     return [candidate if candidate.is_absolute() else cwd / candidate]
+
+
+def targeted(where: str | None, cwd: Path, session, common: Path):
+    """The tree an operation lands in — but only when that tree is *this* repository's.
+
+    None means it is none of this repository's business: another repository entirely, or
+    no repository at all. The answer comes from the path the operation names rather than
+    from the directory the session sits in, because those differ constantly — a
+    `cd`-then-git into a sibling checkout, a `git -C` back into the main checkout, an
+    absolute path into a worktree — and in every one of those the session's own status is
+    the wrong thing to judge by. `where` of None means the command named nothing (or named
+    something unreadable), and then the session's own tree is both the honest reading and
+    the conservative one.
+
+    "The same repository" is the shared **common** git directory, not a path prefix: a
+    linked worktree lives inside the main checkout's directory tree, so a prefix test
+    reads every worktree as the main checkout, and an unrelated clone that happens to sit
+    inside it as this repo's business. The common dir is neither.
+    """
+    if where is None:
+        return session
+    directory = Path(where)
+    if not directory.is_absolute():
+        directory = cwd / directory
+    found = find_tree(directory)
+    if found is None:
+        return None
+    if key(common_git_dir(found[1])) != key(common):
+        return None
+    return found
 
 
 def main() -> None:
@@ -457,17 +861,39 @@ def main() -> None:
     branch = integration_branch(main_root)
 
     if event == "SessionStart":
+        context = (
+            "This repository writes only from worktrees. Edits to the main "
+            "checkout are denied by a hook, including one-line ones.\n\n"
+            + PROTOCOL.format(branch=branch)
+            + "\n\n"
+            + BASE_NOTE.format(branch=branch)
+            + "\n\nA change is finished when its worktree is gone too: after the merge, "
+            "`ExitWorktree` (`action: \"keep\"`), then `git worktree remove <path>` and "
+            "`git branch -D <branch>` from the main checkout."
+        )
+        # The sweep runs at SessionStart deliberately: it is the one moment nothing is in
+        # flight, so a landed tree still on disk is somebody's leftovers rather than the
+        # work in progress two minutes from its own merge.
+        standing = sweep_spent(common)
+        if standing:
+            context += (
+                "\n\nWorktrees still on disk that recorded a merge, left by an earlier "
+                "session:\n"
+                + "\n".join(f"- {path}" for path in standing)
+                + "\nEach ran `gh pr merge` from inside itself. That is recorded *before* "
+                "the merge, so a merge the forge refused leaves the same record as one that "
+                "landed — confirm with `gh pr view <n> --json state` before removing "
+                "anything, and treat uncommitted changes as a merge that did not land. Then "
+                "`git worktree remove <path>` and `git branch -D <branch>`, from the main "
+                "checkout, for the ones that are yours. A worktree another session is "
+                "holding is its business even after its branch merges: leave it, and say it "
+                "is there."
+            )
         emit(
             {
                 "hookSpecificOutput": {
                     "hookEventName": "SessionStart",
-                    "additionalContext": (
-                        "This repository writes only from worktrees. Edits to the main "
-                        "checkout are denied by a hook, including one-line ones.\n\n"
-                        + PROTOCOL.format(branch=branch)
-                        + "\n\n"
-                        + BASE_NOTE.format(branch=branch)
-                    ),
+                    "additionalContext": context,
                 }
             }
         )
@@ -478,10 +904,19 @@ def main() -> None:
             return
         if stop_blocks(common, session) >= MAX_STOP_BLOCKS:
             return
+        # Spent first. A landed tree can also read as holding unlanded commits — a squash
+        # merge leaves none of the branch's own commits in `origin/<branch>` — and telling
+        # a session to push work it has already merged is the one wrong answer here.
+        topic = branch_of(git_dir)
+        marker = is_spent(common, tree_root, topic)
+        if marker:
+            stop_blocks(common, session, bump=True)
+            block_stop_cleanup(tree_root, branch, topic, marker)
+            return
         holding = unlanded(tree_root, branch)
         if holding:
             stop_blocks(common, session, bump=True)
-            block_stop(tree_root, branch, holding)
+            block_stop(tree_root, branch, topic, holding)
         return
 
     if event != "PreToolUse":
@@ -491,17 +926,18 @@ def main() -> None:
 
     if tool in FILE_TOOLS:
         for path in target_paths(payload, Path(cwd)):
-            target = key(path)
-            root = key(tree_root)
-            if target != root and not target.startswith(root + os.sep):
+            scope = targeted(str(path), Path(cwd), located, common)
+            if scope is None:
                 continue  # Outside this repository — not this repository's rule.
-            if not linked:
+            target_root, target_git_dir, target_linked = scope
+            if not target_linked:
                 deny(reason_main_checkout("file edits are not made", branch), warn_only)
                 return
-            if branch_of(git_dir) == branch:
+            topic = branch_of(target_git_dir)
+            if topic == branch:
                 deny(reason_integration_branch(branch), warn_only)
                 return
-            marker = is_spent(common, tree_root)
+            marker = is_spent(common, target_root, topic)
             if marker:
                 deny(reason_spent(marker, branch), warn_only)
                 return
@@ -519,13 +955,24 @@ def main() -> None:
         # after-hook that can tell a merge apart from a merge that failed. A worktree
         # marked spent by a merge that did not land is the harmless direction: the
         # remedy is a new worktree, which is what the protocol wanted anyway.
-        mark_spent(common, tree_root, "gh pr merge was run from this worktree")
+        mark_spent(
+            common,
+            tree_root,
+            branch_of(git_dir),
+            "gh pr merge was run from this worktree",
+        )
 
-    for subcommand, _args in git_calls(command):
+    for subcommand, _args, where in git_calls(command):
+        scope = targeted(where, Path(cwd), located, common)
+        if scope is None:
+            # Another repository, or none. Its branches, its integration branch, its rules
+            # — and the remedy this hook would print is not even possible there.
+            continue
+        _, _, target_linked = scope
         if subcommand == "stash" and not (_args and _args[0] in {"list", "show"}):
             deny(reason_stash(), warn_only)
             return
-        if not linked and subcommand in MUTATORS:
+        if not target_linked and subcommand in MUTATORS:
             deny(reason_main_checkout(f"`git {subcommand}` does not run", branch), warn_only)
             return
 


### PR DESCRIPTION
worktree-guard.py was hand-installed here and has been drifting ever since:
chrisJuresh/skills packages the same hook, and six changes have landed there
that this copy never got. This replaces the script with that one, at 13a1e29,
via `install.py --repo . --branch development`.

Only the script moves. The install re-registers the three hooks and rewrites
.claude/worktree-per-change.json, and both come out byte-identical to what was
already committed — the hand install had the same shape — so they are left
alone rather than committed as line-ending churn.

What the repo gains, in the order it cost this session a turn:

* The denial no longer promises a hatch the reader cannot reach. The old text
  ended "set CLAUDE_WORKTREE_GATE=off only if the guard is provably wrong",
  which reads as something a session can do, and it is not: the variable is
  read from the hook's own environment, so a per-command prefix is set after
  the hook that denied the command has already run. The new text says a
  session cannot turn it off and to report the wrong denial instead of
  spending turns routing around it.

* Every rule is judged against the tree the operation NAMES, not the tree the
  session sits in, so `git -C ~/other-repo pull` is not this repository's
  business, and a `git -C` back into this main checkout still is.

* The base is spelled `origin/development` — the fetched remote tip — and the
  message says why local HEAD and the default branch are both wrong here,
  which is the mistake CLAUDE.md already had to warn about in prose.

* Stop holds the teardown, so a session cannot walk away from a merged PR
  leaving the worktree and a live push target standing. It also names
  `action: "keep"` rather than `"remove"`, which is what ExitWorktree actually
  accepts for a worktree it only entered — the exact refusal hit while merging
  #20 an hour ago.

* A spent marker is a record that a merge was ATTEMPTED, so an unfinished
  rebase in a spent tree outranks it and the write is allowed. The marker goes
  down before `gh pr merge` runs, and announcing a refused merge as done was
  costing conflict resolution.

Verified before committing: the skill's own suite is 101 passed, 0 failed on
this machine, and a smoke test against this repo's real layout confirms writes
denied in the main checkout and allowed here, `git reset` denied there, `git
stash` denied in a worktree, and add/push/gh untouched.

Two of those 101 only pass after a fix that is not upstream yet: three
assertions compare `str(path) in json.dumps(...)`, which cannot hold on
Windows because json.dumps doubles the backslashes. Two expect True and fail;
the third expects False and passes for the wrong reason. The guard is not
implicated — with the comparison corrected the suite is clean.
