### PR TITLE
Measure the corner eye off the photo strip, not the page edge

### DIFF
--- a/design/plate/plate-tuner.html
+++ b/design/plate/plate-tuner.html
@@ -323,15 +323,17 @@ var CAR = [
    with the plate's geometry at the bottom of the page and the plate's want of a
    dissolve, which is none: both its inner edges are empty sky in this frame. So it
    is the car's list with the fade row dropped and the two vertical rows pointing
-   the other way. `out from right` is the row that matters most here, because the
-   frame is not mirrored and it is what stands the subject in the corner. */
+   the other way. `in from the strip` is the row that matters most here, and it is
+   the one row on the sheet that is measured off the column rather than off an edge
+   of the page — the frame is not mirrored, so where the picture stands relative to
+   the photographs is the whole composition. */
 var EYE = [
   { k: "--eye-opacity", label: "opacity", unit: "", min: 0, max: 0.6, step: 0.005, dp: 3, dark: true,
     tip: "Its own, as the other two are their own, and holding the same number today.\nThis frame is a steel lattice with sky through it rather than a solid mass, so it carries less ink than either at the same setting — which is an argument for reading it against them here rather than assuming the shared value is still right." },
   { k: "--eye-fill", label: "width ÷ fold", unit: "", min: 0.1, max: 1.2, step: 0.001, dp: 3,
     tip: "Width as a share of the first screen, as --car-fill is.\nWhat it really sets is how tall the mast stands: the mast is 87.6% of the frame, so 1.167× this width. It has a ceiling the car sets rather than the file — much past 0.39 the top of the mast arrives under the gondola and the two read as one machine. Watch the gap between them, not the size." },
-  { k: "--eye-x", label: "out from right", unit: "px", min: -400, max: 400, step: 1, dp: 0,
-    tip: "Positive moves it left, in off the page's right edge.\nNegative today, and load-bearing rather than a nudge: the frame is not mirrored, so the subject sits in the left three-fifths of the file and the right two-fifths is sky. This is what pushes that dead margin off the page and puts the cable stays in the corner. Drag it toward 0 and the whole picture walks in off the edge, leaving white where the corner should be." },
+  { k: "--eye-x", label: "in from the strip", unit: "px", min: -200, max: 900, step: 1, dp: 0,
+    tip: "The gap between the photo strip's first photograph and this picture's left edge. Positive moves it right, away from the strip.\nThe one placement on the page that is measured off the column rather than off a page edge, and that is what keeps this gap the same on every screen — the strip is pinned to a centred column, so a corner offset would drift from it as the window widens. Watch the gap, not the distance to the edge: the right-hand two-fifths of the frame is sky, and how much of it stays on the page is whatever the window's height leaves over." },
   { k: "--eye-y", label: "up from the fold", unit: "px", min: -1200, max: 1200, step: 1, dp: 0,
     tip: "Positive lifts it off --fold, the bottom of the first screen; negative hangs it past that line.\nUnlike the plate's, this does not resize anything — --eye-fill is a share of the fold, not of what --eye-y leaves." },
   { k: "--eye-crop", label: "crop the foot", unit: "", min: 0, max: 0.9, step: 0.005, dp: 3,

--- a/portfolio/styles.css
+++ b/portfolio/styles.css
@@ -302,23 +302,32 @@
   /* Picked by index.html, like --plate-src, and unset for the same reason. */
   --car-src: none;
 
-  /* The corner eye — the third plate, in the page's BOTTOM-RIGHT corner: the
+  /* The corner eye — the third plate, in the page's BOTTOM-RIGHT quarter: the
      London Eye seen rim-on, so the wheel reads as a mast of capsules rather than
      as a circle. The block near the foot of this sheet has the rest.
 
-     It is the car's shape of control and not the plate's, because it is anchored
-     the car's way: one corner, one rule — its own bottom-right corner stands in
-     the page's, and its foot lands on --fold, the same line the plate's foot and
-     the cut title land on. There is no second rule and nothing to pin at the top:
-     as shot there is a tenth of a frame of empty sky above the mast, so the top
-     of the picture is not an edge and has nothing to stand in.
+     VERTICALLY it is the car's shape of control and not the plate's, because it is
+     anchored the car's way: one edge, one rule — its foot lands on --fold, the same
+     line the plate's foot and the cut title land on. There is no second rule and
+     nothing to pin at the top: as shot there is a tenth of a frame of empty sky
+     above the mast, so the top of the picture is not an edge and has nothing to
+     stand in.
+
+     HORIZONTALLY it is neither of them, and this is the one picture of the three
+     that is not measured off a page edge at all. It hangs off --edge — the line the
+     text column starts on, which is also where the photo strip's first photograph
+     stands — so the distance from the strip to the wheel is a constant and the
+     window's right-hand edge is nothing to it. See --eye-x for why: the strip is
+     pinned to a CENTRED column and a corner is pinned to the window, so the two
+     used to travel at different speeds and the gap between them was whatever the
+     width happened to make it.
 
      The frame is NOT mirrored — see the eye paragraph in build-plate.py, where the
      plate's flip-it argument is set out for this frame and declined. What that
-     leaves for this end is --eye-x, which does the job the flip would have: the
-     subject occupies the left three-fifths of the file and the right two-fifths is
-     empty sky, so the dead margin is pushed off the page rather than folded to the
-     other side of the picture.
+     leaves for this end is the choice of which edge --eye-x pins: the subject
+     occupies the left three-fifths of the file and the right two-fifths is empty
+     sky, so it is the picture's LEFT edge that is held and the dead margin that is
+     allowed to run off the page.
 
      What it costs is nothing the car did not already cost. The picture's two inner
      edges are its left and its top, and in this frame both are empty sky — 4.5% of
@@ -377,29 +386,43 @@
                         /* the ceiling on --plate-w and --car-w, for the third
                            time and the same reason: 2800px is the top rung
                            index.html will fetch.                              */
-  --eye-x: 247px;       /* out from the RIGHT edge of the page, positive → left.
-                           POSITIVE, which reverses what this value was doing, and
-                           the reversal is the whole of the change — read the sign
-                           before reading the number.
-                           The job it used to do: the subject ends at 59.9% of the
-                           file's width and the remaining 40.1% is sky, so a negative
-                           offset of 0.401 × --eye-w carries that dead margin off the
-                           right-hand edge and stands the cable stays on it. That is
-                           what the frame not being mirrored is paid for in — see the
-                           eye paragraph in build-plate.py. At 629px wide the same
-                           rule asks for -252px.
-                           +247px does the opposite: it pulls the file 247px INBOARD,
-                           so the 252px of dead sky stays on the page and the stays
-                           finish ~499px short of the edge. The picture is no longer
-                           anchored in the bottom-right corner — it stands in the
-                           right-hand third with paper on both sides of it, which is
-                           the one arrangement the corner geometry above was built to
-                           avoid. It is here because it was asked for by name; -252px
-                           is the value that restores the corner.
-                           A length against a share, and at this sign the drift is no
-                           longer the gentle one: a taller window widens the dead
-                           margin the offset is no longer cancelling, so the gap to
-                           the edge grows with the fold.                        */
+  --eye-x: 292.94px;    /* INBOARD from the photo strip, positive → right: the gap
+                           between the strip's first photograph and the picture's
+                           own left edge. Not a page edge, and that is the whole of
+                           what changed — read what it is measured FROM before
+                           reading the number.
+                           It used to be 247px out from the window's right edge, and
+                           the trouble with that was not the number. The strip is
+                           pinned to a centred column, so its first photograph moves
+                           half a pixel for every pixel of window; a corner offset
+                           moves a whole one. Widen the window by 200px and the two
+                           part company by 100px. The picture was placed by eye on a
+                           1920×1080 screen, so that placement was right on exactly
+                           one display and drifted on every other.
+                           292.94px is that same placement, re-measured against the
+                           strip instead: at 1920×1080 the first photograph stands at
+                           736.5px and the picture's left edge at 1029.44px, and the
+                           difference is this. So the display it was tuned on looks
+                           the way it did, and every other one now looks the way that
+                           one does — no breakpoint, because --edge is a function of
+                           the width and this is a constant added to it.
+                           The LEFT edge is what is pinned, not the right, and that
+                           is a choice the file's own asymmetry makes: the subject
+                           ends at 59.9% of the width and the remaining 40.1% is sky
+                           (see build-plate.py's eye paragraph for why it was not
+                           simply flipped). --eye-w is a share of --fold, so a taller
+                           window hands the picture more width — and holding the left
+                           edge spends all of it on the right, pushing dead sky
+                           towards the page's edge, where holding the right edge
+                           would have walked the mast in over the column instead.
+                           What that costs is at the far end, and it is cheap twice
+                           over. Sky begins to leave the page above roughly
+                           0.86 × width − 130px of height — 1517px on a 1920-wide
+                           window — and that is what the sky is FOR. The stays only
+                           reach the box's right edge past about 1.43 × width − 220px,
+                           which is 2532px at 1920: a window half again as tall as it
+                           is wide. Nothing scrolls sideways when they do (html and
+                           body see to that), and the mast is nowhere near it.  */
   --eye-y: 0px;         /* up from --fold, positive → up; negative hangs it past
                            the fold. 0 IS the rule, and it is a variable for the
                            reason --plate-y is: so the rule can be broken by hand
@@ -1134,8 +1157,9 @@ body::after {
 }
 
 /* ---- the corner eye -------------------------------------------------------
-   The third plate: the London Eye rim-on, in the bottom-right corner of the
-   document, at --eye-opacity. Everything the corner-plate block says about why
+   The third plate: the London Eye rim-on, standing beside the photo strip in the
+   bottom-right of the document, at --eye-opacity. Everything the corner-plate
+   block says about why
    the grade is baked rather than filtered, and about starting at the top of the
    document and leaving at the fold, is true of this one too — same stock, same
    script, same piece of paper.
@@ -1145,9 +1169,13 @@ body::after {
    the alternatives are the same two bad ones. Two empty divs cost two lines of
    HTML and answer neither question.
 
-   What it takes from the CAR is its anchoring — one corner, one rule, and a size
-   measured against --fold rather than against a band — so --eye-fill behaves like
-   --car-fill and --eye-y moves the picture without resizing it. What it takes
+   What it takes from the CAR is its vertical anchoring — one edge, one rule, and a
+   size measured against --fold rather than against a band — so --eye-fill behaves
+   like --car-fill and --eye-y moves the picture without resizing it. Sideways it
+   takes neither of theirs: it is the only one of the three measured off --edge
+   rather than off a page edge, so it holds its distance from the strip instead of
+   from the window. That is --eye-x's block in :root, and the two lines of full
+   bleed below are what make the measurement exact. What it takes
    from the PLATE is its geometry at the bottom of the page: the box's own bottom
    edge is what the picture's foot stands on, so `height` carries --eye-y and the
    crop is a negative `bottom` offset that pushes the foot out through it. One
@@ -1167,20 +1195,35 @@ body::after {
 .eye {
   position: absolute;
   top: 0;
-  left: 0;
-  right: 0;
+  /* The carousel's own full-bleed frame, and it is the same two lines because it
+     has to be the same box. --edge is written in vw, so it only lands on the
+     column's edge when it is measured inside a box that is 100vw wide and centred
+     the way .carousel's margins make one; the body's box is 100vw LESS the
+     scrollbar, and measuring --edge from its right-hand edge would put the picture
+     half a scrollbar out — 7.5px on Windows, nothing where scrollbars are
+     overlaid, which is the kind of error that is invisible on the machine it is
+     tuned on. Here the strip's first photograph and this picture's left edge are
+     two offsets in one frame, so the gap between them is exact and the scrollbar
+     cancels out of it rather than being corrected for. */
+  left: calc(50% - 50vw);
+  right: calc(50% - 50vw);
   height: calc(var(--fold) - var(--eye-y));
   z-index: -1;
   pointer-events: none;
   background-image: var(--eye-src);
   background-repeat: no-repeat;
-  /* The four-value form, for --plate-x's reason: --eye-x is a distance out from
-     the corner the picture stands in and nothing else. The vertical offset is the
-     crop and only the crop — the height above has already put the box's bottom
-     edge where --eye-y asks for it — and it is negative so the foot is pushed
-     below that edge and clipped by it. */
+  /* The four-value form, for --plate-x's reason: an offset from a named edge is a
+     distance and nothing else, where a percentage would have been a share of the
+     difference between the box and the image and would have changed meaning every
+     time --eye-w did. LEFT is the named edge here, where the plate and the car
+     name the ones they stand in: this picture stands beside the photo strip rather
+     than in a corner, so it is measured from the strip's first photograph — --edge
+     — and --eye-x is the gap. The vertical offset is the crop and only the crop —
+     the height above has already put the box's bottom edge where --eye-y asks for
+     it — and it is negative so the foot is pushed below that edge and clipped
+     by it. */
   background-position:
-    right var(--eye-x)
+    left calc(var(--edge) + var(--eye-x))
     bottom calc(-1 * var(--eye-crop) * var(--eye-w));
   background-size: var(--eye-w) auto;
   opacity: var(--eye-opacity);


### PR DESCRIPTION
The eye was placed by eye on a 1920x1080 screen, 247px in from the
window's right edge. The strip it sits beside is pinned to a centred
column, so its first photograph moves half a pixel for every pixel of
window where a corner offset moves a whole one: widen the window by
200px and the two part company by 100px. The placement was therefore
right on one display and drifted on every other.

--eye-x now names the gap between the strip's first photograph and the
picture's own left edge, added to --edge, and 292.94px is that same
1920x1080 placement re-measured against the strip. The picture lands on
the same two pixels it did there and holds that gap at every width with
no breakpoint, since --edge is already a function of the width.

The LEFT edge is what is pinned. --eye-w is a share of --fold, so a
taller window hands the picture more width; spending it on the right
pushes the dead two-fifths of sky towards the page's edge, where holding
the right edge would have walked the mast in over the column.

.eye takes .carousel's full-bleed frame for this, because --edge is
written in vw and only lands on the column's edge inside a box that is
100vw wide -- the body's box is 100vw less the scrollbar, and measuring
from its right-hand edge would have put the picture half a scrollbar
out. Both offsets now live in one frame and the scrollbar cancels.

plate-tuner's row is relabelled to match: `in from the strip`.
