### PR TITLE
Give chroma-pictures its own split, and a blur

### DIFF
--- a/design/effects/effects-tuner.html
+++ b/design/effects/effects-tuner.html
@@ -171,10 +171,19 @@
       { prop: "--fx-paper-invert",   label: "invert", min: 0, max: 1, step: 1 },
       { prop: "--fx-paper-size",     label: "tile size", min: 48, max: 1024, step: 4, unit: "px" }
     ]},
-    { token: "chroma", name: "chromatic aberration", rows: [
+    { token: "chroma", name: "chromatic aberration — the type", rows: [
       { prop: "--fx-chroma-x",     label: "split x", min: -4, max: 4, step: 0.05, unit: "px" },
       { prop: "--fx-chroma-y",     label: "split y", min: -4, max: 4, step: 0.05, unit: "px" },
       { prop: "--fx-chroma-alpha", label: "fringe alpha", min: 0, max: 1, step: 0.01 }
+    ]},
+    /* The other half, and its ranges are wider than the type's on purpose: these
+       numbers are read against a photograph a few hundred pixels across rather
+       than against a 15px glyph, so the split that reads at all starts about
+       where the type's tops out. */
+    { token: "chroma-pictures", name: "chromatic aberration — the pictures", rows: [
+      { prop: "--fx-chroma-pic-x",    label: "split x", min: -12, max: 12, step: 0.1, unit: "px" },
+      { prop: "--fx-chroma-pic-y",    label: "split y", min: -12, max: 12, step: 0.1, unit: "px" },
+      { prop: "--fx-chroma-pic-blur", label: "fringe blur", min: 0, max: 8, step: 0.1, unit: "px" }
     ]},
     { token: "grain", name: "grain", rows: [
       { prop: "--fx-grain-opacity", label: "opacity", min: 0, max: 0.4, step: 0.005 },
@@ -226,10 +235,16 @@
             "exclusion", "luminosity"];
   }
 
-  /* chroma-pictures has no numbers of its own — it is a second decision about
-     the same split — so it is a chip with no group, and this is where that is
-     written down rather than being an omission in GROUPS. */
-  var CHIP_ONLY = ["chroma-pictures"];
+  /* Every token in api.effects now has a group above. There was a CHIP_ONLY list
+     here naming chroma-pictures as the exception — a chip with nothing to drag,
+     because it shared the type's split — and it is gone rather than emptied:
+     it named one token and was read by nothing, so as a list of none it would
+     have been a comment pretending to be code. A token that is a decision and
+     not a number simply has no entry in GROUPS, which the chips already show.
+
+     The chips are built from api.effects and the groups from GROUPS, and neither
+     checks the other. A token added to effects.js and not to GROUPS gets a chip
+     and no rows, which is exactly what chroma-pictures used to be. */
 
   var STORE = "portfolio-effects-tuner";
 

--- a/portfolio/effects.js
+++ b/portfolio/effects.js
@@ -97,10 +97,16 @@
     return 'url("' + here + '#fx-chroma")';
   }
 
-  /* The split itself. dx/dy are attributes on the two feOffset primitives, so
+  /* The split itself, and the softness of it. dx/dy are attributes on the two
+     feOffset primitives and stdDeviation is one on the two feGaussianBlurs, so
      they are set here and not in the sheet; the values come FROM the sheet, so
-     --fx-chroma-x stays the one place the number is written and the tuner can
-     move it like any other.
+     --fx-chroma-pic-* stays the one place each number is written and the tuner
+     can move them like any others.
+
+     --fx-chroma-pic-* and not --fx-chroma-*: this filter is the PICTURES' half
+     of the effect and the type's shadows are the other, and the two carry their
+     own numbers because a split only means anything against the size of what it
+     is splitting. See the chroma block in styles.css.
 
      Through measure(), for the reason under `resolving a length` below: a custom
      property is not resolved by getComputedStyle, so a value written in rem, or
@@ -108,8 +114,9 @@
      wrong number out of it. Measuring costs one layout on a drag and is right
      whatever unit the sheet or the tuner ends up expressing the split in. */
   function syncChroma() {
-    var dx = len("--fx-chroma-x");
-    var dy = len("--fx-chroma-y");
+    var dx = len("--fx-chroma-pic-x");
+    var dy = len("--fx-chroma-pic-y");
+    var soft = len("--fx-chroma-pic-blur");
     var r = document.getElementById("fx-chroma-r");
     var b = document.getElementById("fx-chroma-b");
     if (!r || !b) return;
@@ -117,6 +124,10 @@
     r.setAttribute("dy", -dy);
     b.setAttribute("dx", dx);
     b.setAttribute("dy", dy);
+    var rs = document.getElementById("fx-chroma-r-blur");
+    var bs = document.getElementById("fx-chroma-b-blur");
+    if (rs) rs.setAttribute("stdDeviation", soft);
+    if (bs) bs.setAttribute("stdDeviation", soft);
   }
 
   /* ---- the grain tile ----------------------------------------------------
@@ -445,7 +456,7 @@
        explicitly rather than re-syncing everything on every drag. */
     set: function (name, value) {
       root.style.setProperty(name, value);
-      if (name === "--fx-chroma-x" || name === "--fx-chroma-y") syncChroma();
+      if (name.indexOf("--fx-chroma-pic-") === 0) syncChroma();
       if (name.indexOf("--fx-ascii") === 0 || name === "--fx-y") scheduleAscii();
     },
     /* Every --fx- override off the root, back to what the sheet declares, with

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -268,7 +268,7 @@
        two things that used to sit at this line, an @font-face at the foot of
        styles.css and a script that attached /fonts/friz-local.css on localhost
        only, are both gone. See the cut title block in styles.css. -->
-  <link rel="stylesheet" href="styles.css?v=25">
+  <link rel="stylesheet" href="styles.css?v=26">
 </head>
 <body>
   <!-- Only ever on screen while a corner picture is genuinely outstanding: it is
@@ -314,8 +314,10 @@
        the three corner pictures ever do — the type gets the same split from a
        pair of text-shadows instead, which costs no compositing layer. See the
        chroma block in styles.css for why, and effects.js for who writes the two
-       feOffset primitives' dx/dy: filter primitives take ATTRIBUTES, so no
-       amount of custom property can drive them.
+       feOffset primitives' dx/dy and the two feGaussianBlur stdDeviations:
+       filter primitives take ATTRIBUTES, so no amount of custom property can
+       drive them. The numbers come from --fx-chroma-pic-*, which is the
+       pictures' own set — the type's --fx-chroma-* reach nothing in here.
 
        The two channels are pulled apart in opposite directions and the green is
        left where it is, which is what a prism does to a white edge. They are
@@ -342,9 +344,16 @@
                 0 0 0 1 0"/>
       <feOffset in="fx-r" dx="0" dy="0" result="fx-r-off" id="fx-chroma-r"/>
       <feOffset in="fx-b" dx="0" dy="0" result="fx-b-off" id="fx-chroma-b"/>
-      <feComposite in="fx-r-off" in2="fx-g" operator="arithmetic"
+      <!-- The moved channels go soft and the green does not, which is the half
+           of chromatic aberration a text-shadow cannot imitate: a lens that
+           cannot focus three wavelengths on one plane also cannot focus them to
+           one sharpness. stdDeviation 0 is an exact no-op, and it is what ships
+           — this is a control the tuner can reach, not a change to the page. -->
+      <feGaussianBlur in="fx-r-off" stdDeviation="0" result="fx-r-soft" id="fx-chroma-r-blur"/>
+      <feGaussianBlur in="fx-b-off" stdDeviation="0" result="fx-b-soft" id="fx-chroma-b-blur"/>
+      <feComposite in="fx-r-soft" in2="fx-g" operator="arithmetic"
                    k1="0" k2="1" k3="1" k4="0" result="fx-rg"/>
-      <feComposite in="fx-rg" in2="fx-b-off" operator="arithmetic"
+      <feComposite in="fx-rg" in2="fx-b-soft" operator="arithmetic"
                    k1="0" k2="1" k3="1" k4="0"/>
     </filter>
   </svg>
@@ -357,6 +366,6 @@
        the page is whole without — nothing below depends on it, and a browser
        that never runs it gets the CV, the photographs and the cut title exactly
        as they were before any of this. -->
-  <script src="effects.js?v=1"></script>
+  <script src="effects.js?v=2"></script>
 </body>
 </html>

--- a/portfolio/styles.css
+++ b/portfolio/styles.css
@@ -2065,12 +2065,32 @@ body::after {
      offset at one angle, which is what a prism does and what the effect is
      recognised as.
 
-     effects.js writes --fx-chroma-x/-y onto the filter's feOffset primitives:
-     SVG filter primitives take attributes, not CSS properties, so nothing else
-     can make the two halves move together. */
+     The three below are the TYPE's half and only the type's. */
   --fx-chroma-x: 0.6px;
   --fx-chroma-y: 0px;
   --fx-chroma-alpha: 0.5;
+
+  /* ...and these are the PICTURES' half, which is `chroma-pictures`. They were
+     the same three numbers until the two halves were separated, and sharing them
+     was wrong for a reason that only shows once you try to tune either: a split
+     is measured against what it is splitting. 0.6px either side of a 15px glyph
+     is a fringe you read as a fringe; the same 0.6px across a photograph 600px
+     wide is a rounding error, and the offset that reads on the pictures washes
+     the type out. One number could serve both only if they were the same size.
+
+     effects.js writes them onto the filter's primitives, because SVG filter
+     primitives take ATTRIBUTES and no amount of custom property can drive one.
+     That is also why the pictures get a third control the type cannot have:
+     `blur` is an feGaussianBlur on the two offset channels — the red and the
+     blue go soft while the green stays where it is, which is what a lens does
+     and what stops a hard-edged fringe on a photograph reading as a bug. A
+     text-shadow has no equivalent, so the type's third number is alpha instead.
+
+     Shipped at the type's old values with the blur off, so this separation
+     changed no pixel by itself. */
+  --fx-chroma-pic-x: 0.6px;
+  --fx-chroma-pic-y: 0px;
+  --fx-chroma-pic-blur: 0px;
 
   /* ---- everything below here is off unless its token is in data-fx --------- */
 
@@ -2276,7 +2296,8 @@ body::after {
    decision from the split's size: at --plate-opacity of 0.12 a 0.6px fringe on a
    photograph is close to unmeasurable, and paying a compositing layer per
    picture for it is worth being able to decline while the type keeps the
-   split. */
+   split. Its own three numbers are --fx-chroma-pic-* above; the --fx-chroma-*
+   ones next to them drive the type and reach nothing here. */
 :root[data-fx~="chroma-pictures"] body::after,
 :root[data-fx~="chroma-pictures"] .car,
 :root[data-fx~="chroma-pictures"] .eye {


### PR DESCRIPTION
It was a chip with nothing under it: `chroma-pictures` drove the SVG filter
from --fx-chroma-x/-y, the same two numbers the type's shadows use, so the
tuner had no group for it and there was nothing to drag.

Sharing them was wrong on its own terms. A split only means something against
the size of the thing being split: 0.6px either side of a 15px glyph is a
fringe, and the same 0.6px across a photograph 600px wide is a rounding
error, so the offset that reads on the pictures washes out the type. One
number could serve both only if they were the same size.

So the filter reads --fx-chroma-pic-x/-y instead, and takes a third control
the type cannot have — an feGaussianBlur on the two offset channels, so the
red and the blue go soft while the green stays put. That is the half of
chromatic aberration a text-shadow has no way to imitate, and it is what
stops a hard-edged fringe on a photograph reading as a rendering bug.

Shipped at the type's old values with the blur at 0, which is an exact no-op
in feGaussianBlur, so nothing on the page moves by itself. styles.css and
effects.js versions bumped.
