### PR TITLE
Ship the halftone screen and take the film off the stack

### DIFF
--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -7,15 +7,19 @@
      where they are judged.
      Three of the eleven ship on. `chroma` splits the type and `chroma-pictures`
      splits the three corner photographs — two tokens because they are two
-     decisions, one of which costs a compositing layer per picture.
+     decisions, one of which costs a compositing layer per picture, and only the
+     pictures' half is on, so the type is left unsplit.
 
-     data-fx-no-text and data-fx-no-gallery go here too, and neither is set: they
-     name the effects that are to be kept off the type and off the carousel, and
-     nothing is at the moment. They are attributes rather than another token
-     because they are a property OF an effect and not a twelfth one, and they are
-     read here for the same reason data-fx is — one place, no drift. What they do
-     is KEEPING A LAYER OFF THE TYPE in styles.css; the tuner writes them. -->
-<html lang="en" data-fx="film paper chroma chroma-pictures">
+     data-fx-no-text and data-fx-no-gallery go here too, and both are set: they
+     name the effects that are to be kept off the type and off the carousel —
+     the halftone off both, the paper off the carousel. They are attributes
+     rather than another token because they are a property OF an effect and not
+     a twelfth one, and they are read here for the same reason data-fx is — one
+     place, no drift. What they do is KEEPING A LAYER OFF THE TYPE in
+     styles.css; the tuner writes them. -->
+<html lang="en" data-fx="halftone paper chroma-pictures"
+      data-fx-no-text="halftone"
+      data-fx-no-gallery="paper halftone">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/portfolio/styles.css
+++ b/portfolio/styles.css
@@ -1966,7 +1966,7 @@ body::after {
   /* Where the stack stops. --fx-y is the twin of --plate-y and moves the foot of
      every layer at once; --fx-fade is how far above that foot the dissolve
      starts, as a share of the band. */
-  --fx-y: 0px;
+  --fx-y: -55px;
   --fx-band: calc(var(--fold) - var(--fx-y));
   --fx-fade: 0;
 
@@ -2012,7 +2012,7 @@ body::after {
      but sizes near a whole fraction of 512 resample most cleanly. */
   --fx-paper-src: image-set(url("img/tex/paper-512.webp?v=3311dec2") 1x,
                             url("img/tex/paper-1024.webp?v=3311dec2") 2x);
-  --fx-paper-size: 320px;
+  --fx-paper-size: 384px;
   --fx-paper-strength: 0.22;
   --fx-paper-blend: multiply;
   --fx-paper-invert: 0;
@@ -2055,13 +2055,17 @@ body::after {
          C * (B - 1) = +1   puts the field on white
          C * (B - 1) = -1   puts the field on black
 
-     which is why the shipped numbers are (1.5, 2) on light and (0.75, 4) on
-     dark. Both satisfy it, and both have the same detail gain B*C = 3, so the
-     two themes carry the same amount of texture rather than merely both having
-     some. Move B and C together along that relation to change how hard the
-     detail bites; break the relation deliberately and the flat field starts
-     tinting the page, which is a legitimate thing to want and is how you get
-     stock that is not quite white.
+     which is why the numbers are (1.5, 2) on light and (0.75, 4) on dark. Both
+     satisfy it, and both have the same detail gain B*C = 3, so the two themes
+     carry the same amount of texture rather than merely both having some. Move
+     B and C together along that relation to change how hard the detail bites;
+     break the relation deliberately and the flat field starts tinting the page,
+     which is a legitimate thing to want and is how you get stock that is not
+     quite white.
+
+     The film still sits on it in both themes. The paper does on light and no
+     longer does on dark, which is that deliberate break — see the dark block
+     below.
 
      --fx-*-strength is then the honest amount control on top: it fades the
      detail toward the paper without moving the field off its endpoint. */
@@ -2105,27 +2109,27 @@ body::after {
 
      Shipped at the type's old values with the blur off, so this separation
      changed no pixel by itself. */
-  --fx-chroma-pic-x: 0.6px;
-  --fx-chroma-pic-y: 0px;
+  --fx-chroma-pic-x: 2.6px;
+  --fx-chroma-pic-y: 2.6px;
   --fx-chroma-pic-blur: 0px;
 
   /* ---- everything below here is off unless its token is in data-fx --------- */
 
-  --fx-grain-opacity: 0.055;    /* animated grain, over the static film        */
-  --fx-grain-size: 180px;       /* the noise tile, drawn small                 */
-  --fx-grain-fps: 12;
+  --fx-grain-opacity: 0.09;     /* animated grain, over the static film        */
+  --fx-grain-size: 600px;       /* the noise tile, drawn small                 */
+  --fx-grain-fps: 2;
 
-  --fx-halftone-pitch: 3.4px;   /* dot to dot                                  */
-  --fx-halftone-dot: 0.34;      /* the dot's radius as a share of the pitch    */
-  --fx-halftone-angle: 45deg;   /* the screen angle a printer would use        */
-  --fx-halftone-opacity: 0.5;
-  --fx-halftone-blend: overlay;
+  --fx-halftone-pitch: 3.9px;   /* dot to dot                                  */
+  --fx-halftone-dot: 0.2;       /* the dot's radius as a share of the pitch    */
+  --fx-halftone-angle: 11deg;   /* the screen angle a printer would use        */
+  --fx-halftone-opacity: 1;
+  --fx-halftone-blend: multiply;
 
   --fx-vignette-start: 55%;     /* where the corner darkening begins           */
   --fx-vignette-strength: 0.3;
 
-  --fx-halation-radius: 6px;    /* the glow around type and pictures           */
-  --fx-halation-alpha: 0.22;
+  --fx-halation-radius: 16.5px; /* the glow around type and pictures           */
+  --fx-halation-alpha: 0.9;
 
   --fx-scan-pitch: 3px;         /* CRT: scanline to scanline                   */
   --fx-scan-alpha: 0.28;
@@ -2138,13 +2142,13 @@ body::after {
   --fx-roll-alpha: 0.05;
   --fx-roll-period: 7s;
 
-  --fx-ascii-cell: 9px;         /* the character cell, in CSS pixels           */
-  --fx-ascii-contrast: 1.25;
-  --fx-ascii-opacity: 0.4;
+  --fx-ascii-cell: 7.5px;       /* the character cell, in CSS pixels           */
+  --fx-ascii-contrast: 0.8;
+  --fx-ascii-opacity: 0.18;
   --fx-ascii-invert: 0;
 
-  --fx-weave-amount: 3px;       /* gate weave: how far the film wanders        */
-  --fx-weave-period: 0.9s;
+  --fx-weave-amount: 15px;      /* gate weave: how far the film wanders        */
+  --fx-weave-period: 3.25s;
 }
 
 /* The stack itself. Absolute in body's coordinates, as the corner pictures are,
@@ -2298,10 +2302,10 @@ body::after {
   opacity: var(--fx-paper-strength);
 }
 
-/* The other end of the relation. Declared here rather than in the palette block
-   at the top of the sheet for the same reason the whole stack is in one place —
-   and this is the third thing in the file that is stated twice per theme, after
-   --plate-opacity and the baked grade itself. */
+/* The other end of the relation — for the film. Declared here rather than in the
+   palette block at the top of the sheet for the same reason the whole stack is
+   in one place — and this is the third thing in the file that is stated twice
+   per theme, after --plate-opacity and the baked grade itself. */
 :root[data-theme="dark"] {
   --fx-film-invert: 0;
   --fx-film-lift: 0.75;
@@ -2309,10 +2313,15 @@ body::after {
   --fx-film-blend: screen;
   --fx-film-strength: 0.18;
 
-  --fx-paper-lift: 0.75;
-  --fx-paper-contrast: 4;
-  --fx-paper-blend: screen;
-  --fx-paper-strength: 0.4;
+  /* The paper leaves the relation on this side, deliberately. `normal` rather
+     than `screen` composites the flat field instead of clipping it, so there is
+     no endpoint to solve C*(B-1) for and the two numbers are free: 8 is a
+     harder bite on the fibre than the relation would have allowed, and 0.06 is
+     what keeps the field it drags along with it from washing the black out. */
+  --fx-paper-lift: 0.8;
+  --fx-paper-contrast: 8;
+  --fx-paper-blend: normal;
+  --fx-paper-strength: 0.06;
 }
 
 /* ---- the film, on a small screen ------------------------------------------


### PR DESCRIPTION
The levels the tuner settled on. The stack goes from `film paper chroma
chroma-pictures` to `halftone paper chroma-pictures`: the film plate and the
type's chroma split come off, and the halftone screen goes on, kept off the type
and off the carousel by data-fx-no-text and data-fx-no-gallery — the first
change to use the attributes that #46 added.

The film's own numbers stay where they are, as the defaults its token still
reaches for when the tuner turns it back on. Same for the grain, ascii, halation
and weave levels moved here: all four are off in the stack and this is retuning
what they open at.

The one that is more than a number is the paper on dark. It leaves the levels
relation the sheet documents — `normal` rather than `screen` composites the flat
field instead of clipping it, so C*(B-1) has no endpoint to solve for and
(0.8, 8) is free to bite harder than the relation allows, at a strength that
keeps the field it drags with it off the black. The prose claimed both textures
sat on the relation in both themes; it now says which one does not.
