### PR TITLE
Date the vendored guard, and take the four changes it had missed

### DIFF
--- a/.claude/hooks/worktree-guard.py
+++ b/.claude/hooks/worktree-guard.py
@@ -650,19 +650,49 @@ def reason_integration_branch(branch: str) -> str:
     )
 
 
-def reason_spent(marker: dict, branch: str) -> str:
+def reason_spent(marker: dict, branch: str, common: Path, tree_root: Path) -> str:
     landed = marker.get("why") or "its PR merged"
     return (
-        f"Denied: this worktree's change has already landed ({landed}), so it is finished "
-        "work. Editing it again grows a branch that has been reviewed and merged, and the "
-        "new edit reaches nobody until someone notices and opens a second PR from a tree "
-        "that looks done.\n\n"
+        f"Denied: this worktree's change looks finished ({landed}), so editing it again "
+        "grows a branch that has been reviewed and merged, and the new edit reaches nobody "
+        "until someone notices and opens a second PR from a tree that looks done.\n\n"
         "The next change is a new one: call **EnterWorktree** again for a fresh worktree "
         "and branch, cut from the current "
         f"`origin/{branch}` so it already contains what you just merged.\n\n"
+        # The mark records that `gh pr merge` RAN, not that it succeeded, and this is the
+        # one denial in the guard that can therefore be flatly wrong about the state of
+        # the world. Saying so here is not hedging: measured 2026-08-13, a session whose
+        # merge GitHub refused for a conflict read this text as fact, believed its work
+        # was delivered, and spent two turns reporting a guard bug instead of clearing a
+        # marker. The unfinished-rebase check above catches the common shape of that; a
+        # merge refused for a failing check leaves no rebase and still lands here.
+        + spent_doubt(spent_marker(common, tree_root))
+        + "\n\n"
         + BASE_NOTE.format(branch=branch)
         + "\n\n"
         + ESCAPE
+    )
+
+
+def spent_doubt(marker_path: Path) -> str:
+    """The sentence that lets a wrongly-marked session out, with the check that decides it.
+
+    Named after what it is: this mark is written *before* `gh pr merge` runs, so it records
+    an attempt. Every other denial in this guard is about state git can be asked for
+    directly; this one is about something that happened earlier and might not have worked.
+    """
+    return (
+        "**But this mark records that `gh pr merge` RAN, not that it landed** — it is "
+        "written before the command, because no later hook can tell a merge from a merge "
+        "that failed. A merge GitHub refuses (a conflict with a base that moved, a failing "
+        "check) leaves exactly this mark. So ask the forge before believing it:\n"
+        "`gh pr view <n> --json state --jq .state`\n\n"
+        "**`MERGED`** — the tree really is finished; take the fresh worktree above. "
+        "**Anything else** — the mark is wrong, and clearing it is the fix rather than a "
+        "workaround:\n"
+        f"`rm {marker_path}`\n"
+        "Then carry on in this tree. Clearing a mark for a PR the forge calls `MERGED` is "
+        "how a merged branch grows a commit that reaches nobody, so check first, every time."
     )
 
 
@@ -939,7 +969,7 @@ def main() -> None:
                 return
             marker = is_spent(common, target_root, topic)
             if marker:
-                deny(reason_spent(marker, branch), warn_only)
+                deny(reason_spent(marker, branch, common, target_root), warn_only)
                 return
         return
 
@@ -952,9 +982,16 @@ def main() -> None:
 
     if linked and _MERGED.search(command):
         # Recorded *before* the merge runs rather than after, because there is no
-        # after-hook that can tell a merge apart from a merge that failed. A worktree
-        # marked spent by a merge that did not land is the harmless direction: the
-        # remedy is a new worktree, which is what the protocol wanted anyway.
+        # after-hook that can tell a merge apart from a merge that failed.
+        #
+        # Being wrong in this direction is *survivable*, not harmless, and the difference
+        # is what `mid_operation` and `spent_doubt` are for. "The remedy is a new
+        # worktree, which is what the protocol wanted anyway" — the old note here — holds
+        # only when the merge actually landed. When it did not, the branch still has to
+        # reach the integration branch, and a fresh worktree abandons the conflict while
+        # leaving an open PR that can never merge. So: an unfinished rebase outranks the
+        # mark, and the denial names the forge check and the marker path rather than
+        # asserting the change is done.
         mark_spent(
             common,
             tree_root,

--- a/.claude/worktree-per-change.json
+++ b/.claude/worktree-per-change.json
@@ -1,3 +1,8 @@
 {
-  "integrationBranch": "development"
+  "integrationBranch": "development",
+  "guard": {
+    "source": "https://github.com/chrisJuresh/skills worktree-per-change/scripts/worktree_guard.py",
+    "syncedFrom": "598efba775e8c9e40a54f1b1e0809c255e28a0fb",
+    "sha256": "319251048ab2177aeda90ab7b2052c313107b0cb75ad272217b95e567bb5d099"
+  }
 }


### PR DESCRIPTION
The copy committed in #21 came from 13a1e29 and nothing recorded that, so the
only way to answer "is this current" was to diff it against a clone. Upstream
moved four times the same evening. This resyncs to 598efba and writes down
where it came from.

`.claude/worktree-per-change.json` gains a `guard` block — source, `syncedFrom`,
`sha256` — written by install.py rather than by hand, because a hand-kept record
is right once and silently wrong from the next resync on. That is the failure it
exists to catch, one level up.

The hash is over the file's LF-normalised bytes, which is what git stores. It is
recorded as 31925104, and `git show :.claude/hooks/worktree-guard.py` hashes to
31925104, so the record verifies against a checkout on any platform. This repo
pins `* text=auto eol=lf` while the machine that ran the installer is
`core.autocrlf=true`, so a hash of the working copy would have read 758ccda and
matched no checkout of this repo anywhere — including this one.

What the guard gains, beyond #21:

* A spent marker records that a merge was ATTEMPTED, not that it succeeded. The
  marker goes down before `gh pr merge` runs, because no hook can tell a merge
  from one the forge refused. An unfinished rebase in a spent tree now outranks
  it and the write is allowed — conflict resolution is the most expensive thing
  a wrong denial could stop, and it is exactly the work a refused merge leaves.
* The sweep and the Stop block leave a mid-rebase tree out rather than
  announcing it as landed and asking for it to be removed.
* The spent denial names its own doubt, so a session that hits it is told the
  marker may be recording a merge that never happened, and how to check.
* The guard tokenises before it looks for command boundaries, so a `&&` inside a
  quoted argument no longer reads as one.

Verified: 104 guard checks and 27 installer checks pass upstream at 598efba, and
a smoke test against this repo's real layout passes ten cases — writes denied in
the main checkout and allowed here, `git reset` denied there, a `git -C` back
into the main checkout denied from here, `git add -A` in a DIFFERENT repository
allowed, `git stash` denied, and named-path add / push / gh untouched.

Only the guard and the config move. The install re-registers the three hooks
identically to what is already committed, so settings.json is left alone rather
than committed as line-ending churn.
