### PR TITLE
Take the force off the ends of the page turn

### DIFF
--- a/portfolio/app.js
+++ b/portfolio/app.js
@@ -397,30 +397,59 @@
     // This lives inside the carousel's block because it shares its reading of who
     // owns the gesture — the roll is the one thing that takes the wheel first.
     //
-    // THE CURVE. The turn is one cubic Hermite in scroll position: it leaves
-    // where the page IS, at the speed the page is ALREADY MOVING, and arrives at
-    // the port with its speed back at zero. From a standstill the velocity term
-    // drops out and what is left is smoothstep, 3s² - 2s³ — so the sheet begins
-    // to move rather than being thrown. What this replaced was an ease-out cubic,
-    // which is fastest at its very first frame: right for something with a finger
-    // still on it, wrong for a page turn taken from rest by one notch of a wheel.
-    // Peak speed falls from three times the average to one and a half, and it now
-    // falls in the MIDDLE of the turn instead of at the edge.
+    // THE CURVE. The turn is one QUINTIC Hermite in scroll position: it leaves
+    // where the page IS, at the speed the page is ALREADY MOVING and under the
+    // acceleration already ON it, and arrives at the port with both back at zero.
+    // From a standstill the two carried terms drop out and what is left is
+    // smootherstep, 10s³ - 15s⁴ + 6s⁵.
     //
-    // The word inherits all of that for nothing. cut-morph.js drives the morph
-    // off the scroll fraction this writes, so the hard start was the word's hard
-    // start too — eight letters given their whole stagger in the first few frames
-    // and then most of the turn to finish in. On a curve that is slowest at both
-    // ends the letters turn with the paper.
+    // What it replaced was the cubic, which from rest is smoothstep. Smoothstep
+    // leaves and arrives at rest, but its ACCELERATION steps from nothing to full
+    // in one frame at each end and holds a straight ramp in between — the page was
+    // put under a constant force, carried across at a nearly steady 1.5× the
+    // average, and had the force taken off it just as abruptly. That is a motor,
+    // not a sheet of paper, and it is what read as linear. A curve is only as
+    // smooth as its roughest derivative, and the cubic's second one is a step at
+    // both ends. The quintic has three boundary conditions per end instead of two,
+    // so acceleration starts and finishes at zero as well: the force swells into
+    // the paper and ebbs out of it, nothing is ever switched on, and the middle is
+    // a genuine peak at 1.875× rather than a plateau.
     //
-    // The velocity term is what makes a reversal continuous. Restarting the old
-    // tween from the current position left the page travelling one way at full
+    // NOTHING MOVES FASTER FOR IT. TURN went 640 → 800 ms in the same breath,
+    // because 1.875 / 1.5 is exactly 800 / 640: peak speed on a 1440×1000 window
+    // is 2051 px/s either way, to the pixel. The whole of the extra 160 ms is
+    // spent in the leaving and the arriving — the stretch of the turn that
+    // actually carries the distance is 405 ms where it was 389. The turn is not
+    // slower; its ends are quieter.
+    //
+    // The word inherits all of that for nothing. cut-morph.js drives the morph off
+    // the scroll fraction this writes, so this is also the first of the two
+    // easings that reach a letter's shape, and stretching the turn by the same
+    // factor the peak rose by leaves the second one exactly where it was: every
+    // one of the eight letters peaks within 1% of the rate it peaked at before,
+    // fractionally under it. See the note on SMOOTHSTEP in cut-morph.js.
+    //
+    // The two carried terms are what make a reversal continuous. Restarting the
+    // old tween from the current position left the page travelling one way at full
     // speed and the next frame travelling the other way at full speed, and there
-    // is no such thing in paper. Carried in, the sheet slows, stops, and comes
-    // back — and the word unwinds with it, because it is reading the same number.
+    // is no such thing in paper. The speed went in first; the acceleration is the
+    // same argument one derivative up, and it is the one that matters at exactly
+    // the moment a reversal happens, because that is when the force is largest.
+    // Carried in, the sheet slows, stops, and comes back — and the word unwinds
+    // with it, because it is reading the same number.
+    //
+    // Both carried terms are zero at BOTH ends of their basis, so whatever a turn
+    // is handed, it still lands on the far port at a standstill. Swept at every
+    // hundredth of a reversal it leaves the two ports untouched; swept again for a
+    // reversal of a reversal — the one case where a turn is asked to change its
+    // mind while a large force is on it — the page can be carried 26 px past a
+    // port and clamped there by the browser for 109 ms, against the cubic's 13 px
+    // and 247 ms. Further past, and a third of the time.
     var doorway = document.querySelector(".doorway");
-    var TURN = 640;                                     // ms for a whole page turn
-    var turnRaf = null, turnTarget = null, turnV = 0;   // turnV in px/ms, signed
+    var TURN = 800;                                     // ms for a whole page turn
+    // turnV in px/ms and turnA in px/ms², both signed: the speed and the force
+    // this turn is carrying, read by the next one if it interrupts.
+    var turnRaf = null, turnTarget = null, turnV = 0, turnA = 0;
     function inDoorway() {                              // the two-port regime, per CSS
       return doorway && window.getComputedStyle(doorway).display !== "none";
     }
@@ -429,9 +458,13 @@
       var root = document.documentElement;
       var start = window.scrollY, dist = target - start;
       var v0 = turnRaf === null ? 0 : turnV;            // the speed already on the page
+      var a0 = turnRaf === null ? 0 : turnA;            // and the force already on it
       if (turnRaf) cancelAnimationFrame(turnRaf);
       turnTarget = target;
-      function land() { turnRaf = null; turnTarget = null; turnV = 0; root.style.scrollSnapType = ""; }
+      function land() {
+        turnRaf = null; turnTarget = null; turnV = 0; turnA = 0;
+        root.style.scrollSnapType = "";
+      }
       if (reduce || !dist) { window.scrollTo(0, target); land(); return; }
       // TURN is written for the whole document; anything shorter takes the same
       // top speed rather than the same time, which is the square root of the
@@ -441,15 +474,29 @@
       var dur = TURN * Math.max(0.45, Math.sqrt(Math.min(1, Math.abs(dist) / full)));
       var t0 = null;
       root.style.scrollSnapType = "none";
+      // the carried speed and force expressed per unit of s, which is what the
+      // basis below is written in
+      var m0 = v0 * dur, c0 = a0 * dur * dur;
       turnRaf = requestAnimationFrame(function frame(ts) {
         if (t0 === null) t0 = ts;
-        var s = Math.min(1, (ts - t0) / dur);
-        // Hermite with the far end pinned at rest: s²(3 - 2s) carries the
-        // distance, s(s - 1)² carries the speed in and is zero at both ends. The
-        // second line is the same pair differentiated — the speed this turn would
-        // hand on to one that interrupts it.
-        var y = start + dist * (s * s * (3 - 2 * s)) + v0 * dur * (s * (s - 1) * (s - 1));
-        turnV = (dist * 6 * s * (1 - s) + v0 * dur * (3 * s - 1) * (s - 1)) / dur;
+        var s = Math.min(1, (ts - t0) / dur), u = 1 - s;
+        // Three terms, one per thing the turn has to honour. s³(10 - 15s + 6s²)
+        // carries the DISTANCE and is smootherstep. s(1 - s)³(3s + 1) carries the
+        // SPEED in, ½s²(1 - s)³ the FORCE; both are zero at s = 0 and s = 1 in
+        // value, slope and curvature, so neither can move where the turn lands or
+        // disturb the standstill it lands at.
+        var y = start
+              + dist * (s * s * s * (10 - 15 * s + 6 * s * s))
+              + m0 * (s * u * u * u * (3 * s + 1))
+              + c0 * (0.5 * s * s * u * u * u);
+        // the same three differentiated once and twice: what this turn hands on to
+        // one that interrupts it
+        turnV = (dist * 30 * s * s * u * u
+               + m0 * (1 + s * s * (-18 + s * (32 - 15 * s)))
+               + c0 * (s * (1 + s * (-4.5 + s * (6 - 2.5 * s))))) / dur;
+        turnA = (dist * 60 * s * (1 + s * (-3 + 2 * s))
+               + m0 * (s * (-36 + s * (96 - 60 * s)))
+               + c0 * (1 + s * (-9 + s * (18 - 10 * s)))) / (dur * dur);
         window.scrollTo(0, s < 1 ? y : target);
         if (s < 1) turnRaf = requestAnimationFrame(frame); else land();
       });

--- a/portfolio/cut-morph.js
+++ b/portfolio/cut-morph.js
@@ -123,8 +123,17 @@
      the letters caught by both whipped through their transition at six times
      their own rate. Smoothstep is the gentlest curve that still leaves and
      arrives at rest, which is all this end needs: the turn is where the drama
-     belongs, and the letter only has to not start and stop with a jolt. The two
-     together now peak at 2.25×, where they used to reach 6×.
+     belongs, and the letter only has to not start and stop with a jolt.
+
+     THE TURN HAS SINCE GONE UP AN ORDER, from a cubic to a quintic, and this line
+     did not have to move with it. The quintic peaks at 1.875× where the cubic
+     peaked at 1.5×, so the product of the two ratios went 2.25× to 2.8125× — but
+     a ratio is against an average, and the turn was lengthened by the same 1.25
+     in the same commit precisely so the average would fall by it. What a letter
+     is actually drawn at is the product against the CLOCK, and swept frame by
+     frame all eight peak within 1% of where they peaked before, every one of them
+     fractionally under. So the drama stayed in the paper: the page's ends got
+     quieter and the letters kept their rate.
 
      Both ends still land exactly on 0 and 1, so at either resting place every
      letter is the real Bézier outline of a real typeface and not a polygon. */

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -385,7 +385,7 @@
   </svg>
   <noscript><p style="text-align:center;font-family:'Sitka Text',Charter,'Iowan Old Style',Georgia,serif;padding:2rem">This site needs JavaScript enabled.</p></noscript>
   <script src="content.js?v=3"></script>
-  <script src="app.js?v=21"></script>
+  <script src="app.js?v=22"></script>
   <!-- Last, and after app.js rather than beside it: the effect stack is a
        treatment of a finished page, and drawAscii() measures the corner pictures
        against a layout that has to exist first. It is also the one script here
@@ -398,6 +398,6 @@
        only ever replaces one <svg>'s contents, so a browser that skips it —
        blocked, errored, or asking for reduced motion — keeps the baked Friz
        path exactly as it is inline. -->
-  <script src="cut-morph.js?v=2"></script>
+  <script src="cut-morph.js?v=3"></script>
 </body>
 </html>


### PR DESCRIPTION
The turn was a cubic Hermite, which from rest is smoothstep. It leaves and
arrives at rest, but its acceleration steps from nothing to full in one frame at
each end and holds a straight ramp between them: the page was put under a
constant force, carried across at a nearly steady 1.5× the average, and had the
force taken off it just as abruptly. That is a motor rather than a sheet of
paper, and it is what read as linear. A curve is only as smooth as its roughest
derivative, and the cubic's second one is a step at both ends.

It is now a quintic Hermite — three boundary conditions per end instead of two,
so acceleration starts and finishes at zero as well. Nothing is ever switched on.
The force swells into the paper and ebbs out of it, and the middle is a real peak
at 1.875× rather than a plateau.

Nothing moves faster for it. TURN went 640 to 800 ms in the same change, because
1.875 / 1.5 is exactly 800 / 640: peak speed on a 1440×1000 window is 2050.8 px/s
either way, measured off both sets of expressions. The stretch of the turn that
actually carries the distance is 405 ms where it was 389. The whole of the extra
160 ms is spent in the leaving and the arriving.

The word kept its rate too. cut-morph.js drives the morph off the scroll fraction
the turn writes, so this is the first of the two easings that reach a letter's
shape, and stretching the turn by the same factor the peak rose by leaves the
second one exactly where it was. Swept frame by frame, all eight letters peak
within 1% of where they peaked before, every one of them fractionally under. So
the letter easing stays smoothstep and the specimen needs no re-cut.

The quintic carries the incoming acceleration as well as the incoming speed,
which is the reversal argument one derivative up — and it is the derivative that
matters at exactly the moment of a reversal, because that is when the force is
largest. Both carried terms are zero in value, slope and curvature at both ends
of their basis, so whatever a turn is handed, it still lands on the far port at a
standstill.

Verified against the shipped expressions: y, v and a are 0 at s = 0 and 875, 0, 0
at s = 1, exactly; the handover to an interrupting turn matches position, speed
and force to the last bit at all 99 reversal points; no reversal leaves either
port. A reversal of a reversal — a turn asked to change its mind with a large
force on it — can be carried 26 px past a port and clamped there by the browser
for 109 ms, against the cubic's 13 px and 247 ms. Further past, and a third of
the time.
