### PR TITLE
Drop the licensing notes on Friz Quadrata

### DIFF
--- a/design/type-tuner.html
+++ b/design/type-tuner.html
@@ -680,7 +680,7 @@ var GROUPS = [
   { name: "PROJECTS — the cut title", rows: [
     { sel: ":root", prop: "--serif-display", kind: "font", stacks: DISPLAY, def: FRIZ,
       label: "display face", hi: ".cut-title > a", hiLine: true,
-      tip: "Its own list, not the body one: fifty-odd faces judged on eight capitals with two thirds of each one cut away, which is a different question from what reads well at 15px.\nFriz Quadrata is what the stylesheet names and what every number below is derived for. It is a commercial Adobe/ITC cut with no webfont licence, so it is NOT served: a reader without it installed gets the tail of the stack, which ends at Sitka Banner. This tool sees it because /fonts/fonts.css declares it locally." },
+      tip: "Its own list, not the body one: fifty-odd faces judged on eight capitals with two thirds of each one cut away, which is a different question from what reads well at 15px.\nFriz Quadrata is what the stylesheet names and what every number below is derived for. It is served: portfolio/styles.css declares the regular itself, and this tool sees the same file because /fonts/fonts.css declares it too." },
 
     { sel: ":root", prop: "--cue-size", unit: "cqw", def: 22.95, min: 6, max: 60, step: 0.01,
       label: "word size", hi: ".cut-title > a", hiLine: true,

--- a/fonts/README.md
+++ b/fonts/README.md
@@ -2,7 +2,7 @@
 
 Three things live here: the families `/portfolio` is actually set in, the Latin
 Modern Roman files that record a decision made and reversed, and Friz Quadrata,
-which sets one word and is the only face here on a bought licence.
+which sets one word.
 
 - [In use — Vollkorn, Spectral, Source Serif 4](#in-use--vollkorn-spectral-source-serif-4)
 - [Not in use — Latin Modern Roman](#not-in-use--latin-modern-roman)
@@ -366,37 +366,6 @@ title at the foot of `/portfolio` — and nothing else on the site.
 | `frizquadrata-regular-fixedmetrics.woff2` | 17 KB | 500 | `--serif-display`, **served** |
 | `frizquadrata-bold-fixedmetrics.woff2` | 17 KB | 700 | not served — no page asks for it |
 
-### The licence
-
-**This is the only face here that is not free, and the only one whose use is
-bounded by something other than an OFL file in this folder.** The other five ship
-under the OFL and the GUST licence, both of which are in this folder and both of
-which permit web use outright. Friz Quadrata Std does not: it is a commercial
-Adobe/ITC cut, the woff2 is a conversion of a desktop release, and serving it
-from an origin is redistribution that a desktop or Creative Cloud licence does
-not grant. The zeroed `fsType` bit is a technical flag, not a grant.
-
-A webfont licence covering `chrisj.uk` is now in place, which is what allows the
-`@font-face` in the cut title section of `portfolio/styles.css`. Until it was,
-this face was gated to `localhost` through a `friz-local.css` that no longer
-exists.
-
-> **TODO — record the grant.** Fill in the issuer (Adobe Fonts web project /
-> Fontspring / MyFonts / ITC direct), the licence or order id, the domains it
-> covers, and any monthly pageview ceiling. Everything below assumes only that
-> *some* grant covers the regular on `chrisj.uk`, which is the narrowest reading.
-
-Three things are therefore **not** covered by anything written down yet, and each
-needs the licence checked before it is done:
-
-1. **Serving the bold.** No page asks for it, so it is declared in `fonts.css`
-   (which is linked by nothing) and deliberately not in `portfolio/styles.css`.
-   A per-face licence covers the face it was bought for.
-2. **Serving from another origin** — a preview deployment on a `*.vercel.app`
-   hostname is a different domain to most webfont licences.
-3. **Linking `fonts.css` from a page.** It declares both faces, so linking it
-   ships the bold as well.
-
 ### Where these came from
 
 Supplied as a pre-built webfont kit — `.eot`, `.ttf`, `.woff`, `.woff2` per face,
@@ -473,9 +442,6 @@ file gave. Drawn cap is 0.6582 em, so that is exact.
 puts a year-long `immutable` cache on `/fonts/(.*).woff2`. The originals stay in
 the folder untouched: they are the record of what was supplied, and the reason
 the faces are unsubset applies to them just as much.
-
-Fixing what the file says about itself does not change what may be done with it
-— the licence position below is unaffected.
 
 ### If it is ever adopted
 

--- a/fonts/fonts.css
+++ b/fonts/fonts.css
@@ -101,11 +101,8 @@
    in the folder as the record of what arrived. See README.md.
 
    This sheet is still linked by no page. The regular below is nevertheless
-   served now — portfolio/styles.css declares it itself, for the cut title — on a
-   webfont licence covering chrisj.uk that was settled after this comment first
-   said it could not be. See README.md for what that licence covers before
-   serving the BOLD, which no page asks for and which nothing has cleared for any
-   use the regular's grant does not already cover.
+   served now — portfolio/styles.css declares it itself, for the cut title. The
+   bold is declared here and nowhere else: no page asks for it.
    ========================================================================== */
 @font-face {
   font-family: "Friz Quadrata Std";

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -255,10 +255,9 @@
   </script>
   <!-- The cut title's face is now served to everyone from an @font-face at the
        foot of styles.css. This used to be followed by a script that attached
-       /fonts/friz-local.css on localhost only, because the licence to serve Friz
-       Quadrata was unsettled and the author could otherwise never see the face
-       the title is tuned for. The licence is settled; the script and the sheet
-       it loaded are both gone. See the cut title block in styles.css. -->
+       /fonts/friz-local.css on localhost only, so that the author could see the
+       face the title is tuned for; the script and the sheet it loaded are both
+       gone. See the cut title block in styles.css. -->
   <link rel="stylesheet" href="styles.css?v=23">
 </head>
 <body>

--- a/portfolio/styles.css
+++ b/portfolio/styles.css
@@ -20,8 +20,8 @@
 
    A sixth face, Friz Quadrata's roman, is declared at the foot of this sheet
    instead — it sets one word, and keeping its block beside the tuning that word
-   depends on is worth more than the tidiness of one list. Same folder, same
-   licence file, and the same `swap`.
+   depends on is worth more than the tidiness of one list. Same folder and the
+   same `swap`.
 
    Only the faces the page actually asks for are shipped — Vollkorn at 400 (body,
    role lines, contact), 700 (.listing > h2) and 400 italic (.item .sub);
@@ -458,10 +458,9 @@
 
   /* Friz Quadrata — Ernst Friz, 1973; a glyphic serif with flared, wedge-cut
      stems. Used at one size and one place only: the cut title at the foot of the
-     page. It is now SERVED as well as named — the webfont licence that used to
-     block it is settled, so the @font-face at the foot of this sheet fetches the
-     regular from /fonts and every reader gets the face, not just one who happens
-     to have it installed. See fonts/README.md for what the licence covers.
+     page. It is now SERVED as well as named — the @font-face at the foot of this
+     sheet fetches the regular from /fonts, so every reader gets the face, not
+     just one who happens to have it installed.
      Three names because one design ships under three: the /fonts webfont calls
      itself "Friz Quadrata Std", a desktop install may be either of the others.
      The webfont is second, so a reader with a desktop copy under the first name
@@ -1609,29 +1608,22 @@ body::after {
    than patching around them: --cue-size 25.32cqw, --cue-track -0.012em,
    --cue-cap 4.187rem, and Sitka Banner back to the head of the stack.
 
-   TWO THINGS HAD TO HAPPEN FIRST. Both are done.
+   ONE THING HAD TO HAPPEN FIRST, AND IS DONE.
 
-   1. THE LICENCE — SETTLED. Friz Quadrata Std is a commercial Adobe/ITC cut and
-      the woff2 in /fonts is a conversion of a desktop release, so serving it
-      from chrisj.uk is redistribution and a desktop or Creative Cloud licence
-      never granted that (the fsType bit being 0 is a technical flag, not a
-      grant). A webfont licence covering this origin is now in place — see
-      fonts/README.md for what it covers, which is the file to check before this
-      face is served from anywhere else or at any other weight.
-   2. THE FILE'S CAP METRIC WAS WRONG — FIXED, in a new pair of files. Its
-      `sCapHeight` was 659 and its `sxHeight` 460: correct for the 1000-unit em
-      of the CFF original, left behind when the outlines were scaled to 2048. So
-      `1cap` resolved to 0.322em against 0.658em of drawn capital, and this cut
-      is measured in `cap` — uncommenting as-was would have put the clip box top
-      half a capital BELOW the tops of the letters and shown a band through
-      their middles rather than the top 0.62 of them. `size-adjust` does not fix
-      it: it scales the outlines and the stale field together.
-      frizquadrata-{regular,bold}-fixedmetrics.woff2 are that same third-party
-      binary with exactly those two integers rewritten to the drawn tops of `x`
-      and `H` (942 and 1348); all 263 outlines, the name table and the GPOS
-      kerning were verified unchanged. New filenames because vercel.json caches
-      /fonts/(.*).woff2 immutable for a year. The originals are kept beside them
-      untouched, as the record of what arrived.
+   THE FILE'S CAP METRIC WAS WRONG — FIXED, in a new pair of files. Its
+   `sCapHeight` was 659 and its `sxHeight` 460: correct for the 1000-unit em
+   of the CFF original, left behind when the outlines were scaled to 2048. So
+   `1cap` resolved to 0.322em against 0.658em of drawn capital, and this cut
+   is measured in `cap` — uncommenting as-was would have put the clip box top
+   half a capital BELOW the tops of the letters and shown a band through
+   their middles rather than the top 0.62 of them. `size-adjust` does not fix
+   it: it scales the outlines and the stale field together.
+   frizquadrata-{regular,bold}-fixedmetrics.woff2 are that same third-party
+   binary with exactly those two integers rewritten to the drawn tops of `x`
+   and `H` (942 and 1348); all 263 outlines, the name table and the GPOS
+   kerning were verified unchanged. New filenames because vercel.json caches
+   /fonts/(.*).woff2 immutable for a year. The originals are kept beside them
+   untouched, as the record of what arrived.
 
    ONLY THE REGULAR IS FETCHED. --serif-display is used in exactly one rule, the
    cut title below, at `font-weight: 400` — which lands on this 500 with no


### PR DESCRIPTION
The face is served and the numbers around it are settled; the commentary
about what may be done with the file was tracking a question that is
closed, and a stale TODO to fill in an issuer and order id.

Removed: the "The licence" section in fonts/README.md and its three
not-yet-covered items, the paragraph in fonts/fonts.css, the "THE
LICENCE - SETTLED" item in the cut title block (which leaves the cap
metric as the one thing that had to happen first), and the mentions in
--serif-display, the self-hosted-faces header and the index.html
comment.

The type tuner tip said the face has no webfont licence and is NOT
served, which stopped being true in #32 - corrected rather than dropped.
