### PR TITLE
Say who else depends on an empty ?fx=

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,11 @@ statically from Vercel.
   redraws the three corner photographs as a field of characters. Each is a token
   in `<html data-fx="…">` and each is off unless its token is there; three ship
   on. Add `?fx=film paper` to the URL to see any combination, or `?fx=` for the
-  page underneath. Almost all of it is CSS — the layers are composited quads, and
-  the only things that animate are off by default. The textures are baked by
+  page underneath — which is also how my GitHub profile README screenshots this
+  page, since a texture meant to be felt at full size only reads as noise once
+  it has been resampled into a README. Almost all of it is CSS — the layers are
+  composited quads, and the only things that animate are off by default. The
+  textures are baked by
   `design/effects/build-textures.py` and tuned in `design/effects/effects-tuner.html`.
   The trick that makes one asset serve both themes is in **THE LEVELS STAGE** in
   `portfolio/styles.css`.

--- a/portfolio/effects.js
+++ b/portfolio/effects.js
@@ -111,7 +111,18 @@
      `?fx=` with an empty value is meaningful and is not the same as no `?fx=` at
      all — it is "none of them", and it is the way to see the page underneath
      without clearing anything. Hence the `has` test rather than a truthiness
-     one. */
+     one.
+
+     THAT EMPTY VALUE IS SOMEBODY ELSE'S API. chrisJuresh/chrisJuresh — the
+     GitHub profile repo — screenshots this page with `?fx=` on the URL to get
+     the untreated version for its README, because the textures are meant to be
+     felt at full size and the README shows them resampled to a fraction of the
+     captured width. So the meaning of an empty `?fx=` is not ours alone to
+     change: renaming the parameter, or making an empty value mean "no
+     preference" and fall through to the default, would put the stack back into
+     that preview. Its capture script reads `data-fx` back after load and throws
+     if anything is still on, so a change here fails there loudly rather than
+     shipping a textured preview — but it fails in a repo nobody is looking at. */
   function initial() {
     try {
       var q = new URLSearchParams(location.search);


### PR DESCRIPTION
The GitHub profile README is a screenshot of this page taken with `?fx=`,
so that the preview shows the page underneath rather than textures that only
survive being seen at full size. Nothing here said so, which made the
meaning of an empty `?fx=` look like ours alone to change.

Comments and README only — no behaviour moves.
