### PR TITLE
Let each effect be kept off the type or off the carousel

### DIFF
--- a/design/effects/effects-tuner.html
+++ b/design/effects/effects-tuner.html
@@ -25,6 +25,18 @@
     somebody rewriting a row's declaration as an expression; then it would show
     here as a default of NaN rather than as a wrong number quietly shipped.
 
+    THE TWO EXCLUSIONS. Under each group head, `exclude text` and `exclude
+    gallery` — keep this effect off the type, keep it off the carousel. They are
+    paint order and not a mask: the excluded content is lifted ABOVE the layer,
+    so the glyphs and the photographs come out clean and the paper around them
+    still takes the texture. There is one paint order, so a lift clears every
+    layer below the one it was asked for as well; those are drawn dashed on the
+    toggle nobody pressed, and named in the banner and in the export. See
+    KEEPING A LAYER OFF THE TYPE in styles.css.
+
+    Only the toggles a token can answer are drawn. api.excludable is where that
+    is decided, in effects.js, and a group that reaches neither says so.
+
     PER-THEME ROWS. Eight of them — the film's and the paper's levels stages —
     are declared once in :root and again in :root[data-theme="dark"], because
     this page's two papers are #fff and #000 and one set of numbers cannot serve
@@ -106,6 +118,19 @@
     .row.moved .undo { visibility: visible; }
     .undo:hover { color: var(--ui-hit); }
 
+    /* ---- the two exclusions, per group ------------------------------------ */
+    .keep { display: flex; flex-wrap: wrap; gap: 0.3rem; padding: 0 0.7rem 0.35rem; }
+    .keep button {
+      padding: 0.08rem 0.4rem; border-radius: 99px; font-size: 11px;
+      color: var(--ui-mut); border-color: var(--ui-line);
+    }
+    .keep button[aria-pressed="true"] { background: var(--ui-hit); color: var(--ui-bg); border-color: var(--ui-hit); }
+    /* A layer the lift went over on its way to one that was asked for. Marked on
+       the toggle it was not pressed on, because that is where somebody would
+       look to find out why the effect is missing from the type anyway. */
+    .keep button[data-implied="1"] { border-style: dashed; border-color: var(--ui-hit); color: var(--ui-hit); }
+    .keep .none { font-size: 10.5px; color: var(--ui-mut); padding: 0.1rem 0; }
+
     .out { flex: 0 0 auto; border-top: 1px solid var(--ui-line); }
     .out textarea { width: 100%; height: 11rem; border: 0; border-radius: 0; padding: 0.5rem 0.7rem; resize: vertical; font: 11.5px/1.5 ui-monospace, Consolas, monospace; }
     .warn { margin: 0; padding: 0.45rem 0.7rem; background: rgba(216, 167, 106, 0.16); font-size: 11.5px; }
@@ -128,6 +153,9 @@
     <button id="copy" type="button">copy CSS</button>
   </div>
   <p class="warn" id="warn"></p>
+  <!-- Separate from the one above, which is about the SHEET being unreadable and
+       stays up for the session. This one comes and goes with the exclusions. -->
+  <p class="warn" id="keepwarn"></p>
   <div class="wrap">
     <div class="side">
       <div class="chips" id="chips"></div>
@@ -254,6 +282,7 @@
   var exportEl = document.getElementById("export");
   var countEl = document.getElementById("count");
   var warnEl = document.getElementById("warn");
+  var keepWarnEl = document.getElementById("keepwarn");
   var themeBtn = document.getElementById("theme");
   var fwEl = document.getElementById("fw");
   var fhEl = document.getElementById("fh");
@@ -263,9 +292,14 @@
   /* Defaults as the sheet declares them, per theme. Probed once per load. */
   var base = { light: {}, dark: {} };
   /* What has been moved away from those. Rows marked `theme` live under their
-     theme's key; everything else under `any`, which is applied in both. */
-  var state = { light: {}, dark: {}, any: {}, fx: null };
+     theme's key; everything else under `any`, which is applied in both.
+     `keep` is the two exclusion lists — which effects have been told to stay off
+     the type and off the carousel — held here rather than in the frame for the
+     same reason every number is: the frame is reloaded and re-driven, and the
+     tuner is the thing that remembers. */
+  var state = { light: {}, dark: {}, any: {}, keep: { text: [], gallery: [] }, fx: null };
   var rowEls = {};
+  var keepEls = [];
 
   function allRows() {
     var out = [];
@@ -347,6 +381,7 @@
 
     /* groups */
     controlsEl.textContent = "";
+    keepEls = [];
     GROUPS.forEach(function (g) {
       var wrap = document.createElement("div");
       wrap.className = "group";
@@ -355,6 +390,7 @@
       head.className = "ghead";
       head.textContent = g.name;
       wrap.appendChild(head);
+      if (g.token) wrap.appendChild(makeKeep(g.token));
       var rows = document.createElement("div");
       rows.className = "rows";
       g.rows.forEach(function (row) { rows.appendChild(makeRow(row)); });
@@ -362,6 +398,47 @@
       controlsEl.appendChild(wrap);
     });
     syncChips();
+  }
+
+  /* ---- exclude text / exclude gallery ------------------------------------
+     Two toggles per effect, and only the ones that token can actually answer:
+     effects.js decides that in EXCLUDABLE and hands it over as api.excludable,
+     so a group that reaches neither the type nor the strip — chroma-pictures,
+     ascii, weave — says so rather than offering a pair of buttons that would do
+     nothing when pressed. The band group has no token and gets nothing.
+
+     `gallery` is the carousel and its scrollbar, not the three corner
+     photographs. Those are the pictures the ascii and chroma-pictures groups act
+     on, which is why they are named separately in this panel. */
+  var KEEP_LABEL = { text: "exclude text", gallery: "exclude gallery" };
+
+  function makeKeep(token) {
+    var el = document.createElement("div");
+    el.className = "keep";
+    var can = (api.excludable && api.excludable[token]) || [];
+    if (!can.length) {
+      var note = document.createElement("span");
+      note.className = "none";
+      note.textContent = "reaches neither the type nor the carousel";
+      el.appendChild(note);
+      return el;
+    }
+    can.forEach(function (what) {
+      var b = document.createElement("button");
+      b.type = "button";
+      b.textContent = KEEP_LABEL[what];
+      b.dataset.what = what;
+      b.dataset.token = token;
+      b.addEventListener("click", function () {
+        var list = state.keep[what];
+        var at = list.indexOf(token);
+        if (at < 0) list.push(token); else list.splice(at, 1);
+        applyAll();
+      });
+      el.appendChild(b);
+      keepEls.push(b);
+    });
+    return el;
   }
 
   function makeRow(row) {
@@ -444,6 +521,8 @@
      an incremental path that can disagree with the state it is meant to mirror —
      and the theme rows make an incremental path genuinely awkward, since
      switching theme has to UNSET whatever the other theme's inline value was. */
+  var live = null;    /* what the frame says the exclusions actually came out as */
+
   function applyAll() {
     api.clearVars();
     allRows().forEach(function (row) {
@@ -451,6 +530,11 @@
       if (b[row.prop] === undefined) return;
       api.set(row.prop, b[row.prop] + (row.unit || ""));
     });
+    /* After clearVars, which takes --fx-text-z and --fx-gallery-z with it. The
+       return value is what the page IS doing rather than what it was told to,
+       and the two differ whenever a lift had to go over a layer nobody asked to
+       exclude — see KEEPING A LAYER OFF THE TYPE in styles.css. */
+    live = api.setExclusions(state.keep);
     sync();
     save();
     writeExport();
@@ -466,8 +550,39 @@
       ui.el.classList.toggle("moved", bucket(row)[row.prop] !== undefined);
     });
     syncChips();
+    syncKeep();
     countEl.textContent = changeCount();
     countEl.dataset.n = changeCount();
+  }
+
+  /* Pressed for what was asked, dashed for what the paint order took with it.
+     The second is the honest half of this panel: a toggle nobody pressed that is
+     nevertheless in force reads as a bug in the effect otherwise. */
+  function syncKeep() {
+    keepEls.forEach(function (b) {
+      var what = b.dataset.what, token = b.dataset.token;
+      var asked = state.keep[what].indexOf(token) >= 0;
+      var implied = !asked && live && live[what] &&
+                    live[what].alsoOff.indexOf(token) >= 0;
+      b.setAttribute("aria-pressed", asked ? "true" : "false");
+      b.dataset.implied = implied ? "1" : "0";
+      b.title = implied
+        ? "not asked for — it is under a layer that was, and there is only one " +
+          "paint order, so it comes off the " +
+          (what === "text" ? "type" : "carousel") + " too"
+        : KEEP_LABEL[what];
+    });
+    var over = [];
+    ["text", "gallery"].forEach(function (what) {
+      if (live && live[what] && live[what].alsoOff.length) {
+        over.push((what === "text" ? "off the type" : "off the carousel") +
+                  " as well: " + live[what].alsoOff.join(", "));
+      }
+    });
+    keepWarnEl.textContent = over.length
+      ? "One paint order, so a lift clears every layer below the one it was " +
+        "asked for — " + over.join("; ") + "."
+      : "";
   }
 
   function syncChips() {
@@ -486,11 +601,24 @@
     return Object.keys(state.any).length +
            Object.keys(state.light).length +
            Object.keys(state.dark).length +
-           (fxChanged() ? 1 : 0);
+           (fxChanged() ? 1 : 0) +
+           (keepChanged() ? 1 : 0);
   }
   function fxChanged() {
     if (!api) return false;
     return api.list().slice().sort().join(" ") !== api.shipped.slice().sort().join(" ");
+  }
+  /* Both lists against what the markup ships, as one change rather than two —
+     the same accounting fxChanged does, and for the same reason: the badge
+     counts things that would have to be pasted somewhere, and these two are one
+     line of index.html between them. */
+  function keepChanged() {
+    if (!api) return false;
+    var was = api.shippedExclusions || { text: [], gallery: [] };
+    return ["text", "gallery"].some(function (what) {
+      return state.keep[what].slice().sort().join(" ") !==
+             (was[what] || []).slice().sort().join(" ");
+    });
   }
 
   /* ---- theme, frame ------------------------------------------------------ */
@@ -522,6 +650,11 @@
 
   document.getElementById("reset").addEventListener("click", function () {
     state.light = {}; state.dark = {}; state.any = {};
+    /* api.reset() puts the frame's own copy back to what the markup ships; this
+       is the tuner's copy of the same thing, and applyAll below writes it back
+       over the top, so it has to be the shipped lists and not empty ones. */
+    var was = (api && api.shippedExclusions) || { text: [], gallery: [] };
+    state.keep = { text: (was.text || []).slice(), gallery: (was.gallery || []).slice() };
     if (api) api.reset();
     applyAll();
   });
@@ -560,10 +693,30 @@
     var out = "/* design/effects/effects-tuner.html — paste into portfolio/styles.css.\n" +
               "   Only what moved, with the shipped value alongside. The two blocks are\n" +
               "   the two halves of THE LEVELS STAGE; keep each in the right one. */\n\n";
-    if (fxChanged()) {
-      out += "<!-- portfolio/index.html -->\n" +
-             '<html lang="en" data-fx="' + api.list().join(" ") + '">\n' +
-             "     /* ships: " + api.shipped.join(" ") + " */\n\n";
+    /* One <html> line, because that is what it is in the file — the effects and
+       the two exclusions are three attributes on one tag, and exporting them as
+       three snippets would invite pasting one and losing the others. Omitted
+       attributes are omitted, so an unchanged one is not restated as noise. */
+    if (fxChanged() || keepChanged()) {
+      var was = api.shippedExclusions || { text: [], gallery: [] };
+      var attrs = ' lang="en" data-fx="' + api.list().join(" ") + '"';
+      if (state.keep.text.length) attrs += '\n      data-fx-no-text="' + state.keep.text.join(" ") + '"';
+      if (state.keep.gallery.length) attrs += '\n      data-fx-no-gallery="' + state.keep.gallery.join(" ") + '"';
+      out += "<!-- portfolio/index.html -->\n<html" + attrs + ">\n" +
+             "     /* ships: data-fx=\"" + api.shipped.join(" ") + "\"" +
+             (was.text.length ? " no-text=\"" + was.text.join(" ") + "\"" : "") +
+             (was.gallery.length ? " no-gallery=\"" + was.gallery.join(" ") + "\"" : "") +
+             " */\n";
+      /* Named here as well as in the banner, because the export is the thing
+         that gets pasted and read back weeks later without the panel next to it. */
+      ["text", "gallery"].forEach(function (what) {
+        if (live && live[what] && live[what].alsoOff.length) {
+          out += "     /* and, from the paint order alone, off the " +
+                 (what === "text" ? "type" : "carousel") + ": " +
+                 live[what].alsoOff.join(" ") + " */\n";
+        }
+      });
+      out += "\n";
     }
     var light = block("light", ":root");
     var dark = block("dark", ':root[data-theme="dark"]');
@@ -578,6 +731,7 @@
     try {
       localStorage.setItem(STORE, JSON.stringify({
         state: { light: state.light, dark: state.dark, any: state.any },
+        keep: state.keep,
         theme: theme, w: fwEl.value, h: fhEl.value
       }));
     } catch (_) {}
@@ -585,12 +739,21 @@
   function restore() {
     var raw = null;
     try { raw = localStorage.getItem(STORE); } catch (_) {}
+    /* The frame's own attributes are the starting point, not an empty pair —
+       what index.html ships is a real state and reopening the tuner should show
+       it. A stored session then replaces it, as it does for every number. */
+    var was = (api && api.shippedExclusions) || { text: [], gallery: [] };
+    state.keep = { text: (was.text || []).slice(), gallery: (was.gallery || []).slice() };
     if (raw) {
       try {
         var s = JSON.parse(raw);
         state.light = s.state.light || {};
         state.dark = s.state.dark || {};
         state.any = s.state.any || {};
+        if (s.keep) {
+          state.keep.text = s.keep.text || [];
+          state.keep.gallery = s.keep.gallery || [];
+        }
         if (s.w) fwEl.value = s.w;
         if (s.h) fhEl.value = s.h;
       } catch (_) {}

--- a/portfolio/effects.js
+++ b/portfolio/effects.js
@@ -41,6 +41,62 @@
 
   var STORE = "portfolio-fx";
 
+  /* ---- what an effect can be kept OFF ------------------------------------
+     Two exclusions — the type, and the carousel — and the three ways a token
+     can answer them, because the eleven effects are not all the same shape.
+
+     STACKED is the tokens that paint as a layer in .fx. Those are excluded by
+     paint order: the content is lifted above the layer, so both exclusions are
+     available and neither is exact when several layers disagree (see KEEPING A
+     LAYER OFF THE TYPE in styles.css). The selector is the layer or layers the
+     token turns on, and the z comes off the element rather than being repeated
+     here, so renumbering the sheet is not a change to this file.
+
+     SHADOWED is the two that are a text-shadow ON the type. They have nothing to
+     lift over and no presence on the strip: `no text` is the sheet not writing
+     the declaration, which it does on its own from data-fx-no-text, and there is
+     no gallery question to ask.
+
+     Everything else — chroma-pictures, ascii, weave — reaches neither the type
+     nor the strip, and gets neither toggle rather than an inert pair of them. */
+  var STACKED = {
+    paper: ".fx-paper",
+    halftone: ".fx-halftone",
+    film: ".fx-film",
+    grain: ".fx-grain",
+    crt: ".fx-grille, .fx-scan, .fx-roll, .fx-tube",
+    vignette: ".fx-vignette"
+  };
+  var SHADOWED = ["chroma", "halation"];
+
+  /* token -> which of the two exclusions it can answer. The tuner draws its
+     toggles off this rather than knowing the three shapes above. */
+  var EXCLUDABLE = {};
+  EFFECTS.forEach(function (name) {
+    EXCLUDABLE[name] = STACKED[name] ? ["text", "gallery"]
+                     : SHADOWED.indexOf(name) >= 0 ? ["text"]
+                     : [];
+  });
+
+  /* What the markup ships, read the same way and for the same reason `data-fx`
+     is: index.html is the one place the default is written and this file cannot
+     drift from it. Filtered through EXCLUDABLE, so an attribute naming a token
+     that has no answer to that question is dropped rather than half-applied.
+
+     Not persisted the way `on` is, and no ?fx= equivalent. An exclusion is a
+     decision about how the site is composed rather than something a visitor
+     chooses, so it lives in the markup this exports to and nowhere else. */
+  function excluded(attr, what) {
+    return tokens(root.getAttribute(attr)).filter(function (name) {
+      return EXCLUDABLE[name].indexOf(what) >= 0;
+    });
+  }
+  var off = {
+    text: excluded("data-fx-no-text", "text"),
+    gallery: excluded("data-fx-no-gallery", "gallery")
+  };
+  var SHIPPED_OFF = { text: off.text.slice(), gallery: off.gallery.slice() };
+
   function tokens(s) {
     return String(s || "").trim().split(/\s+/).filter(function (t) {
       return EFFECTS.indexOf(t) >= 0;
@@ -78,6 +134,67 @@
     /* The ASCII pass is the one effect with work to do at the moment it is
        switched on, and nothing to do while it is off. */
     if (on.indexOf("ascii") >= 0) scheduleAscii(); else clearAscii();
+  }
+
+  /* ---- the exclusions, applied -------------------------------------------
+     Two attributes and two numbers, rebuilt whole every time. The attribute is
+     what was ASKED for and is what the export writes into index.html; the number
+     is derived from it, and is the odd z the lifted content stands on — one
+     above the highest layer being excluded, since the sheet numbers the layers
+     even.
+
+     `auto` and not 0 when nothing stacked is excluded. That is the case where
+     only chroma or halation is listed, which the sheet handles by not writing a
+     declaration and which wants no lift at all; `z-index: auto` leaves the four
+     text blocks in tree order under the whole stack, where they started, while
+     0 would have made each of them a stacking context for nothing. */
+  function zOf(token) {
+    var sel = STACKED[token];
+    if (!sel) return null;
+    var top = null;
+    Array.prototype.forEach.call(document.querySelectorAll(sel), function (el) {
+      var z = parseInt(getComputedStyle(el).zIndex, 10);
+      if (!isNaN(z) && (top === null || z > top)) top = z;
+    });
+    return top;
+  }
+
+  function applyExclusions() {
+    ["text", "gallery"].forEach(function (what) {
+      var list = off[what];
+      var top = null;
+      list.forEach(function (t) {
+        var z = zOf(t);
+        if (z !== null && (top === null || z > top)) top = z;
+      });
+      if (!list.length) {
+        /* Nothing asked for: the attribute and the number both go, so a page
+           with no exclusions carries no trace of the machinery. */
+        root.removeAttribute("data-fx-no-" + what);
+        root.style.removeProperty("--fx-" + what + "-z");
+        return;
+      }
+      root.setAttribute("data-fx-no-" + what, list.join(" "));
+      root.style.setProperty("--fx-" + what + "-z", top === null ? "auto" : String(top + 1));
+    });
+  }
+
+  /* The cost of there being one paint order: a layer nobody asked to exclude,
+     which the lift went over anyway because it sits below one that was asked
+     for. Reported rather than hidden — it is the difference between what the
+     page is doing and what the tuner was told to do. */
+  function overExcluded(what) {
+    var top = null;
+    off[what].forEach(function (t) {
+      var z = zOf(t);
+      if (z !== null && (top === null || z > top)) top = z;
+    });
+    if (top === null) return [];
+    return Object.keys(STACKED).filter(function (t) {
+      if (off[what].indexOf(t) >= 0) return false;
+      var z = zOf(t);
+      return z !== null && z < top;
+    });
   }
 
   /* ---- chromatic aberration ---------------------------------------------
@@ -410,6 +527,7 @@
   var tile = grainTile();
   if (tile) root.style.setProperty("--fx-grain-src", tile);
   syncChroma();
+  applyExclusions();
   apply(false);
 
   /* Both of the things the ASCII pass is measured against can move under it: the
@@ -481,9 +599,39 @@
       style.setProperty("--fx-chroma-url", chromaUrl());
       if (tile) style.setProperty("--fx-grain-src", tile);
       syncChroma();
+      /* --fx-text-z and --fx-gallery-z are --fx- names too, so the sweep above
+         took them. They are derived, like the two put back on the lines above,
+         and are re-derived here rather than exempted. */
+      applyExclusions();
       scheduleAscii();
     },
+    /* The exclusions, whole, every time — the same clean-slate contract `set`
+       has and for the same reason: two lists and two derived numbers are cheaper
+       to rebuild than an incremental path is to keep honest.
+       Returns what the page is ACTUALLY doing, which is not always what was
+       asked: `alsoOff` names the layers the lift went over on the way. */
+    setExclusions: function (next) {
+      ["text", "gallery"].forEach(function (what) {
+        off[what] = ((next && next[what]) || []).filter(function (name) {
+          return (EXCLUDABLE[name] || []).indexOf(what) >= 0;
+        });
+      });
+      applyExclusions();
+      return window.portfolioFx.exclusions();
+    },
+    exclusions: function () {
+      return {
+        text: { off: off.text.slice(), alsoOff: overExcluded("text") },
+        gallery: { off: off.gallery.slice(), alsoOff: overExcluded("gallery") }
+      };
+    },
+    /* Which of the two questions each token can answer at all — the tuner draws
+       its toggles from this rather than repeating the three shapes. */
+    excludable: EXCLUDABLE,
+    shippedExclusions: { text: SHIPPED_OFF.text.slice(), gallery: SHIPPED_OFF.gallery.slice() },
     reset: function () {
+      off.text = SHIPPED_OFF.text.slice();
+      off.gallery = SHIPPED_OFF.gallery.slice();
       window.portfolioFx.clearVars();
       on = tokens(SHIPPED);
       apply(true);

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -7,7 +7,14 @@
      where they are judged.
      Three of the eleven ship on. `chroma` splits the type and `chroma-pictures`
      splits the three corner photographs — two tokens because they are two
-     decisions, one of which costs a compositing layer per picture. -->
+     decisions, one of which costs a compositing layer per picture.
+
+     data-fx-no-text and data-fx-no-gallery go here too, and neither is set: they
+     name the effects that are to be kept off the type and off the carousel, and
+     nothing is at the moment. They are attributes rather than another token
+     because they are a property OF an effect and not a twelfth one, and they are
+     read here for the same reason data-fx is — one place, no drift. What they do
+     is KEEPING A LAYER OFF THE TYPE in styles.css; the tuner writes them. -->
 <html lang="en" data-fx="film paper chroma chroma-pictures">
 <head>
   <meta charset="utf-8">
@@ -268,7 +275,7 @@
        two things that used to sit at this line, an @font-face at the foot of
        styles.css and a script that attached /fonts/friz-local.css on localhost
        only, are both gone. See the cut title block in styles.css. -->
-  <link rel="stylesheet" href="styles.css?v=26">
+  <link rel="stylesheet" href="styles.css?v=27">
 </head>
 <body>
   <!-- Only ever on screen while a corner picture is genuinely outstanding: it is
@@ -366,6 +373,6 @@
        the page is whole without — nothing below depends on it, and a browser
        that never runs it gets the CV, the photographs and the cut title exactly
        as they were before any of this. -->
-  <script src="effects.js?v=2"></script>
+  <script src="effects.js?v=3"></script>
 </body>
 </html>

--- a/portfolio/styles.css
+++ b/portfolio/styles.css
@@ -1259,8 +1259,25 @@ body::after {
 }
 /* fade the whole page in on load. A CSS animation (not a JS-toggled class) so
    it can't get stuck invisible if a rAF never fires; if animations are off or
-   unsupported the page simply shows at full opacity. */
-.js .page { animation: page-in 0.9s cubic-bezier(0.22, 1, 0.36, 1) both; }
+   unsupported the page simply shows at full opacity.
+
+   `backwards` and not `both`, and the difference is not cosmetic. `forwards`
+   keeps the last keyframe applied for ever, and the last keyframe says
+   `transform: none` — which does not compute to the keyword afterwards but to
+   the identity MATRIX, and any transform other than none makes an element a
+   stacking context. So .page was one, permanently, from the moment the fade
+   ended, and everything inside it was sealed into its own z ordering: KEEPING A
+   LAYER OFF THE TYPE further down cannot lift a paragraph over .fx-film across
+   a stacking context, and the exclusions silently did nothing.
+
+   Nothing is lost by dropping it. The last keyframe of both animations below is
+   the element's own base style — opacity 1, no transform — so forward fill was
+   holding a value identical to the one underneath it, and `backwards` still
+   covers the case the `both` was written for: the page is invisible before and
+   during the fade and up afterwards, whether or not any script ran. If anything
+   it is safer, since the state the page rests in is now the sheet's rather than
+   a keyframe's. */
+.js .page { animation: page-in 0.9s cubic-bezier(0.22, 1, 0.36, 1) backwards; }
 @keyframes page-in {
   from { opacity: 0; transform: translateY(8px); }
   to   { opacity: 1; transform: none; }
@@ -1280,7 +1297,7 @@ body::after {
    (It also keeps the profile-README screenshot honest: Playwright fast-forwards
    finite animations to their end state, which a JS-toggled class would not.) */
 .js.plate-wait .page {
-  animation: page-held-in 2.4s cubic-bezier(0.22, 1, 0.36, 1) both;
+  animation: page-held-in 2.4s cubic-bezier(0.22, 1, 0.36, 1) backwards;
 }
 @keyframes page-held-in {
   /* 62.5% of 2.4s is 1.5s: hold, then the same 0.9s fade as above. */
@@ -2193,6 +2210,66 @@ body::after {
     transparent 100%);
 }
 
+/* ---- KEEPING A LAYER OFF THE TYPE OR OFF THE PHOTO STRIP -------------------
+   Each effect can be told, in the tuner, not to lie over the type or not to lie
+   over the carousel. The way that is done is paint order and not a hole: the
+   excluded content is lifted ABOVE the layer, so the glyphs and the photographs
+   come out untouched while the paper around them still takes the texture. A
+   mask would have been independent per layer and would have cut a rectangle
+   across the page, which is not what either of these effects is for.
+
+   Every layer therefore needs a z of its own, in the order it already paints
+   in. EVEN numbers, so the content has an odd one to stand on between any two
+   of them — --fx-text-z and --fx-gallery-z are (the highest excluded layer) + 1,
+   written by effects.js, which reads these numbers back off the elements rather
+   than keeping a copy. Renumber here and nothing else has to know.
+
+   A z-index on a LAYER is safe, and the warning at the top of .fx is about a
+   z-index on the CONTAINER: an element's own stacking context does not change
+   what its blending sees, because mix-blend-mode blends with the backdrop of the
+   PARENT group, and .fx is still not one. Measured with a bare patch of paper
+   before and after, as that comment asks for.
+
+   WHAT THIS CANNOT DO. There is one paint order, so the layers a piece of
+   content is lifted over are always the lowest ones. Ask for the film to be off
+   the type while the paper — which paints below the film — is not, and the paper
+   comes off it too; there is no order in which the type is above the film and
+   below the paper. The tuner names any layer that gets excluded this way rather
+   than letting it pass as what you asked for. */
+.fx-paper    { z-index: 2; }
+.fx-halftone { z-index: 4; }
+.fx-film     { z-index: 6; }
+.fx-grain    { z-index: 8; }
+.fx-grille   { z-index: 10; }
+.fx-scan     { z-index: 12; }
+.fx-roll     { z-index: 14; }
+.fx-tube     { z-index: 16; }
+.fx-vignette { z-index: 18; }
+
+/* The type, in its four blocks rather than as .col, because .col CONTAINS the
+   carousel — lifting the column would carry the strip with it and the two would
+   stop being separable, which is the whole of what these two toggles are.
+   .cbar goes with the carousel: it is the strip's scrollbar, not a paragraph.
+
+   `var(--fx-text-z)` with no fallback is deliberate. effects.js writes the word
+   `auto` when nothing STACKED is excluded — chroma and halation are excluded by
+   their declaration simply not being written, a few rules below, and need no
+   lift — and `z-index: auto` leaves these in tree order under the whole stack,
+   which is where they started. An invalid value here would instead make the
+   whole declaration unset and take `position: relative` with it. */
+:root[data-fx-no-text] .masthead,
+:root[data-fx-no-text] .intro,
+:root[data-fx-no-text] .listing,
+:root[data-fx-no-text] .cut-title {
+  position: relative;
+  z-index: var(--fx-text-z);
+}
+:root[data-fx-no-gallery] .carousel,
+:root[data-fx-no-gallery] .cbar {
+  position: relative;
+  z-index: var(--fx-gallery-z);
+}
+
 :root[data-fx~="film"] .fx-film {
   display: block;
   background-image: var(--fx-film-src);
@@ -2273,8 +2350,11 @@ body::after {
    overlap behind a glyph's own body they sum to neutral, so the effect is
    confined to the edges by construction rather than by choosing a small enough
    alpha. */
-:root[data-fx~="chroma"] .col,
-:root[data-fx~="chroma"] .cut-title {
+/* `exclude text` for this one is not a lift — there is nothing to lift over,
+   because the effect IS on the type. It is the declaration not being written,
+   which is the cheapest exclusion in the sheet and the only exact one. */
+:root[data-fx~="chroma"]:not([data-fx-no-text~="chroma"]) .col,
+:root[data-fx~="chroma"]:not([data-fx-no-text~="chroma"]) .cut-title {
   text-shadow:
     calc(-1 * var(--fx-chroma-x)) calc(-1 * var(--fx-chroma-y)) 0
       rgba(255, 0, 0, var(--fx-chroma-alpha)),
@@ -2387,13 +2467,18 @@ body::after {
    This is decoration on a CV; it should degrade by not appearing, and it does —
    an engine without color-mix drops the declaration and gets the page it would
    have had anyway. */
-:root[data-fx~="halation"] .col,
-:root[data-fx~="halation"] .cut-title {
+:root[data-fx~="halation"]:not([data-fx-no-text~="halation"]) .col,
+:root[data-fx~="halation"]:not([data-fx-no-text~="halation"]) .cut-title {
   text-shadow: 0 0 var(--fx-halation-radius)
     color-mix(in srgb, currentColor calc(var(--fx-halation-alpha) * 100%), transparent);
 }
-:root[data-fx~="halation"][data-fx~="chroma"] .col,
-:root[data-fx~="halation"][data-fx~="chroma"] .cut-title {
+/* Both, in one declaration, because text-shadow does not accumulate across
+   rules. The two guards are what make that composable again: exclude either one
+   and this stops matching, leaving the other's own rule above to apply alone —
+   which it does, and correctly, because this selector outweighs both of them
+   only while both effects are actually wanted on the type. */
+:root[data-fx~="halation"]:not([data-fx-no-text~="halation"])[data-fx~="chroma"]:not([data-fx-no-text~="chroma"]) .col,
+:root[data-fx~="halation"]:not([data-fx-no-text~="halation"])[data-fx~="chroma"]:not([data-fx-no-text~="chroma"]) .cut-title {
   text-shadow:
     calc(-1 * var(--fx-chroma-x)) calc(-1 * var(--fx-chroma-y)) 0
       rgba(255, 0, 0, var(--fx-chroma-alpha)),


### PR DESCRIPTION
Two toggles under every group head in the tuner. They are paint order and
not a mask: the excluded content is lifted ABOVE the layer, so the glyphs
and the photographs come out clean while the paper around them still takes
the texture. A mask would have been exact per layer and would have cut a
hard rectangle across the page, which is not what any of these effects is
for.

Every layer in .fx gets an even z in the order it already painted in, and
--fx-text-z / --fx-gallery-z are one above the highest layer being excluded.
effects.js reads those numbers back off the elements rather than keeping a
copy, so renumbering the sheet is not a change to the script. The lists live
on <html> as data-fx-no-text and data-fx-no-gallery, read at boot the same
way data-fx is, and the tuner exports all three as one tag.

The type is lifted in its four blocks and not as .col, because .col contains
the carousel and lifting the column would carry the strip with it — the two
have to move separately or the toggles are one toggle.

chroma and halation are not layers; they are a text-shadow ON the type. For
those `exclude text` is the declaration not being written, which is exact,
and there is no gallery question to ask. chroma-pictures, ascii and weave
reach neither, and get no toggles rather than an inert pair.

WHAT IT CANNOT DO, and the tuner says so rather than letting it pass: there
is one paint order, so a lift clears every layer below the one it was asked
for. Ask for the film off the type and the paper comes off it too. Those are
drawn dashed on the toggle nobody pressed, named in a banner, and written
into the export.

Also: page-in and page-held-in go from `both` to `backwards` fill, and that
is what makes any of the above work. `forwards` keeps the last keyframe for
ever, the last keyframe says `transform: none`, and that computes afterwards
to the identity MATRIX rather than the keyword — so .page was a permanent
stacking context and nothing inside it could be lifted over .fx at all. The
last keyframe of both animations is the element's own base style, so forward
fill was holding a value identical to the one underneath it; dropping it
changes no frame of either fade.

styles.css and effects.js versions bumped.
