### PR TITLE
Stop the effect stack moving the cut title out of its corner

### DIFF
--- a/portfolio/styles.css
+++ b/portfolio/styles.css
@@ -1691,6 +1691,23 @@ body::after {
      > > span    .visually-hidden, and the only text in here. */
 .cut-title {
   container-type: inline-size;
+  /* POSITIONED HERE, WITH NO OFFSETS, AND ONLY SO THAT NOTHING ELSE HAS TO
+     POSITION IT. `relative` with all four insets auto lays this out exactly
+     where `static` would; what it buys is that the element already takes a
+     z-index, so the effect stack's exclusion lift can give it one without
+     writing `position` of its own. That matters because .cut-title is the one
+     lifted block that IS positioned in a regime — `absolute`, pinned to the
+     fold, in the one-screen block at the end of this sheet — and the lift's
+     selector outweighs that rule three classes to one. It once wrote
+     `position: relative` for all four blocks together and won: the word came
+     out of its corner, took `top: 100vh` as a RELATIVE offset (a screen down
+     the page, on top of where the flow had already put it), took its width
+     from the flow instead of from the two insets — 1382px of picture where 316
+     was wanted — and, being back in .page's flow, added its height to the
+     document and broke the two-screen snap.
+     The one-screen rule stays authoritative because it is later in the sheet at
+     equal specificity; see the note above that media query. */
+  position: relative;
   width: 100%;
   max-width: var(--col);                 /* sized and centred exactly like .col */
   margin: var(--cue-gap) auto 0;
@@ -2291,14 +2308,24 @@ body::after {
    their declaration simply not being written, a few rules below, and need no
    lift — and `z-index: auto` leaves these in tree order under the whole stack,
    which is where they started. An invalid value here would instead make the
-   whole declaration unset and take `position: relative` with it. */
+   whole declaration unset and take `position: relative` with it.
+
+   THE LIFT NEVER WRITES `position` ON .cut-title, and that is why it is on the
+   second selector rather than the first. Three of these four are static and
+   need positioning before a z-index means anything; the fourth is `absolute` in
+   the one-screen regime, and this selector — two attributes and a class against
+   that rule's bare class — outweighs it. Writing `relative` here therefore did
+   not add a stacking context to the cut title, it MOVED it: out of the corner,
+   with `top: 100vh` re-read as a relative offset and the width taken from the
+   flow rather than from the two insets. So .cut-title positions itself instead,
+   in its own block above, and all this has left to do is the number. */
 :root[data-fx-no-text] .masthead,
 :root[data-fx-no-text] .intro,
-:root[data-fx-no-text] .listing,
-:root[data-fx-no-text] .cut-title {
+:root[data-fx-no-text] .listing {
   position: relative;
   z-index: var(--fx-text-z);
 }
+:root[data-fx-no-text] .cut-title { z-index: var(--fx-text-z); }
 :root[data-fx-no-gallery] .carousel,
 :root[data-fx-no-gallery] .cbar {
   position: relative;


### PR DESCRIPTION
The exclusion lift wrote `position: relative` on all four text blocks
together, and .cut-title is the one of the four that is already positioned:
`absolute`, pinned to the fold, in the one-screen block at the end of the
sheet. Two attributes and a class beat that rule's bare class, so the lift
won, and with `data-fx-no-text="halftone"` shipped in the markup it won on
the page as it is served.

What that did, at 1440x1000: the word left the corner and took `top: 100vh`
as a RELATIVE offset — a screen below where the flow had already put it —
took its width from the flow instead of from the two insets, so 1382px of
picture was drawn where 316.5 was wanted, and, being back in .page's flow,
added its own height to the document and took it from 1875 to 2080, which
is the two-screen snap gone as well.

.cut-title now positions itself, `relative` with no offsets, which lays it
out exactly where `static` did and leaves it able to take a z-index; the
lift keeps `position` for the three blocks that are genuinely static and
gives the cut title only the number. The one-screen rule is authoritative
again because it is later in the sheet at equal specificity.

Measured against d6000fa, the commit before the effect stack landed: with
the fix the title's box is [90, 1000, 316.5], its picture [90, 968.45,
316.5, 67.23] and the document 1875 tall, on all three of shipped, lift-off
and no-effects-at-all — identical to the pre-effects page, and at the
capture's 592px identical again with both gutters at 80. The lift still
works: the title keeps z-index 5 over the halftone's 4, and the glyph is
what hit-tests at the word.
