### PR TITLE
Say the things that are true about this repo's own protocol

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,20 +7,29 @@ Agent-facing notes for this repo. Human-facing docs are in [README.md](README.md
 Every change is made in its own git worktree, on its own branch, and reaches
 `development` as a merged pull request. **Nothing is ever written in the main
 checkout** — not a one-line fix, not a typo, not "just this once". A committed
-`PreToolUse` hook denies it, and `/worktree-per-change` is the full protocol.
+`PreToolUse` hook denies it.
+
+**`/worktree-per-change` is the protocol and the authority on it.** Below is only
+what is specific to this repository. Where the two ever disagree the skill is
+right, because it is the thing that gets maintained — this file is a copy that
+drifted once already.
 
 `development` is the integration branch; it reaches `main` separately. Never
 open a PR into `main`.
 
-1. Before the first edit, take a worktree cut from `development`:
+1. Before the first edit, cut a worktree from the **fetched** `origin/development`:
 
    ```bash
+   git fetch origin development
    git worktree add .claude/worktrees/<name> -b <short-topic-name> origin/development
    ```
 
-   Then call **`EnterWorktree`** with that path. A bare `EnterWorktree` cuts from
-   `main`, because `worktree.baseRef` cannot name a branch — that base is wrong
-   here and carries the divergence into the diff without complaining.
+   Then call **`EnterWorktree`** with that path. A bare `EnterWorktree` is wrong
+   here whichever way `worktree.baseRef` is set: it never accepts a branch name,
+   and both values it does accept are wrong in a repo that integrates through
+   anything but its default branch — `fresh` cuts from `main` and carries the
+   whole divergence into your diff, `head` cuts from whatever the last session
+   left in the main checkout. Neither complains.
 
 2. Work and commit in the worktree, staging paths by name. Never `git add -A`,
    and never `git stash`: `refs/stash` is one stack for the whole repository, so
@@ -39,22 +48,35 @@ open a PR into `main`.
    second worktree and a second PR — the hook denies further edits in a worktree
    whose PR has already merged.
 
-5. Leave the worktree standing until its PR merges and name the path in your
-   reply. **Once it has merged, take all three down**: the remote branch with
-   `--delete-branch` above, the worktree with `ExitWorktree`
-   (`action: "remove"`), then the local branch. In that order — deleting a
-   branch out from under a live worktree leaves the worktree on a detached
-   HEAD.
+5. **Then take all three down.** The change is finished when the worktree is
+   gone, not when the PR merges: a merged branch left standing is a live push
+   target after the PR that reviewed it has closed, and a commit pushed there
+   looks like ordinary work while reaching `development` never.
 
-   A merged branch left standing is not untidiness. It is a live push target
-   after the PR that reviewed it has closed, and a commit pushed there looks
-   like ordinary work while reaching `development` never.
+   Confirm against GitHub first. Everything merges here with `--squash`, which
+   replays the diff as one new commit and keeps no ancestry, so `git branch -d`,
+   `git branch --merged` and `git merge-base --is-ancestor` all read a merged
+   branch as unmerged — every branch in this repo, not an edge case:
 
-   **Check that `--delete-branch` actually did it.** `gh` deletes the local
-   branch first and the remote second, and abandons the remote when the local
-   one fails — which it does whenever a worktree still holds the branch, so
-   every change here. It reports only `failed to delete local branch` and
-   leaves the branch it was asked to remove:
+   ```bash
+   gh pr view <n> --json state --jq .state   # expect MERGED
+   ```
+
+   Then `ExitWorktree` with **`action: "keep"`**, `git worktree remove <path>`,
+   `git branch -D <branch>` — in that order, because nothing can remove the tree
+   it is standing in, and deleting a branch out from under a live worktree leaves
+   it on a detached HEAD.
+
+   **`action: "remove"` does not work here.** It only removes a worktree
+   `EnterWorktree` itself created, and under this protocol the tree is made with
+   `git worktree add` and entered by path. It refuses, and costs a round trip at
+   the one moment the session is trying to finish.
+
+   **Check that `--delete-branch` actually deleted the remote.** `gh` deletes the
+   local branch first and abandons the remote when that fails — which it does
+   whenever a worktree still holds the branch, so every change here. It reports
+   only `failed to delete local branch` and leaves the branch it was asked to
+   remove:
 
    ```bash
    git fetch origin --prune
@@ -62,17 +84,45 @@ open a PR into `main`.
    git push origin --delete <branch>   # if it is still listed
    ```
 
-   **Confirm the merge against GitHub, not against git.** Everything merges
-   here with `--squash`, which replays the diff as one new commit and keeps no
-   ancestry, so `git branch -d`, `git branch --merged` and
-   `git merge-base --is-ancestor` all read a merged branch as unmerged — every
-   branch in this repo, not an edge case. Ask
-   `gh pr view <n> --json state --jq .state` for `MERGED`, then
-   `git branch -D <branch>`.
+   If a permission rule refuses that push, `gh` reaches the same ref:
+   `gh api -X DELETE repos/chrisJuresh/portfolio/git/refs/heads/<branch>`.
 
-The rule lives in `.claude/settings.json`, `.claude/hooks/worktree-guard.py` and
-`.claude/worktree-per-change.json`, all committed — a worktree only gets a file
-if git puts it there, so `.gitignore` un-ignores exactly those three.
+The main checkout is for reading and pulling. `git pull --ff-only origin
+development` is how it is brought up to date; `reset`, `merge` and `checkout` are
+denied there, and **a session cannot turn the guard off to get around that** —
+`CLAUDE_WORKTREE_GATE` is read from the hook's own environment, so a per-command
+prefix is set after the hook has already run. If a denial is wrong, say so in
+your reply and stop.
+
+### The guard is vendored, not written here
+
+`.claude/hooks/worktree-guard.py` is a copy taken from
+[chrisJuresh/skills](https://github.com/chrisJuresh/skills). **Do not edit it in
+this repo** — a fix made here is lost at the next resync and leaves the copy
+undatable. Fix it upstream and resync.
+
+`.claude/worktree-per-change.json` records which upstream commit the copy came
+from and the sha256 of its LF-normalised bytes, so "is this current" is a
+question this repo can answer on its own. Both are written by the installer; to
+resync, from a worktree:
+
+```bash
+python ~/.claude/skills/worktree-per-change/scripts/install.py --repo . --branch development --dry-run
+```
+
+Then without `--dry-run`. That path is the skill link the installer makes itself,
+so it works wherever the skill is installed; `${CLAUDE_SKILL_DIR}` is only set
+while a skill is running and is unset in a plain shell. `--status` alone reports
+what is installed and what each worktree is still holding.
+
+The install also rewrites `.claude/settings.json` — revert it if the only change
+is line endings — and leaves a `settings.json.*.bak` to delete.
+
+`.gitignore` ignores `.claude/` except the three files that carry this rule —
+`settings.json`, `hooks/worktree-guard.py`, `worktree-per-change.json` — and
+`launch.json`, which the preview starts the dev server from. A worktree only gets
+a file if git puts it there, so anything ignored is missing from every tree the
+work is actually done in.
 
 ## Agent skills
 
@@ -83,10 +133,15 @@ See `docs/agents/issue-tracker.md`.
 
 ### Triage labels
 
-The five canonical roles, each label string equal to its name. See
-`docs/agents/triage-labels.md`.
+The five canonical roles, each label string equal to its name. **Four of the five
+do not exist on the repo yet**, so `gh issue edit --add-label` fails on them —
+see `docs/agents/triage-labels.md` for which, and the one command that creates
+them.
 
 ### Domain docs
 
-Single-context — one `CONTEXT.md` and `docs/adr/` at the repo root. See
+Single-context — one `CONTEXT.md` and one `docs/adr/` at the repo root. Neither
+exists yet, and that is the intended state: they are written lazily, by
+`/domain-modeling`, when a term or a decision actually gets resolved. Proceed
+silently when they are absent rather than flagging it. See
 `docs/agents/domain.md`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -13,3 +13,28 @@ The skills speak in terms of five canonical triage roles. This file maps those r
 When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
 
 Edit the right-hand column to match whatever vocabulary you actually use.
+
+## These labels have to exist before they can be applied
+
+Only `wontfix` is currently on the repo — it is one of GitHub's defaults. The other four have never been created, so `gh issue edit <n> --add-label needs-triage` fails with `not found`, and so does every `--label` filter that names one. A label is created on first use by nothing; `gh` will not make one for you.
+
+Create the missing four, and the `wayfinder:*` labels `docs/agents/issue-tracker.md` uses, in one go:
+
+```bash
+gh label create needs-triage    --color d93f0b --description "Maintainer needs to evaluate this issue"  --force
+gh label create needs-info      --color fbca04 --description "Waiting on reporter for more information" --force
+gh label create ready-for-agent --color 0e8a16 --description "Fully specified, ready for an AFK agent"  --force
+gh label create ready-for-human --color 1d76db --description "Requires human implementation"            --force
+```
+
+`--force` makes each idempotent, so re-running updates rather than erroring on one already there.
+
+`docs/agents/issue-tracker.md` also names `wayfinder:map` and `wayfinder:<type>` for `/wayfinder`. None of those exist either; create them the same way if that skill is ever used:
+
+```bash
+gh label create wayfinder:map       --color 5319e7 --description "Wayfinder map issue"       --force
+gh label create wayfinder:research  --color c5def5 --description "Wayfinder research ticket" --force
+gh label create wayfinder:prototype --color c5def5 --description "Wayfinder prototype ticket" --force
+gh label create wayfinder:grilling  --color c5def5 --description "Wayfinder grilling ticket" --force
+gh label create wayfinder:task      --color c5def5 --description "Wayfinder task ticket"     --force
+```


### PR DESCRIPTION
CLAUDE.md was written before the guard became a maintained skill and has been
drifting against it since. Three of its instructions are now wrong, and the
first one cost this session two round trips in an afternoon:

* **`ExitWorktree` with `action: "remove"` does not work here.** Step 5 said to
  take the worktree down with it. It only removes a tree `EnterWorktree` itself
  created, and under this protocol every tree is made with `git worktree add`
  and entered by path — so it refuses, at the one moment the session is trying
  to finish. `action: "keep"`, then `git worktree remove`.

* **The base is the FETCHED `origin/development`.** The old text had no fetch,
  so a worktree could be cut from a local ref that had not moved since someone
  else merged, silently reintroducing landed work as a conflict. And "a bare
  `EnterWorktree` cuts from `main`" was only half of it: `worktree.baseRef`
  chooses between the default branch and local HEAD, and in a repo integrating
  through `development` BOTH are wrong.

* **`git push origin --delete` is not always available.** A permission rule can
  refuse it, and the branch then stays up with nothing saying so. `gh api -X
  DELETE …/git/refs/heads/<branch>` reaches the same ref.

It also now says what the main checkout is FOR — `pull --ff-only`, nothing else
— and that a session cannot turn the guard off to work around a denial, because
`CLAUDE_WORKTREE_GATE` is read from the hook's environment and a per-command
prefix lands after the hook has already run. Both were learned by trying.

The protocol prose that duplicated `/worktree-per-change` is cut rather than
re-synced. Two copies of one rule is how this drifted, and the skill is the copy
that gets maintained; what stays here is what is specific to this repository,
plus a line saying the skill wins on any disagreement. Same reason the guard now
carries its provenance: `.claude/hooks/worktree-guard.py` is vendored, must not
be edited in place, and the resync command is written down.

Two more claims were simply not true:

* **Four of the five triage labels do not exist.** `docs/agents/triage-labels.md`
  maps five roles to five label strings; only `wontfix` is on the repo, and it is
  there because GitHub ships it. `gh issue edit --add-label needs-triage` fails.
  The table now says so and carries the `gh label create` lines, plus the
  `wayfinder:*` labels `issue-tracker.md` names, which are missing too. Left for
  a human to run: creating labels is not this change's business.

* **`CONTEXT.md` and `docs/adr/` do not exist**, which CLAUDE.md stated as fact.
  That IS the intended state — `docs/agents/domain.md` says to proceed silently
  when they are absent because `/domain-modeling` writes them lazily — so the
  summary now says the intended thing instead of implying a missing file.
