### PR TITLE
Make a re-baked picture visible on the deployment the same day

### DIFF
--- a/design/plate/build-plate.py
+++ b/design/plate/build-plate.py
@@ -276,6 +276,7 @@ which move a judgement you would make at --plate-opacity:
 
 from __future__ import annotations
 
+import hashlib
 import json
 import sys
 from dataclasses import dataclass
@@ -799,6 +800,27 @@ def write_neutral(pic: Picture, lin: np.ndarray, alpha_f: np.ndarray, computed: 
     }, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
 
 
+def ladder_stamp() -> str:
+    """A short digest of EVERY picture's ladder, for portfolio/index.html's
+    IMG_VERSION.
+
+    Over all of them and not just the one this run built, because it is one token
+    on the page covering every rung of every picture — so a run that touches only
+    the eye still has to report a value that accounts for the plate and the car,
+    or pasting it would silently revert their share of the URL.
+
+    Names as well as bytes, so that a rung appearing or disappearing moves the
+    stamp even in the impossible case where the remaining bytes are unchanged.
+    Sorted, because glob order is not promised and a stamp that depends on it
+    would differ between machines for one picture.
+    """
+    h = hashlib.sha256()
+    for p in sorted(OUT_DIR.glob("*.webp")):
+        h.update(p.name.encode("utf-8"))
+        h.update(p.read_bytes())
+    return h.hexdigest()[:8]
+
+
 def usage() -> str:
     """The invocation line out of the docstring, found rather than indexed.
 
@@ -894,6 +916,12 @@ def main() -> int:
     print(f"{pic.neutral_path.relative_to(REPO)}  "
           f"{pic.neutral_path.stat().st_size / 1024:.0f} KB"
           f"  + {pic.meta_path.name}   (design/plate/plate-tuner.html reads these)")
+
+    # Last line of the run, because it is the one thing left to do by hand. A
+    # re-bake that is not followed by this paste is invisible on the deployment
+    # for a day whatever else it got right — see rungUrl in portfolio/index.html.
+    print(f'\nvar IMG_VERSION = "{ladder_stamp()}";'
+          f"   <- portfolio/index.html, if it differs from what is there")
     return 0
 
 

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -65,6 +65,12 @@
       var RUNGS = [800, 1300, 2000, 2800];
       var WAIT_MS = 1500;
 
+      /* A digest of every ladder file in portfolio/img/, appended to each rung's
+         URL — see rungUrl below for what it is for. design/plate/build-plate.py
+         prints the current value at the end of every run; paste it here whenever
+         it differs from this one, in the same commit as the re-baked files. */
+      var IMG_VERSION = "3785c80b";
+
       /* One entry per picture, and `fill` is the only thing that separates them:
          the width it is drawn at as a share of the first screen. All three are
          scaled to the height of that screen — see --fold in styles.css — so the
@@ -136,10 +142,25 @@
         };
 
         /* Light is unsuffixed. Keep this spelling and Picture.out_path() in
-           design/plate/build-plate.py together — they are the same two names. */
+           design/plate/build-plate.py together — they are the same two names.
+
+           ?v= is not decoration and not a cache-buster in the usual sense: it is
+           the only thing that makes a re-bake VISIBLE. A rung's filename is
+           content-independent — eye-800.webp is eye-800.webp before and after the
+           grade moves — and vercel.json caches /portfolio/img/ for a day with a
+           week of stale-while-revalidate, so re-baking a picture and deploying it
+           leaves every browser and every edge that already has the old bytes
+           serving them for up to 24 hours. That is not hypothetical: the eye
+           shipped mirrored in #24, was un-mirrored in #25 under the same filename,
+           and went on being mirrored on the deployment while being correct on
+           localhost, which sends no such headers.
+           Bumping IMG_VERSION changes the URL, so the new bytes are simply a
+           different resource and arrive at once. Forgetting to bump it leaves the
+           old behaviour exactly as it was — a day — rather than making it worse,
+           which is why the header itself is left long. */
         var rungUrl = function (p, width, theme) {
           return "img/" + p.stem + "-" + (theme === "dark" ? "dark-" : "") +
-                 width + ".webp";
+                 width + ".webp?v=" + IMG_VERSION;
         };
 
         /* A miss on a dark file is the ordinary untuned state and not an error:


### PR DESCRIPTION
A rung's filename is content-independent — eye-800.webp is eye-800.webp whatever
the grade says — and vercel.json caches /portfolio/img/ for a day with a week of
stale-while-revalidate behind it. So re-baking a picture and deploying it changes
nothing anyone can see until the cache lets go.

That is the whole of why the eye went on being mirrored on the deployment after
#25 un-mirrored it, while being correct on localhost, which sends no such
headers. #24 and #25 shipped the same filename a few hours apart and the first
one won.

So each rung's URL now carries ?v=IMG_VERSION, a digest of every ladder file in
portfolio/img/. build-plate.py grows ladder_stamp() and prints the current value
as the last line of every run, to be pasted into index.html in the same commit as
the files it describes.

The header in vercel.json is deliberately left alone. With the token, a bump is
instant; without one, a forgotten paste leaves exactly today's behaviour rather
than a worse one, which would not be true if the cache were made immutable to
match.
