### PR TITLE
Start the page turn from rest, and let the word turn with it

### DIFF
--- a/design/cut-title/morph/specimen.html
+++ b/design/cut-title/morph/specimen.html
@@ -247,7 +247,7 @@ function tween(c,t){
   }
   return s;
 }
-const ease=t=>t<=0?0:t>=1?1:(t<.5?4*t*t*t:1-Math.pow(-2*t+2,3)/2);
+const ease=t=>t<=0?0:t>=1?1:t*t*(3-2*t);   /* smoothstep — same curve portfolio/cut-morph.js uses */
 
 /* a rig is one svg: eight letters, each with its own clock */
 function rig(svg,face){

--- a/design/cut-title/morph/specimen.tpl.html
+++ b/design/cut-title/morph/specimen.tpl.html
@@ -247,7 +247,7 @@ function tween(c,t){
   }
   return s;
 }
-const ease=t=>t<=0?0:t>=1?1:(t<.5?4*t*t*t:1-Math.pow(-2*t+2,3)/2);
+const ease=t=>t<=0?0:t>=1?1:t*t*(3-2*t);   /* smoothstep — same curve portfolio/cut-morph.js uses */
 
 /* a rig is one svg: eight letters, each with its own clock */
 function rig(svg,face){

--- a/portfolio/app.js
+++ b/portfolio/app.js
@@ -396,26 +396,62 @@
     // owns the turn again for the keyboard and for touch, which never came here.
     // This lives inside the carousel's block because it shares its reading of who
     // owns the gesture — the roll is the one thing that takes the wheel first.
+    //
+    // THE CURVE. The turn is one cubic Hermite in scroll position: it leaves
+    // where the page IS, at the speed the page is ALREADY MOVING, and arrives at
+    // the port with its speed back at zero. From a standstill the velocity term
+    // drops out and what is left is smoothstep, 3s² - 2s³ — so the sheet begins
+    // to move rather than being thrown. What this replaced was an ease-out cubic,
+    // which is fastest at its very first frame: right for something with a finger
+    // still on it, wrong for a page turn taken from rest by one notch of a wheel.
+    // Peak speed falls from three times the average to one and a half, and it now
+    // falls in the MIDDLE of the turn instead of at the edge.
+    //
+    // The word inherits all of that for nothing. cut-morph.js drives the morph
+    // off the scroll fraction this writes, so the hard start was the word's hard
+    // start too — eight letters given their whole stagger in the first few frames
+    // and then most of the turn to finish in. On a curve that is slowest at both
+    // ends the letters turn with the paper.
+    //
+    // The velocity term is what makes a reversal continuous. Restarting the old
+    // tween from the current position left the page travelling one way at full
+    // speed and the next frame travelling the other way at full speed, and there
+    // is no such thing in paper. Carried in, the sheet slows, stops, and comes
+    // back — and the word unwinds with it, because it is reading the same number.
     var doorway = document.querySelector(".doorway");
-    var TURN = 420;                                     // ms for a page turn
-    var turnRaf = null, turnTarget = null;
+    var TURN = 640;                                     // ms for a whole page turn
+    var turnRaf = null, turnTarget = null, turnV = 0;   // turnV in px/ms, signed
     function inDoorway() {                              // the two-port regime, per CSS
       return doorway && window.getComputedStyle(doorway).display !== "none";
     }
     function pageMax() { return document.documentElement.scrollHeight - window.innerHeight; }
     function turnPage(target) {
       var root = document.documentElement;
+      var start = window.scrollY, dist = target - start;
+      var v0 = turnRaf === null ? 0 : turnV;            // the speed already on the page
       if (turnRaf) cancelAnimationFrame(turnRaf);
       turnTarget = target;
-      function land() { turnRaf = null; turnTarget = null; root.style.scrollSnapType = ""; }
-      if (reduce) { window.scrollTo(0, target); land(); return; }
-      var start = window.scrollY, dist = target - start, t0 = null;
+      function land() { turnRaf = null; turnTarget = null; turnV = 0; root.style.scrollSnapType = ""; }
+      if (reduce || !dist) { window.scrollTo(0, target); land(); return; }
+      // TURN is written for the whole document; anything shorter takes the same
+      // top speed rather than the same time, which is the square root of the
+      // fraction. Floored so a reversal caught near its own port still has room
+      // to absorb the speed it came in with instead of being flung past it.
+      var full = Math.max(1, pageMax());
+      var dur = TURN * Math.max(0.45, Math.sqrt(Math.min(1, Math.abs(dist) / full)));
+      var t0 = null;
       root.style.scrollSnapType = "none";
       turnRaf = requestAnimationFrame(function frame(ts) {
         if (t0 === null) t0 = ts;
-        var p = Math.min(1, (ts - t0) / TURN);
-        window.scrollTo(0, start + dist * (1 - Math.pow(1 - p, 3)));   // ease-out cubic
-        if (p < 1) turnRaf = requestAnimationFrame(frame); else land();
+        var s = Math.min(1, (ts - t0) / dur);
+        // Hermite with the far end pinned at rest: s²(3 - 2s) carries the
+        // distance, s(s - 1)² carries the speed in and is zero at both ends. The
+        // second line is the same pair differentiated — the speed this turn would
+        // hand on to one that interrupts it.
+        var y = start + dist * (s * s * (3 - 2 * s)) + v0 * dur * (s * (s - 1) * (s - 1));
+        turnV = (dist * 6 * s * (1 - s) + v0 * dur * (3 * s - 1) * (s - 1)) / dur;
+        window.scrollTo(0, s < 1 ? y : target);
+        if (s < 1) turnRaf = requestAnimationFrame(frame); else land();
       });
     }
     document.addEventListener("wheel", function (e) {

--- a/portfolio/cut-morph.js
+++ b/portfolio/cut-morph.js
@@ -112,15 +112,28 @@
   }
 
   /* Quantised to 240 steps, which is finer than the eye can follow at this size
-     and stops a one-pixel scroll from rebuilding eight path strings. */
+     and stops a one-pixel scroll from rebuilding eight path strings.
+
+     Each letter's own share of the scroll is eased with SMOOTHSTEP, s²(3 - 2s),
+     and the choice of curve matters more here than it looks. Two easings are
+     multiplied together on the way to a shape: the page turn in app.js shapes T
+     against time, and this shapes the letter against T. Peak rates multiply with
+     them — so the ease-in-out cubic that used to be on this line, twice as fast
+     at its middle as its average, met a turn three times as fast at its start and
+     the letters caught by both whipped through their transition at six times
+     their own rate. Smoothstep is the gentlest curve that still leaves and
+     arrives at rest, which is all this end needs: the turn is where the drama
+     belongs, and the letter only has to not start and stop with a jolt. The two
+     together now peak at 2.25×, where they used to reach 6×.
+
+     Both ends still land exactly on 0 and 1, so at either resting place every
+     letter is the real Bézier outline of a real typeface and not a polygon. */
   function draw(T) {
     var span = 1 - STAGGER * (WORD.length - 1), i, L, t, q;
     for (i = 0; i < letters.length; i++) {
       L = letters[i];
       t = (T - i * STAGGER) / span;
-      t = t <= 0 ? 0 : t >= 1 ? 1 : t < 0.5
-        ? 4 * t * t * t
-        : 1 - Math.pow(-2 * t + 2, 3) / 2;
+      t = t <= 0 ? 0 : t >= 1 ? 1 : t * t * (3 - 2 * t);
       q = Math.round(t * 240);
       if (q === L.last) continue;
       L.last = q;

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -385,7 +385,7 @@
   </svg>
   <noscript><p style="text-align:center;font-family:'Sitka Text',Charter,'Iowan Old Style',Georgia,serif;padding:2rem">This site needs JavaScript enabled.</p></noscript>
   <script src="content.js?v=3"></script>
-  <script src="app.js?v=20"></script>
+  <script src="app.js?v=21"></script>
   <!-- Last, and after app.js rather than beside it: the effect stack is a
        treatment of a finished page, and drawAscii() measures the corner pictures
        against a layout that has to exist first. It is also the one script here
@@ -398,6 +398,6 @@
        only ever replaces one <svg>'s contents, so a browser that skips it —
        blocked, errored, or asking for reduced motion — keeps the baked Friz
        path exactly as it is inline. -->
-  <script src="cut-morph.js?v=1"></script>
+  <script src="cut-morph.js?v=2"></script>
 </body>
 </html>


### PR DESCRIPTION
The turn was an ease-out cubic over 420ms: fastest at its very first
frame, at 6250 px/s on a 1440x1000 window. That is the right curve for
something with a finger still on it and the wrong one for a page taken
from rest by one notch of a wheel — the sheet was thrown rather than
turned. It is now one cubic Hermite, which from a standstill is
smoothstep: peak 2051 px/s, one and a half times the average instead of
three, and in the MIDDLE of the turn rather than at its edge.

The word inherits all of that for nothing, because cut-morph.js drives
the morph off the scroll fraction the turn writes. The hard start was
the word's hard start too: eight letters given their whole stagger in
the first few frames and then most of the turn to finish in.

The Hermite's other term is the speed the page is already carrying, and
it is what makes a reversal mid-turn continuous. Restarting the old
tween from the current position left the page travelling one way at full
speed and the next frame travelling the other way at full speed, which
does not happen to paper. Carried in, the sheet slows, stops and comes
back — verified: entry speed matches to the last decimal, the turn
overshoots neither port, and it lands exactly on the far one at zero.

Duration is now the square root of the fraction of the document being
crossed, so a short correction takes the same top speed rather than the
same time, floored at 0.45 so a late reversal still has room to absorb
the speed it came in with.

Two easings multiply on the way to a letter's shape — the turn against
time, then the letter against the turn — so the cut title's own
ease-in-out cubic is now smoothstep as well. It is the gentlest curve
that still leaves and arrives at rest, which is all this end needs now
that the drama is in the turn. The two together peak at 2.25x where they
used to reach 6x. Both ends still land on 0 and 1 exactly, so at either
resting place every letter is a real Bezier outline and not a polygon.

The specimen in design/cut-title/morph/ takes the same curve, so what a
face is chosen against is what ships.
