### PR TITLE
Say who else depends on an empty ?fx=

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,11 @@ statically from Vercel.
   redraws the three corner photographs as a field of characters. Each is a token
   in `<html data-fx="…">` and each is off unless its token is there; three ship
   on. Add `?fx=film paper` to the URL to see any combination, or `?fx=` for the
-  page underneath. Almost all of it is CSS — the layers are composited quads, and
-  the only things that animate are off by default. The textures are baked by
+  page underneath — which is also how my GitHub profile README screenshots this
+  page, since a texture meant to be felt at full size only reads as noise once
+  it has been resampled into a README. Almost all of it is CSS — the layers are
+  composited quads, and the only things that animate are off by default. The
+  textures are baked by
   `design/effects/build-textures.py` and tuned in `design/effects/effects-tuner.html`.
   The trick that makes one asset serve both themes is in **THE LEVELS STAGE** in
   `portfolio/styles.css`.

--- a/portfolio/effects.js
+++ b/portfolio/effects.js
@@ -111,7 +111,18 @@
      `?fx=` with an empty value is meaningful and is not the same as no `?fx=` at
      all — it is "none of them", and it is the way to see the page underneath
      without clearing anything. Hence the `has` test rather than a truthiness
-     one. */
+     one.
+
+     THAT EMPTY VALUE IS SOMEBODY ELSE'S API. chrisJuresh/chrisJuresh — the
+     GitHub profile repo — screenshots this page with `?fx=` on the URL to get
+     the untreated version for its README, because the textures are meant to be
+     felt at full size and the README shows them resampled to a fraction of the
+     captured width. So the meaning of an empty `?fx=` is not ours alone to
+     change: renaming the parameter, or making an empty value mean "no
+     preference" and fall through to the default, would put the stack back into
+     that preview. Its capture script reads `data-fx` back after load and throws
+     if anything is still on, so a change here fails there loudly rather than
+     shipping a textured preview — but it fails in a repo nobody is looking at. */
   function initial() {
     try {
       var q = new URLSearchParams(location.search);

--- a/portfolio/styles.css
+++ b/portfolio/styles.css
@@ -1982,8 +1982,30 @@ body::after {
 :root {
   /* Where the stack stops. --fx-y is the twin of --plate-y and moves the foot of
      every layer at once; --fx-fade is how far above that foot the dissolve
-     starts, as a share of the band. */
-  --fx-y: -55px;
+     starts, as a share of the band.
+
+     0, and it has to stay 0 while --plate-y is: the block above says the band
+     ends on the line the three corner pictures end on, and that is only true
+     while these two agree. #50 exported this at -55px along with the levels the
+     tuner had settled on, and the overhang it bought is the one thing on the
+     page whose FOOT is visible in one theme and not the other — which is what
+     made it look like a light-mode bug rather than a geometry one.
+
+     Both themes have always drawn the same box. What differs is whether the
+     flat field survives the layer's own levels: dark's paper is brightness 0.8
+     then contrast 8, which takes mid-grey to (0.4 - 0.5) * 8 + 0.5, i.e. past
+     black, and `normal` at 0.06 over a black page then composites nothing —
+     dark's halftone `multiply` is the same no-op — so on that side only the
+     photographs carry the treatment and it stops where they stop. Light's paper
+     is 1.5 then 1.25, which leaves the field at 0.81, and `multiply` prints it:
+     the whole band is washed 255 down to 246, the halftone finds tone to shade
+     now that the page is off pure white, and the foot of the box is a hard edge
+     across bare paper. Fifty-five pixels of it, below a fold the pictures had
+     already stopped at.
+
+     So this is not a number to retune. A tuner export that drags it again puts
+     the same edge back on light and nothing at all on dark. */
+  --fx-y: 0px;
   --fx-band: calc(var(--fold) - var(--fx-y));
   --fx-fade: 0;
 


### PR DESCRIPTION
Promotes development. The GitHub profile README now screenshots this page with `?fx=`, so the preview shows the page underneath instead of textures that only read as noise once resampled into a README; the capture change is in chrisJuresh/chrisJuresh#1. This side is comments and README only — it records that an empty `?fx=` is now somebody else's API.