### PR TITLE
Stop the effects tuner overwriting its session before reading it

### DIFF
--- a/design/effects/effects-tuner.html
+++ b/design/effects/effects-tuner.html
@@ -727,7 +727,18 @@
 
   /* ---- persistence ------------------------------------------------------- */
 
+  /* Nothing is written before restore() has read, and that one line is the whole
+     of this file's persistence working at all. save() is reached from sizeFrame(),
+     sizeFrame() is called once at the bottom of this script to give the iframe a
+     width before it loads, and restore() cannot run until the frame's load event
+     — which is later, because the script is synchronous and the load is not. So
+     every session opened the tuner, wrote `{}` over whatever the last one left,
+     and then restored the blank it had just written. Nothing had ever survived a
+     reload; it looked like a tuner that deliberately started clean. */
+  var ready = false;
+
   function save() {
+    if (!ready) return;
     try {
       localStorage.setItem(STORE, JSON.stringify({
         state: { light: state.light, dark: state.dark, any: state.any },
@@ -760,9 +771,13 @@
     }
     theme = doc.documentElement.getAttribute("data-theme") === "dark" ? "dark" : "light";
     themeBtn.textContent = "theme: " + theme;
+    /* Everything above has been read; from here writing is safe, and the
+       sizeFrame below is the first write — it puts back what was just read. */
+    ready = true;
     sizeFrame();
   }
 
+  /* Before the frame has loaded, so this one only sizes it. See save(). */
   sizeFrame();
 })();
 </script>


### PR DESCRIPTION
Nothing has ever survived a reload here, and it did not look like a bug: the
panel came up clean every time, which is what a tuner that deliberately
starts clean also does.

save() is reached from sizeFrame(). sizeFrame() is called once at the bottom
of the script, to give the iframe a width before it loads. restore() cannot
run until the frame's load event, which is later — the script is synchronous
and the load is not. So every session wrote `{}` over whatever the last one
left and then restored the blank it had just written.

One flag: save() does nothing until restore() has read, and restore() sets it
immediately before its own sizeFrame(), which is then the first write and puts
back what was just read. A guard rather than a quiet variant of sizeFrame,
because any future early caller is covered by it too.
