### PR TITLE
Assemble the roll the censor review runs on (#63)

### DIFF
--- a/design/censor/README.md
+++ b/design/censor/README.md
@@ -1,0 +1,155 @@
+# design/censor — which photographs get obscured, and who decided
+
+Dev-only. Nothing here is served: `.vercelignore` excludes `design/` entirely.
+
+The Projects Panel plays a recording of the photo vault's grid ([#57]). The grid
+holds a real personal library, and the clip passes over 73 photographs of it,
+some of which contain identifiable members of the public. This folder is the
+record of which of those are obscured before a single frame is captured, and of
+who signed that decision.
+
+```
+design/censor/
+  roll.json          every photograph the clip passes over — mechanical
+  review.html        the review surface — one photograph at a time, at 1536px
+  review.mjs         serves it, proxies the vault, writes the confirmed list
+  censored.json      the confirmed list — written by review.mjs, signed
+../tools/
+  collect-roll.mjs   writes roll.json; lives there because Playwright does
+```
+
+## The procedure
+
+The grid must be answering on `127.0.0.1:8770` — normally it already is.
+
+**1. Collect the roll.**
+
+```bash
+node design/tools/collect-roll.mjs
+```
+
+Drives the real grid at the geometry the recording uses and writes `roll.json`:
+every photograph whose tile touches the band the camera ever sees. It reads
+boxes and thumbnail URLs and nothing else — it does not look at any photograph.
+
+**2. Review it.**
+
+```bash
+node design/censor/review.mjs
+```
+
+Then open the URL it prints. One photograph at a time at 1536px: `1` contains an
+identifiable person, `2` unsure, `0` does not. There is no skip — the list cannot
+be confirmed until all 73 have been classified — and `2` censors, so an
+ambiguous photograph is obscured with its ambiguity on the record rather than
+rounded to a clean answer. `reveal original` opens the file in Explorer for the
+ones 1536px cannot settle.
+
+Sign it, press **Confirm the list**, and `censored.json` is written.
+
+**3. Commit `roll.json` and `censored.json` together.** They are one artefact:
+`censored.json` carries the `roll_digest` it was signed against, and a decision
+list without the roll it decided about says nothing.
+
+## Why the decision is a person's
+
+Automated detection is rejected on measured grounds, not on principle. Intel's
+model card for `face-detection-adas-0001` reports average precision falling from
+94.1% at head heights over 100px to **37.4%** over 10px, against a stated
+operating floor of 90×90 on 1080p. The tiles here are 162×216 and a face inside
+one is a fraction of that, so a detector would be run squarely in the band where
+its own vendor reports it failing roughly two times in three.
+
+The same reasoning sets the review surface. A judgement made from the grid
+thumbnail would be a judgement made at the size the detector fails at, which is
+why `review.html` shows the vault's 1536px substrate — eight times the tile in
+each dimension — and offers the original file behind it.
+
+It is also why nothing downstream of this folder gets to soften the result.
+Published work on the reversibility of anonymisation shows light blur and fine
+pixelation are partially recoverable by super-resolution, so the mosaic [#65]
+applies has to be coarse enough that a tile resolves to a handful of blocks. If
+the mosaic is weakened, this list stops being a defence.
+
+## Why the roll can go stale, and how you find out
+
+`roll.json` is the grid's default view at one viewport, over one scroll range:
+
+| | | from |
+|---|---|---|
+| viewport | 1440×900 | `record/projects/photos/project.toml` |
+| scroll | 0 → 1200 | `record/projects/photos/actions/scroll-peek.overrides.toml` |
+| band | document y ∈ [0, 2100] | scroll range plus one viewport |
+
+The vault sorts newest-first, so importing a single photograph shifts the whole
+roll and the confirmed list silently stops covering the clip. Same if record's
+viewport or distance moves. Before recording:
+
+```bash
+node design/tools/collect-roll.mjs --check
+```
+
+It exits non-zero and says `DRIFTED` when the roll it finds is not the roll on
+disk, or when the geometry asked for is not the geometry the roll was assembled
+at. A drifted roll means collect and review again — there is no partial re-review,
+because the photographs a shifted roll brings in are exactly the ones nobody has
+looked at.
+
+## What the page targets
+
+The vault addresses thumbnails by content: a tile's image is `/t/<sha256>.webp`.
+So a photograph is targetable by the hash of its own bytes, which survives
+re-sorting, tile recycling and paging — none of which an index or an `nth-child`
+survives. Each entry in `censored.json` carries its selector ready to use:
+
+```
+img[src$="0d66290e….webp"]
+```
+
+`selector_list` is all the censored ones joined, which is the selector the
+capture-time stylesheet in [#65] hangs its mosaic on. That stylesheet is [#65]'s
+to write; this folder decides only which tiles it applies to.
+
+The selectors were checked against the live grid rather than assumed: across the
+clip's scroll range they match all 73 tiles in the roll, no tile in the band goes
+unmatched, and nothing outside the roll is hit.
+
+### Two things [#65] will hit applying them
+
+Both were found while checking the above, and both are cheap to design around
+and expensive to discover during a capture.
+
+**A `<style>` element is refused.** The vault serves
+`default-src 'none'; …; style-src 'self'`, so a stylesheet built the usual way —
+`createElement("style")`, set `textContent`, append — is blocked and its `sheet`
+comes back null. No exception is thrown; the page simply does not censor. #57
+describes injecting the censoring CSS through record's `.evaluate()` hatch, which
+is the right hatch, but not with that shape. Two routes do work, measured on the
+live page:
+
+```js
+// refused: sheet is null, nothing applies
+document.head.appendChild(Object.assign(document.createElement("style"), { textContent: css }))
+
+// works: a constructed stylesheet is not inline content
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(css);
+document.adoptedStyleSheets = [...document.adoptedStyleSheets, sheet];
+```
+
+The same CSP already no-ops record's own `stopSmoothScrolling`, which builds a
+`<style>` element the refused way. That is record's to fix, not this repo's, but
+it means smooth scrolling is not actually being suppressed on this Project.
+
+**Do not set the blur per element.** The obvious fallback — walk the matches and
+set `img.style.filter` — passes CSP and is wrong here. The grid's sheet is
+virtualised: it recycles a tile element by pointing it at a different
+photograph's URL. An inline filter stays on the element through that swap, so a
+censored tile scrolling away hands its blur to an uncensored photograph
+scrolling in, and takes the blur off the one that needed it. A stylesheet rule
+re-matches on the new `src` and cannot desynchronise. The roll's `index` and box
+are reporting for the same reason: they describe where a photograph was when it
+was collected, and only the content hash is safe to target.
+
+[#57]: https://github.com/chrisJuresh/portfolio/issues/57
+[#65]: https://github.com/chrisJuresh/portfolio/issues/65

--- a/design/censor/README.md
+++ b/design/censor/README.md
@@ -95,6 +95,17 @@ at. A drifted roll means collect and review again — there is no partial re-rev
 because the photographs a shifted roll brings in are exactly the ones nobody has
 looked at.
 
+Two habits are guarded against rather than documented away, because both end in a
+signed review quietly not covering the clip:
+
+- The collector **refuses to overwrite** a roll that `censored.json` is signed
+  against, if re-collecting would not reproduce it. Delete both and start over —
+  that is the only honest response, and it should be a decision rather than a
+  side effect of running a command twice.
+- An **unrecognised flag is fatal**. `--check` takes no value, so `--check=true`
+  is not the check; without this it would parse as an unknown key, fall through
+  to the collecting path, and replace the roll while looking like it verified it.
+
 ## What the page targets
 
 The vault addresses thumbnails by content: a tile's image is `/t/<sha256>.webp`.

--- a/design/censor/review.html
+++ b/design/censor/review.html
@@ -1,0 +1,256 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Censor review — the clip's roll</title>
+  <!--
+    Served by review.mjs, never by the site. One photograph at a time, at 1536px
+    against a ~162px grid tile, because a judgement made from a thumbnail is the
+    judgement this ticket exists to refuse.
+
+    Three things about the interaction are load-bearing rather than taste:
+
+      * There is no skip. Every photograph in the roll is classified before the
+        list can be confirmed, because the acceptance criterion is that every
+        one was looked at, and a review that can be left half-done reads
+        identically to one that was finished.
+      * "Unsure" is a decision, not an absence, and it censors. The ticket says
+        the ambiguous ones are classified as containing a person; making that a
+        button the reviewer presses means the ambiguity is recorded rather than
+        rounded away.
+      * Nothing is pre-selected and the keys for clear and censor are not
+        adjacent, so a held-down key cannot walk the roll marking it clear.
+  -->
+  <style>
+    :root { color-scheme: dark; --ui: #eaeaea; --ui-bg: #121212; --ui-panel: #1c1c1c; --ui-line: #333; --ui-mut: #8f8f8f; --ui-hit: #d8a76a; --ui-warn: #e0605a; --ui-ok: #6fae72; }
+    * { box-sizing: border-box; }
+    html, body { height: 100%; }
+    body {
+      margin: 0; display: flex; flex-direction: column;
+      background: var(--ui-bg); color: var(--ui);
+      font: 13px/1.45 "Segoe UI", system-ui, sans-serif;
+    }
+
+    /* ---- top bar ---------------------------------------------------------- */
+    .top {
+      flex: 0 0 auto; display: flex; flex-wrap: wrap; align-items: center; gap: 0.5rem;
+      padding: 0.5rem 0.8rem; border-bottom: 1px solid var(--ui-line);
+    }
+    .top strong { font-size: 11px; letter-spacing: 0.09em; text-transform: uppercase; color: var(--ui-mut); }
+    .grow { flex: 1 1 auto; }
+    button {
+      font: inherit; color: var(--ui); background: transparent;
+      border: 1px solid var(--ui-line); border-radius: 5px;
+      padding: 0.24rem 0.6rem; cursor: pointer;
+    }
+    button:hover:not(:disabled) { border-color: var(--ui-mut); }
+    button:disabled { opacity: 0.4; cursor: default; }
+    kbd {
+      font: 11px/1 ui-monospace, Consolas, monospace; padding: 0.2rem 0.35rem;
+      border: 1px solid var(--ui-line); border-radius: 4px; color: var(--ui-mut);
+    }
+
+    /* ---- the stage -------------------------------------------------------- */
+    .wrap { flex: 1 1 auto; display: flex; min-height: 0; }
+    .stage {
+      flex: 1 1 auto; min-width: 0; display: flex; align-items: center; justify-content: center;
+      padding: 0.8rem; overflow: auto; background: #0a0a0a;
+    }
+    .stage img { display: block; max-width: 100%; max-height: 100%; object-fit: contain; }
+    /* One-to-one: the substrate at its own pixels, scrolled rather than fitted.
+       A face can be legible at 1536 and unreadable fitted to a short window. */
+    .stage.actual { align-items: flex-start; justify-content: flex-start; }
+    .stage.actual img { max-width: none; max-height: none; }
+
+    /* ---- the side --------------------------------------------------------- */
+    .side {
+      flex: 0 0 19rem; display: flex; flex-direction: column; min-height: 0;
+      border-left: 1px solid var(--ui-line); background: var(--ui-panel);
+    }
+    .side section { padding: 0.7rem 0.8rem; border-bottom: 1px solid var(--ui-line); }
+    .side h2 { margin: 0 0 0.5rem; font-size: 11px; letter-spacing: 0.09em; text-transform: uppercase; color: var(--ui-mut); font-weight: 600; }
+    .choices { display: flex; flex-direction: column; gap: 0.35rem; }
+    .choices button { text-align: left; display: flex; align-items: center; gap: 0.5rem; padding: 0.45rem 0.6rem; }
+    .choices button span.grow { font-size: 12px; }
+    button[data-choice="clear"][aria-pressed="true"] { background: var(--ui-ok); border-color: var(--ui-ok); color: #0a0a0a; }
+    button[data-choice="person"][aria-pressed="true"],
+    button[data-choice="unsure"][aria-pressed="true"] { background: var(--ui-warn); border-color: var(--ui-warn); color: #0a0a0a; }
+
+    .meta { font-size: 11px; color: var(--ui-mut); line-height: 1.6; }
+    .meta code { font-family: ui-monospace, Consolas, monospace; word-break: break-all; }
+
+    /* ---- the filmstrip ---------------------------------------------------- */
+    /* Also the progress display: undecided tiles are the ones with no bar. What
+       the clip shows, at the size the clip shows it. */
+    .strip { flex: 1 1 auto; overflow: auto; padding: 0.6rem; display: flex; flex-wrap: wrap; gap: 4px; align-content: flex-start; }
+    .strip button { padding: 0; border-radius: 3px; overflow: hidden; position: relative; line-height: 0; }
+    .strip img { width: 44px; height: 44px; object-fit: cover; opacity: 0.55; }
+    .strip button[aria-current="true"] { outline: 2px solid var(--ui-hit); outline-offset: 1px; }
+    .strip button[aria-current="true"] img { opacity: 1; }
+    .strip button::after {
+      content: ""; position: absolute; inset: auto 0 0 0; height: 4px; background: transparent;
+    }
+    .strip button[data-decision="clear"]::after { background: var(--ui-ok); }
+    .strip button[data-decision="person"]::after,
+    .strip button[data-decision="unsure"]::after { background: var(--ui-warn); }
+
+    /* ---- the foot --------------------------------------------------------- */
+    .foot { flex: 0 0 auto; padding: 0.7rem 0.8rem; border-top: 1px solid var(--ui-line); }
+    .foot input {
+      font: inherit; width: 100%; margin-bottom: 0.5rem; padding: 0.3rem 0.45rem;
+      color: var(--ui); background: var(--ui-bg); border: 1px solid var(--ui-line); border-radius: 5px;
+    }
+    .foot button { width: 100%; padding: 0.45rem; }
+    .said { margin-top: 0.5rem; font-size: 11px; color: var(--ui-mut); }
+    .said[data-tone="bad"] { color: var(--ui-warn); }
+    .said[data-tone="good"] { color: var(--ui-ok); }
+  </style>
+</head>
+<body>
+  <div class="top">
+    <strong>Censor review</strong>
+    <span id="count" class="meta"></span>
+    <span class="grow"></span>
+    <button id="prev">&#8592; back</button>
+    <button id="actual" aria-pressed="false">1:1</button>
+    <button id="reveal" title="Open the original file in Explorer — the last word on a photograph 1536px cannot settle">reveal original</button>
+  </div>
+
+  <div class="wrap">
+    <div class="stage" id="stage"><img id="shot" alt="" decoding="async"></div>
+    <div class="side">
+      <section>
+        <h2>Does this contain an identifiable person?</h2>
+        <div class="choices">
+          <button data-choice="person"><span class="grow">Yes — obscure this tile</span><kbd>1</kbd></button>
+          <button data-choice="unsure"><span class="grow">Unsure — obscure it</span><kbd>2</kbd></button>
+          <button data-choice="clear"><span class="grow">No — leave it as it is</span><kbd>0</kbd></button>
+        </div>
+      </section>
+      <section class="meta" id="meta"></section>
+      <div class="strip" id="strip"></div>
+      <div class="foot">
+        <input id="who" placeholder="your name, to sign the list" autocomplete="off">
+        <button id="confirm" disabled>Confirm the list</button>
+        <div class="said" id="said"></div>
+      </div>
+    </div>
+  </div>
+
+<script type="module">
+const stage = document.getElementById("stage");
+const shot = document.getElementById("shot");
+const strip = document.getElementById("strip");
+const meta = document.getElementById("meta");
+const count = document.getElementById("count");
+const said = document.getElementById("said");
+const who = document.getElementById("who");
+const confirmButton = document.getElementById("confirm");
+
+const roll = await (await fetch("roll.json", { cache: "no-store" })).json();
+const decisions = new Map();
+let at = 0;
+
+/* The strip is built once and only its attributes change afterwards. 73 tiles
+   is small, but rebuilding it per keypress would refetch every thumbnail, and
+   the vault is answering the substrate request at the same moment. */
+const chips = roll.tiles.map((tile, index) => {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.title = `#${index + 1}`;
+  const image = document.createElement("img");
+  image.src = `/t/${tile.sha}.webp`;
+  image.alt = "";
+  image.decoding = "async";
+  image.loading = "lazy";
+  button.appendChild(image);
+  button.addEventListener("click", () => show(index));
+  strip.appendChild(button);
+  return button;
+});
+
+function show(index) {
+  at = Math.max(0, Math.min(roll.tiles.length - 1, index));
+  const tile = roll.tiles[at];
+  shot.src = `/d/${tile.sha}.webp`;
+  meta.innerHTML =
+    `<div>tile ${at + 1} of ${roll.tiles.length} &middot; sheet index ${tile.index}</div>` +
+    `<div>shown at ${tile.width}&times;${tile.height} in the clip, ${tile.top}px down the page</div>` +
+    `<div><code>${tile.sha}</code></div>`;
+  for (const [index_, chip] of chips.entries()) {
+    chip.setAttribute("aria-current", index_ === at ? "true" : "false");
+    const decision = decisions.get(roll.tiles[index_].sha);
+    if (decision) chip.dataset.decision = decision;
+    else delete chip.dataset.decision;
+  }
+  chips[at].scrollIntoView({ block: "nearest" });
+  for (const button of document.querySelectorAll("[data-choice]")) {
+    button.setAttribute("aria-pressed", decisions.get(tile.sha) === button.dataset.choice ? "true" : "false");
+  }
+  const done = decisions.size;
+  count.textContent = `${done} of ${roll.tiles.length} looked at`;
+  confirmButton.disabled = done < roll.tiles.length;
+  document.getElementById("prev").disabled = at === 0;
+}
+
+/* Advancing on a decision is what makes the pass a pass. It stops at the end
+   rather than wrapping, so "it went back to the start" cannot be mistaken for
+   "it is finished". */
+function decide(choice) {
+  decisions.set(roll.tiles[at].sha, choice);
+  show(at < roll.tiles.length - 1 ? at + 1 : at);
+}
+
+for (const button of document.querySelectorAll("[data-choice]")) {
+  button.addEventListener("click", () => decide(button.dataset.choice));
+}
+document.getElementById("prev").addEventListener("click", () => show(at - 1));
+document.getElementById("actual").addEventListener("click", (event) => {
+  const on = stage.classList.toggle("actual");
+  event.currentTarget.setAttribute("aria-pressed", String(on));
+});
+document.getElementById("reveal").addEventListener("click", async () => {
+  const response = await fetch(`/reveal?sha=${roll.tiles[at].sha}`, { method: "POST" });
+  if (!response.ok) tell(await response.text(), "bad");
+});
+
+const KEYS = { 1: "person", 2: "unsure", 0: "clear" };
+addEventListener("keydown", (event) => {
+  if (event.target === who || event.metaKey || event.ctrlKey || event.altKey) return;
+  if (KEYS[event.key]) { event.preventDefault(); decide(KEYS[event.key]); return; }
+  if (event.key === "ArrowLeft") { event.preventDefault(); show(at - 1); }
+  if (event.key === "ArrowRight") { event.preventDefault(); show(at + 1); }
+});
+
+function tell(message, tone) {
+  said.textContent = message;
+  said.dataset.tone = tone;
+}
+
+confirmButton.addEventListener("click", async () => {
+  if (!who.value.trim()) return tell("sign it first — the list records who confirmed it", "bad");
+  confirmButton.disabled = true;
+  const response = await fetch("/confirm", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      roll_digest: roll.roll_digest,
+      confirmed_by: who.value.trim(),
+      confirmed_at: new Date().toISOString(),
+      decisions: Object.fromEntries(decisions),
+    }),
+  });
+  const body = await response.text();
+  if (!response.ok) {
+    confirmButton.disabled = false;
+    return tell(body, "bad");
+  }
+  const { censored, reviewed } = JSON.parse(body);
+  tell(`written — ${censored} of ${reviewed} obscured. censored.json is ready to commit.`, "good");
+});
+
+show(0);
+</script>
+</body>
+</html>

--- a/design/censor/review.mjs
+++ b/design/censor/review.mjs
@@ -237,6 +237,20 @@ const server = http.createServer(async (req, res) => {
   }
 });
 
+/* A review left running in another terminal is the likely cause, and the review
+   is the one thing here that holds unsaved work — so this says so rather than
+   throwing a listen stack, and above all does not suggest killing the process
+   that may be holding a half-finished pass. */
+server.on("error", (error) => {
+  if (error.code === "EADDRINUSE") {
+    console.error(`error: something is already listening on 127.0.0.1:${port}.`);
+    console.error("       if it is another review, use that tab — its decisions are only in the page");
+    console.error(`       and are lost if it is closed. Otherwise: --port ${port + 1}`);
+    process.exit(1);
+  }
+  throw error;
+});
+
 await resolveIds();
 server.listen(port, "127.0.0.1", () => {
   console.log(`review surface   http://127.0.0.1:${port}/`);

--- a/design/censor/review.mjs
+++ b/design/censor/review.mjs
@@ -1,0 +1,245 @@
+/* ============================================================================
+   review.mjs — serve the review surface, and take the author's signature.
+
+     node design/censor/review.mjs            # then open the URL it prints
+     node design/censor/review.mjs --port 8791
+
+   Node builtins only; nothing here is deployed (.vercelignore excludes design/).
+
+   WHY A SERVER AND NOT A FILE:// PAGE
+   ------------------------------------
+   The review has to read roll.json, show each photograph from the vault, and
+   write the confirmed list back. Under file:// the first is blocked by the
+   origin rules and the third is impossible, so the page would end up as a
+   copy-and-paste drawer like the tuners — which is the wrong shape for a
+   safety list. A list that only becomes real when someone pastes it correctly
+   is a list that can be pasted incorrectly.
+
+   So: this serves design/censor/ on localhost, proxies the vault's own routes
+   through the same origin, and writes design/censor/censored.json itself.
+
+   THE THREE VAULT ROUTES IT FORWARDS
+   -----------------------------------
+     /d/<sha>.webp   the 1536px substrate — the review surface. Eight times the
+                     grid tile in each dimension, which is the whole point: the
+                     judgement this ticket wants cannot be made from a thumbnail.
+     /t/<sha>.webp   the grid thumbnail — the filmstrip, and it is also exactly
+                     what the clip shows, so seeing it beside the substrate is
+                     how the reviewer sees what the reader would.
+     /api/reveal     opens the original file in Explorer. The escape hatch for a
+                     photograph 1536px cannot settle. Needs the vault's numeric
+                     id, which the roll does not carry, so the sha is resolved
+                     through one page of /api/photos at startup — the roll is
+                     the newest tiles in the vault's default sort, so they are
+                     all inside the first page and one fetch resolves the lot.
+
+   The vault refuses any request whose Host header it does not recognise, so
+   these are forwarded to 127.0.0.1 rather than rewritten onto this origin.
+   ========================================================================== */
+
+import http from "node:http";
+import { createReadStream } from "node:fs";
+import { readFile, writeFile, stat } from "node:fs/promises";
+import { dirname, extname, join, normalize, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+function args(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (!argv[i].startsWith("--")) continue;
+    const key = argv[i].slice(2);
+    const val = argv[i + 1] && !argv[i + 1].startsWith("--") ? argv[++i] : "true";
+    out[key] = val;
+  }
+  return out;
+}
+const opt = args(process.argv.slice(2));
+const port = Number(opt.port || 8791);
+const vault = opt.vault || "http://127.0.0.1:8770";
+
+const ROLL = resolve(HERE, "roll.json");
+const CONFIRMED = resolve(HERE, "censored.json");
+
+const MIME = {
+  ".html": "text/html; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".mjs": "text/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+};
+
+/* sha -> the vault's numeric id, for /api/reveal. Empty is not fatal: the
+   reveal button reports that it cannot resolve and the review carries on with
+   the substrate, which is the surface it is designed around anyway. */
+const ids = new Map();
+async function resolveIds() {
+  try {
+    const response = await fetch(`${vault}/api/photos?limit=500`);
+    const page = await response.json();
+    for (const photo of page.photos ?? []) ids.set(photo.s, photo.id);
+  } catch (error) {
+    console.warn(`warning: could not resolve photo ids for reveal — ${error.message}`);
+  }
+}
+
+function send(res, status, body, type = "text/plain; charset=utf-8") {
+  res.writeHead(status, { "content-type": type, "cache-control": "no-store" });
+  res.end(body);
+}
+
+/* Serve out of design/censor/ and nowhere else. The path is normalised and then
+   checked to still be under the folder, rather than checked for "..", which is
+   the check that survives encodings nobody thought of. */
+async function serveStatic(res, urlPath) {
+  const rel = decodeURIComponent(urlPath === "/" ? "/review.html" : urlPath);
+  const file = normalize(join(HERE, rel));
+  if (file !== HERE && !file.startsWith(HERE + sep)) return send(res, 403, "forbidden");
+  try {
+    const info = await stat(file);
+    if (!info.isFile()) return send(res, 404, "not found");
+  } catch {
+    return send(res, 404, "not found");
+  }
+  res.writeHead(200, {
+    "content-type": MIME[extname(file).toLowerCase()] ?? "application/octet-stream",
+    "cache-control": "no-store",
+  });
+  createReadStream(file).pipe(res);
+}
+
+async function proxyImage(res, urlPath) {
+  try {
+    const response = await fetch(vault + urlPath);
+    if (!response.ok) return send(res, response.status, "vault said no");
+    const body = Buffer.from(await response.arrayBuffer());
+    res.writeHead(200, { "content-type": "image/webp", "cache-control": "no-store" });
+    res.end(body);
+  } catch (error) {
+    send(res, 502, `vault unreachable — is the grid running on ${vault}? (${error.message})`);
+  }
+}
+
+function readBody(req) {
+  return new Promise((resolve_, reject) => {
+    const chunks = [];
+    let size = 0;
+    req.on("data", (chunk) => {
+      size += chunk.length;
+      /* The confirmed list for a 73-tile roll is a few kilobytes. A megabyte is
+         far past any honest one and far short of anything worth streaming. */
+      if (size > 1_000_000) {
+        req.destroy();
+        reject(new Error("body too large"));
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => resolve_(Buffer.concat(chunks).toString("utf8")));
+    req.on("error", reject);
+  });
+}
+
+async function reveal(req, res) {
+  const sha = new URL(req.url, "http://localhost").searchParams.get("sha");
+  const id = ids.get(sha);
+  if (id === undefined) return send(res, 404, "no id for that hash");
+  try {
+    const response = await fetch(`${vault}/api/reveal`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ id }),
+    });
+    send(res, response.ok ? 200 : response.status, await response.text());
+  } catch (error) {
+    send(res, 502, error.message);
+  }
+}
+
+/* The one write. It re-reads the roll from disk rather than trusting the page's
+   copy, so what gets signed is the roll as committed and not whatever the tab
+   was holding — a tab left open across a re-collect would otherwise sign the
+   old one under the new one's name. */
+async function confirm(req, res) {
+  let submitted;
+  try {
+    submitted = JSON.parse(await readBody(req));
+  } catch (error) {
+    return send(res, 400, `unreadable: ${error.message}`);
+  }
+  const roll = JSON.parse(await readFile(ROLL, "utf8"));
+  if (submitted.roll_digest !== roll.roll_digest) {
+    return send(res, 409, "that review was made against a different roll — reload and start over");
+  }
+
+  const decisions = new Map(Object.entries(submitted.decisions ?? {}));
+  const missing = roll.tiles.filter((tile) => !decisions.has(tile.sha));
+  if (missing.length) return send(res, 400, `${missing.length} photographs were never looked at`);
+
+  /* Checked here as well as in the page, because the acceptance criterion is
+     that the author confirmed the list — so a file that does not say who
+     confirmed it is not the artefact, and the page is the one part of this a
+     stale tab or a paused script can skip. */
+  const by = (submitted.confirmed_by ?? "").trim();
+  if (!by) return send(res, 400, "unsigned — the list records who confirmed it");
+
+  /* Anything not decided "clear" is censored. Written this way round on purpose:
+     the failure mode of a bug here is a photograph obscured that need not have
+     been, not a face published. */
+  const tiles = roll.tiles.map((tile) => ({
+    sha: tile.sha,
+    index: tile.index,
+    decision: decisions.get(tile.sha),
+    censor: decisions.get(tile.sha) !== "clear",
+    selector: `img[src$="${tile.sha}.webp"]`,
+  }));
+  const censored = tiles.filter((tile) => tile.censor);
+
+  await writeFile(
+    CONFIRMED,
+    JSON.stringify(
+      {
+        note:
+          "The confirmed censored tile list. Every tile with censor:true is obscured in " +
+          "the page before capture. Assembled by review.mjs from a human pass over " +
+          "roll.json; see README.md.",
+        roll_digest: roll.roll_digest,
+        viewport: roll.viewport,
+        distance: roll.distance,
+        confirmed_by: by,
+        confirmed_at: submitted.confirmed_at,
+        reviewed: tiles.length,
+        censored: censored.length,
+        selector_list: censored.map((tile) => tile.selector).join(",\n"),
+        tiles,
+      },
+      null,
+      2,
+    ) + "\n",
+    "utf8",
+  );
+
+  console.log(`confirmed: ${censored.length} of ${tiles.length} censored — written ${CONFIRMED}`);
+  send(res, 200, JSON.stringify({ censored: censored.length, reviewed: tiles.length }), MIME[".json"]);
+}
+
+const server = http.createServer(async (req, res) => {
+  const path = req.url.split("?")[0];
+  try {
+    if (req.method === "POST" && path === "/confirm") return await confirm(req, res);
+    if (req.method === "POST" && path === "/reveal") return await reveal(req, res);
+    if (req.method !== "GET") return send(res, 405, "method not allowed");
+    if (/^\/[td]\/[0-9a-f]{64}\.webp$/.test(path)) return await proxyImage(res, path);
+    return await serveStatic(res, path);
+  } catch (error) {
+    send(res, 500, error.stack ?? String(error));
+  }
+});
+
+await resolveIds();
+server.listen(port, "127.0.0.1", () => {
+  console.log(`review surface   http://127.0.0.1:${port}/`);
+  console.log(`vault            ${vault}  (${ids.size} hashes resolved for reveal)`);
+  console.log(`writes           ${CONFIRMED}`);
+});

--- a/design/censor/roll.json
+++ b/design/censor/roll.json
@@ -1,0 +1,597 @@
+{
+  "note": "Every photograph the recording passes over. Assembled by collect-roll.mjs; not a decision about any of them. See README.md.",
+  "grid_url": "http://127.0.0.1:8770/",
+  "viewport": {
+    "width": 1440,
+    "height": 900
+  },
+  "distance": 1200,
+  "band": 2100,
+  "roll_digest": "3b968f3ea171e148fb2d82196a5a590e37315a359a09a99a67013290026e2115",
+  "tiles": [
+    {
+      "sha": "0d66290eeef2929f556afcd04eb914b66608dde5e65daf8c700f6d1215ead6d8",
+      "index": 0,
+      "top": 96,
+      "left": 14,
+      "width": 162,
+      "height": 216
+    },
+    {
+      "sha": "b5d377028d775dfc2be40cca2d65ada4d4f3c5b21755d81b1b0a51f534122cdd",
+      "index": 1,
+      "top": 96,
+      "left": 180,
+      "width": 162,
+      "height": 216
+    },
+    {
+      "sha": "bbd61b9120d8e6a9d633dc15e8c4df7eaa3fee5f87519ac4ea0cfdb5c0c26cce",
+      "index": 2,
+      "top": 96,
+      "left": 346,
+      "width": 162,
+      "height": 216
+    },
+    {
+      "sha": "89536239359ee01e831d7d62e508e50a23f35d14f1ed2a4f2259a56df4238d9f",
+      "index": 3,
+      "top": 96,
+      "left": 512,
+      "width": 162,
+      "height": 216
+    },
+    {
+      "sha": "2128157cac21f1caee8815c00776a2f8175d7be1a4dfd7af8a6b8ec45279cba7",
+      "index": 4,
+      "top": 96,
+      "left": 678,
+      "width": 162,
+      "height": 216
+    },
+    {
+      "sha": "774832865eb6a8aaaad68c397b73005aac6896c62a7167b2d077fa981bbc6ae3",
+      "index": 5,
+      "top": 96,
+      "left": 844,
+      "width": 288,
+      "height": 216
+    },
+    {
+      "sha": "0a1429266cdc213cdc6c5a039f887c8312e8ff6cf111681f1882585affcb469d",
+      "index": 6,
+      "top": 96,
+      "left": 1136,
+      "width": 290,
+      "height": 216
+    },
+    {
+      "sha": "23c34f99af74284413fedc8a2773052533fc512b765399008ca3c7b6c516fcc0",
+      "index": 7,
+      "top": 328,
+      "left": 14,
+      "width": 280,
+      "height": 210
+    },
+    {
+      "sha": "39cd43e47cc10c73c4042ccc040de6bb1793fb05c9b8f198a8eb91df9f3d6cfb",
+      "index": 8,
+      "top": 328,
+      "left": 298,
+      "width": 280,
+      "height": 210
+    },
+    {
+      "sha": "886e7d6848e88f27520ef4e3eec436953059c618bf538e9f6655bcc1738f03a5",
+      "index": 9,
+      "top": 328,
+      "left": 582,
+      "width": 280,
+      "height": 210
+    },
+    {
+      "sha": "0db0c95eb8e268a4094d52e419491903da75f724bdf503f3307c642a7ecfece9",
+      "index": 10,
+      "top": 328,
+      "left": 866,
+      "width": 280,
+      "height": 210
+    },
+    {
+      "sha": "ebf79cd7d69613cf3c289359067efd5d08057178fbfe140c1987791e2e048f20",
+      "index": 11,
+      "top": 328,
+      "left": 1150,
+      "width": 276,
+      "height": 210
+    },
+    {
+      "sha": "cbf8472b07784401e19d5dbbb77a2afd2deec782d30ab2be61169cf4664da730",
+      "index": 12,
+      "top": 554,
+      "left": 14,
+      "width": 288,
+      "height": 216
+    },
+    {
+      "sha": "a68b3d983ccc4d7d3c04cbb1e39544dd4d3c6a3ec258d4de550470c13180141f",
+      "index": 13,
+      "top": 554,
+      "left": 306,
+      "width": 288,
+      "height": 216
+    },
+    {
+      "sha": "2b12312e60abab65be7d4f87dad29c233ae342777b440653a8e80ac78df093f2",
+      "index": 14,
+      "top": 554,
+      "left": 598,
+      "width": 162,
+      "height": 216
+    },
+    {
+      "sha": "c4daabdbe0a1cb25af5c9e143a5561ad2c06b006b82b929ad856763268c38eac",
+      "index": 15,
+      "top": 554,
+      "left": 764,
+      "width": 162,
+      "height": 216
+    },
+    {
+      "sha": "60c3f14a957b19c43df4f00404cf0008b859a787ca07c4e59c18ad61c8433833",
+      "index": 16,
+      "top": 554,
+      "left": 930,
+      "width": 162,
+      "height": 216
+    },
+    {
+      "sha": "20ebfe85ab950530eb95a7876540c2183f65dc5b051cb4fb23af1d8b72d5ee48",
+      "index": 17,
+      "top": 554,
+      "left": 1096,
+      "width": 162,
+      "height": 216
+    },
+    {
+      "sha": "c05add34ea277ae19c09e38680a3dd8a91288ec55238b3ef060f7902c685fd5d",
+      "index": 18,
+      "top": 554,
+      "left": 1262,
+      "width": 164,
+      "height": 216
+    },
+    {
+      "sha": "8428637a361801b6324ed14bf3266cf8d78d49d06e2a3a63c1623cd74ff5246a",
+      "index": 19,
+      "top": 786,
+      "left": 14,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "92aaf8e274fe68801e9dba76fd1e0f33dff9841b7ec87820533ccb1f7932d6bc",
+      "index": 20,
+      "top": 786,
+      "left": 171,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "8bcb4a802a33ce7eed0e0d70e58b9528dcf4a50dd253187168802a883349db6c",
+      "index": 21,
+      "top": 786,
+      "left": 328,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "93ad723c921c2863b18de88932ea26a7e1ec829764a81cab17ca9efbfb8cf2ad",
+      "index": 22,
+      "top": 786,
+      "left": 485,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "9affc9fbea6ad456364c5820ff3db1e119010d3a768da3d92c556f151e026e2b",
+      "index": 23,
+      "top": 786,
+      "left": 642,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "970124a5fad48ba2a86fa380d9796660c6d25902c34afd5f2871fa08b40994c4",
+      "index": 24,
+      "top": 786,
+      "left": 799,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "902818fd5c18a088721ae4a4e80ef2d9156ad7a4eb5708e73cec64218617a4df",
+      "index": 25,
+      "top": 786,
+      "left": 956,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "6cadd29949b20cd5d5bdc6455befeb2025cb330f173510ff71c4ad2b2b198b65",
+      "index": 26,
+      "top": 786,
+      "left": 1113,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "b50866ee82e1503ec6f1ed3558a5fcae27e6ee9f47e50db46fd7be2d5bc672f2",
+      "index": 27,
+      "top": 786,
+      "left": 1270,
+      "width": 156,
+      "height": 204
+    },
+    {
+      "sha": "147d346fd1b32e66675cc483d19d667a17546639bcb4e3418e07d9e23139f2b9",
+      "index": 28,
+      "top": 1006,
+      "left": 14,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "ed9128f59a7fc7e9e3a8521e281961edd9badc58d6a3a1bcabcb2185ec88be81",
+      "index": 29,
+      "top": 1006,
+      "left": 171,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "2ea18be79348c466d8d6d9822c0702fd37e120bf0449cb167d89a41df860ef49",
+      "index": 30,
+      "top": 1006,
+      "left": 328,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "cbc4a29a6464613d29daf3aa334fd8660ba4e9a60d90f377c54cc40830ff63d1",
+      "index": 31,
+      "top": 1006,
+      "left": 485,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "79b24413c88c08335aa291afde900f6925ad6a6b1cdf6a56137401e41521cd14",
+      "index": 32,
+      "top": 1006,
+      "left": 642,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "b3949f164181d8c39b4e3900d2ec04e8d7bdbbce71702aeb4905150a1ef20cc6",
+      "index": 33,
+      "top": 1006,
+      "left": 799,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "8834826bfa74672c777a9074cb5f9f3b401ce368cc8347148ddbc8fcc8f1a4a7",
+      "index": 34,
+      "top": 1006,
+      "left": 956,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "dea7f09083c8597c5487eebb196bfa75d3af5e8a4165ebd5c6eea9184e1d0d00",
+      "index": 35,
+      "top": 1006,
+      "left": 1113,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "b520d9128e90f813fd31f26d0ce82ad01499214e50af0bc2d3cf7a50e3536721",
+      "index": 36,
+      "top": 1006,
+      "left": 1270,
+      "width": 156,
+      "height": 204
+    },
+    {
+      "sha": "c1a4146771f2c0741b09857855966f17ce526a010978ac0d3312acaa81cae0cc",
+      "index": 37,
+      "top": 1226,
+      "left": 14,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "2f6e5844a933addb06c1b4e9fbde21457a896cc9d51016c1a07988d527f8abcb",
+      "index": 38,
+      "top": 1226,
+      "left": 171,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "5c536cdb47f84d53e62718778a501654305d8befc96a2e37bc412f1e11a52fbc",
+      "index": 39,
+      "top": 1226,
+      "left": 328,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "2c0607f1732c48809cfed512c20be13494a0ee8bb84308bc1bcefd72886dd30a",
+      "index": 40,
+      "top": 1226,
+      "left": 485,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "c8b9a0b4da8bc4306091a4b5d13828697322ac0e696594adf252e5f72ea72778",
+      "index": 41,
+      "top": 1226,
+      "left": 642,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "6ec9f56869cbdfb319f1ee4e94380331837de2918548b7e7eb8737b49fb354e1",
+      "index": 42,
+      "top": 1226,
+      "left": 799,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "1301709ef701bf29898ce7d505c2be5e53a0fff4cc08bcfb52f69017dc6a0587",
+      "index": 43,
+      "top": 1226,
+      "left": 956,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "98d4700e11e602a71cdd784ab7cda7167fa83e17f26979e39b198c7da7c1db4d",
+      "index": 44,
+      "top": 1226,
+      "left": 1113,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "89d6235574f651fdd96e949c83e5910ed8313ca3cf9d1680382cff66100345cf",
+      "index": 45,
+      "top": 1226,
+      "left": 1270,
+      "width": 156,
+      "height": 204
+    },
+    {
+      "sha": "e9c1faa35128f63479963f96ad4cc5f6cf2a23b1c0aba06646136df9f33983c8",
+      "index": 46,
+      "top": 1446,
+      "left": 14,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "898cf5d314f51257e0884fcb77723cbc2a12bbbeceb7526f4f5588435d1f50a4",
+      "index": 47,
+      "top": 1446,
+      "left": 171,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "b3b5ec51deaad446c1414f2dacf28265ed6e5f4ddfc997d02e4fec20a2d03082",
+      "index": 48,
+      "top": 1446,
+      "left": 328,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "f6314d9332a2d196cb0dc89667086dae6be81dc39b4880e0b662538e99220224",
+      "index": 49,
+      "top": 1446,
+      "left": 485,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "081380a4d44f8f390b716b8bb4a7e1f2370add7f689597a38a0872907559486b",
+      "index": 50,
+      "top": 1446,
+      "left": 642,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "f9537208acf976baac7d61f8c0a8eabed09bcb39a8e164735ba995fe7f1c07c0",
+      "index": 51,
+      "top": 1446,
+      "left": 799,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "4944f0019e720c7af46191d4e1f4e0b98eec2855dcc5280f5ffb1cf05e9f0f92",
+      "index": 52,
+      "top": 1446,
+      "left": 956,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "502a51b07c59c4cf4256529d00d07bbfb8b6f6ed56cde44c77ae6d5c4cbca0de",
+      "index": 53,
+      "top": 1446,
+      "left": 1113,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "58229acfa2efb0690c3dc50d382b1b58793b7516cd11bbf4a712fc42cdf37c72",
+      "index": 54,
+      "top": 1446,
+      "left": 1270,
+      "width": 156,
+      "height": 204
+    },
+    {
+      "sha": "e59dc5f324dc5d749275a001131ee86c90e1b3e2599a18920ab74749272c5656",
+      "index": 55,
+      "top": 1666,
+      "left": 14,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "6d21dc8e83ca3fe5cc4229e16e59531b1e8aaf5203053dd29467e708205c79b4",
+      "index": 56,
+      "top": 1666,
+      "left": 171,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "5ab82a1e59a712431c1dcbc0018f0d8e66370f2cc1a4cebc48788d106c891679",
+      "index": 57,
+      "top": 1666,
+      "left": 328,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "8660e1cfcf16102b34352f181a5ef0d9c6034e5cd8b89701ef70cdeeebdd567f",
+      "index": 58,
+      "top": 1666,
+      "left": 485,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "b78f3ed214a35ecab2d5878783013850603bf820d10609801213ef283e8c11aa",
+      "index": 59,
+      "top": 1666,
+      "left": 642,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "ccbe1494b63d4b8d20fd03b4aa2af43679ee51bc122aeef263a2063706c31bac",
+      "index": 60,
+      "top": 1666,
+      "left": 799,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "d787a5892e6318a40db2874a99966a21aab5638fc48107b9ee618baf7c833672",
+      "index": 61,
+      "top": 1666,
+      "left": 956,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "273262739caa093cbeb3df8e12283efa9b1576b575e662a966462e7eb3b3aa9b",
+      "index": 62,
+      "top": 1666,
+      "left": 1113,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "e4ff5867baa423f3416b1250dbc0fda5fa66e339a389e64000c2bc329970abba",
+      "index": 63,
+      "top": 1666,
+      "left": 1270,
+      "width": 156,
+      "height": 204
+    },
+    {
+      "sha": "5c7abd5baa3bd07fff251a2c45266b09ca2c661687cf78c5f48a6cbd6c9597b8",
+      "index": 64,
+      "top": 1886,
+      "left": 14,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "407a21d9a12077f3d24832ed676cd698a1515d0f03692442109058357ebefc0b",
+      "index": 65,
+      "top": 1886,
+      "left": 171,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "6baa3c35457ce6cb3d6cf883db6af33342997b392b7445fe4b4869fc1bc12ade",
+      "index": 66,
+      "top": 1886,
+      "left": 328,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "18fabd232494fda5b1432db3f0ab829593b256573bb5533741245c404cbbf4b0",
+      "index": 67,
+      "top": 1886,
+      "left": 485,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "26c1dbb0cbfb5952c352c04c623d183bc6b0f0f59fb50f7c3105ff4ac0b6deac",
+      "index": 68,
+      "top": 1886,
+      "left": 642,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "5dc0e7232671a7147bfadeafb38523b6be46c504bc1f60bf03cefc9a3fc8da74",
+      "index": 69,
+      "top": 1886,
+      "left": 799,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "cdd3b16f1a8d41dcf4d86ca4a884cd3a26284d619b918e01eabaa1d72e3eaedf",
+      "index": 70,
+      "top": 1886,
+      "left": 956,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "bda2d29776363db0e2941ce2423de190ec04c6768c122ef4bcc683cc29314518",
+      "index": 71,
+      "top": 1886,
+      "left": 1113,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "5d7a8bdb5fbeea322b67117d4f587f9f222ce731437a18f5e83abf3fd1b36ee1",
+      "index": 72,
+      "top": 1886,
+      "left": 1270,
+      "width": 156,
+      "height": 204
+    }
+  ]
+}

--- a/design/tools/collect-roll.mjs
+++ b/design/tools/collect-roll.mjs
@@ -1,0 +1,254 @@
+/* ============================================================================
+   collect-roll.mjs — enumerate every photograph the clip passes over.
+
+     node design/tools/collect-roll.mjs                     # write roll.json
+     node design/tools/collect-roll.mjs --check             # has the roll drifted?
+     node design/tools/collect-roll.mjs --url http://127.0.0.1:8770/
+
+   This is the mechanical half of the censored tile list. It answers "which
+   photographs does the recording actually show", and nothing else — it does not
+   look at a single pixel of any of them. Which of them contain an identifiable
+   person is decided by the author in design/censor/review.html, for the reasons
+   in design/censor/README.md.
+
+   It lives here rather than in design/censor/ because this is where the repo's
+   one Playwright install is. The rest of the censoring — the roll it writes, the
+   review surface, the confirmed list — is in design/censor/.
+
+   WHY A BROWSER AND NOT THE API
+   -----------------------------
+   /api/photos returns the library in sort order, but the clip does not show a
+   sort order — it shows whatever the justified-row layout happened to put in
+   front of the camera, at one viewport, over one scroll range. The sheet is
+   virtualised and lays rows out from each photograph's own aspect ratio, so the
+   only honest answer to "what does the clip pass over" comes from driving the
+   real grid at the real geometry and reading the real boxes. Getting this wrong
+   in the safe direction is not possible: a photograph missing from the roll is
+   one the author never reviews and the mosaic never covers.
+
+   THE GEOMETRY IS RECORD'S, RESTATED
+   -----------------------------------
+   The defaults below are the settings the recording is made with, and they are
+   the whole reason the roll is what it is:
+
+     viewport 1440x900   record/projects/photos/project.toml   [viewport]
+     scroll 0 -> 1200    record/projects/photos/actions/scroll-peek.overrides.toml
+     document scroller   record/packages/core/src/page.ts      findScroller
+
+   They are copied rather than imported: this repo does not depend on record's
+   source tree, and a silent import would let record's settings move without
+   anything here noticing. Copied means they can go stale instead — so they are
+   written into roll.json, and --check reports a roll assembled at a geometry
+   that no longer matches. If record's viewport or distance changes, re-run.
+
+   WHAT COUNTS AS "PASSED OVER"
+   -----------------------------
+   The band of the document the camera ever sees is [0, distance + height] —
+   scroll 0 puts the top 900px on screen, scroll 1200 puts [1200, 2100] on
+   screen, and the legs between are continuous. Any tile whose box touches that
+   band is in the roll, including one showing a single pixel at the far edge.
+   That is deliberate: the reviewer's job is to look, and a sliver of a face is
+   still a face.
+
+   Boxes are collected from mounted tiles at a series of stops rather than
+   sampled per frame. The sheet only mounts tiles near the scroll position, so
+   stepping is what makes them exist; the band test is then arithmetic on
+   document coordinates and cannot miss a tile between two stops.
+   ========================================================================== */
+
+import { createHash } from "node:crypto";
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/* ---- record's settings, restated ---------------------------------------- */
+const GRID_URL = "http://127.0.0.1:8770/";
+const VIEWPORT = { width: 1440, height: 900 };
+const DISTANCE = 1200;
+
+/* How far apart the stops are. Only has to be fine enough that the sheet mounts
+   every tile in the band on the way past — the band test itself is exact — so
+   this is well under a viewport rather than near one. */
+const STEP = 100;
+
+/* ---- args --------------------------------------------------------------- */
+function args(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (!argv[i].startsWith("--")) continue;
+    const key = argv[i].slice(2);
+    const val = argv[i + 1] && !argv[i + 1].startsWith("--") ? argv[++i] : "true";
+    out[key] = val;
+  }
+  return out;
+}
+const opt = args(process.argv.slice(2));
+const url = opt.url || GRID_URL;
+const width = Number(opt.width || VIEWPORT.width);
+const height = Number(opt.height || VIEWPORT.height);
+const distance = Number(opt.distance || DISTANCE);
+const out = resolve(opt.out ? opt.out : resolve(HERE, "..", "censor", "roll.json"));
+const checking = opt.check === "true";
+
+const band = distance + height;
+
+/* ---- record's own expressions, so the page scrolls the way the clip does -- */
+const STOP_SMOOTH_SCROLLING = `
+  (() => {
+    const style = document.createElement("style");
+    style.textContent = "*,html,body{scroll-behavior:auto !important}";
+    document.head.appendChild(style);
+  })()
+`;
+const FIND_SCROLLER = `
+  (() => {
+    const document_ = document.scrollingElement || document.documentElement;
+    if (document_.scrollHeight > document_.clientHeight + 4) {
+      window.__recordScroller = document_;
+      return;
+    }
+    let best = null;
+    let deepest = 0;
+    for (const element of document.querySelectorAll("*")) {
+      const overflow = element.scrollHeight - element.clientHeight;
+      const scrollable = /(auto|scroll)/.test(getComputedStyle(element).overflowY);
+      if (scrollable && overflow > deepest) { best = element; deepest = overflow; }
+    }
+    window.__recordScroller = best || document_;
+  })()
+`;
+
+/* Every mounted tile, in document coordinates. `data-index` is the sheet's own
+   position in the current sort and is rebound on recycling, so it is read at the
+   same moment as the box. The hash is taken from the thumbnail URL because the
+   vault addresses thumbnails by content — which is what makes a tile targetable
+   by a selector at all, and targetable across a re-sort. */
+const COLLECT = `
+  (() => {
+    const scroller = window.__recordScroller;
+    const top = scroller.scrollTop;
+    const found = [];
+    for (const tile of document.querySelectorAll(".tile")) {
+      const img = tile.querySelector("img");
+      const src = img && img.getAttribute("src");
+      const match = src && src.match(/([0-9a-f]{64})\\.webp$/);
+      if (!match) continue;
+      const box = tile.getBoundingClientRect();
+      found.push({
+        sha: match[1],
+        index: Number(tile.dataset.index),
+        top: Math.round(box.top + top),
+        left: Math.round(box.left),
+        width: Math.round(box.width),
+        height: Math.round(box.height),
+      });
+    }
+    return found;
+  })()
+`;
+
+async function collect() {
+  const browser = await chromium.launch();
+  const page = await browser.newPage({
+    viewport: { width, height },
+    deviceScaleFactor: 1,
+  });
+  try {
+    await page.goto(url, { waitUntil: "domcontentloaded" });
+    await page.waitForSelector(".tile", { timeout: 30_000 });
+    await page.evaluate(STOP_SMOOTH_SCROLLING);
+    await page.evaluate(FIND_SCROLLER);
+
+    /* Keyed by hash, not by index: a recycled tile comes back under a new index
+       and the same photograph must not enter the roll twice. */
+    const seen = new Map();
+    for (let at = 0; at <= distance; at += STEP) {
+      await page.evaluate(`window.__recordScroller.scrollTop = ${at}`);
+      await page.waitForTimeout(250);
+      for (const tile of await page.evaluate(COLLECT)) {
+        if (!seen.has(tile.sha)) seen.set(tile.sha, tile);
+      }
+    }
+    /* The far end exactly, in case distance is not a multiple of STEP. */
+    await page.evaluate(`window.__recordScroller.scrollTop = ${distance}`);
+    await page.waitForTimeout(400);
+    for (const tile of await page.evaluate(COLLECT)) {
+      if (!seen.has(tile.sha)) seen.set(tile.sha, tile);
+    }
+
+    const inBand = [...seen.values()]
+      .filter((t) => t.top < band && t.top + t.height > 0)
+      .sort((a, b) => a.top - b.top || a.left - b.left);
+
+    return { tiles: inBand, mounted: seen.size };
+  } finally {
+    await browser.close();
+  }
+}
+
+/* The roll's identity: the hashes it holds, in the order the clip meets them.
+   Two runs that agree on this are two runs of the same clip, and a review signed
+   against one is a review of the other. Anything else in the file — boxes,
+   indices, the run's own timestamp — is reporting. */
+const digestOf = (tiles) =>
+  createHash("sha256").update(tiles.map((t) => t.sha).join("\n")).digest("hex");
+
+const { tiles, mounted } = await collect();
+const digest = digestOf(tiles);
+
+if (checking) {
+  let previous;
+  try {
+    previous = JSON.parse(await readFile(out, "utf8"));
+  } catch {
+    console.error(`error: no roll at ${out} to check against — run without --check first`);
+    process.exit(1);
+  }
+  const same = previous.roll_digest === digest;
+  const geometry =
+    previous.viewport?.width === width &&
+    previous.viewport?.height === height &&
+    previous.distance === distance;
+  console.log(`roll on disk   ${previous.tiles.length} tiles  ${previous.roll_digest}`);
+  console.log(`roll now       ${tiles.length} tiles  ${digest}`);
+  if (!geometry) {
+    console.log(
+      `geometry       DRIFTED — on disk ${previous.viewport?.width}x${previous.viewport?.height} ` +
+        `distance ${previous.distance}, asked for ${width}x${height} distance ${distance}`,
+    );
+  }
+  if (same && geometry) {
+    console.log("unchanged — a review signed against this roll still covers the clip");
+    process.exit(0);
+  }
+  console.log("DRIFTED — the confirmed list no longer covers the clip; re-collect and re-review");
+  process.exit(1);
+}
+
+await mkdir(dirname(out), { recursive: true });
+await writeFile(
+  out,
+  JSON.stringify(
+    {
+      note:
+        "Every photograph the recording passes over. Assembled by collect-roll.mjs; " +
+        "not a decision about any of them. See README.md.",
+      grid_url: url,
+      viewport: { width, height },
+      distance,
+      band,
+      roll_digest: digest,
+      tiles,
+    },
+    null,
+    2,
+  ) + "\n",
+  "utf8",
+);
+
+console.log(`${tiles.length} photographs in the band [0, ${band}] (${mounted} tiles mounted in all)`);
+console.log(`roll_digest ${digest}`);
+console.log(`written ${out}`);

--- a/design/tools/collect-roll.mjs
+++ b/design/tools/collect-roll.mjs
@@ -86,6 +86,22 @@ function args(argv) {
   return out;
 }
 const opt = args(process.argv.slice(2));
+
+/* An unknown flag is fatal here, which it is not in render.mjs, and the reason
+   is that the two have different worst cases. This parser only understands
+   `--check`, not `--check=true`; render.mjs mistaking that for an unknown
+   variant costs a re-render, whereas this script's non-checking path OVERWRITES
+   the roll. So a mistyped drift check would replace the roll a confirmed list
+   was signed against and report success, which is the one thing this file must
+   not do quietly. Fail on anything unrecognised rather than fall through. */
+const KNOWN = new Set(["url", "width", "height", "distance", "out", "check"]);
+const unknown = Object.keys(opt).filter((key) => !KNOWN.has(key));
+if (unknown.length) {
+  console.error(`error: unknown flag${unknown.length > 1 ? "s" : ""} ${unknown.map((k) => `--${k}`).join(", ")}`);
+  console.error(`       have: ${[...KNOWN].map((k) => `--${k}`).join(", ")} — and --check takes no value`);
+  process.exit(2);
+}
+
 const url = opt.url || GRID_URL;
 const width = Number(opt.width || VIEWPORT.width);
 const height = Number(opt.height || VIEWPORT.height);
@@ -163,7 +179,16 @@ async function collect() {
     await page.evaluate(FIND_SCROLLER);
 
     /* Keyed by hash, not by index: a recycled tile comes back under a new index
-       and the same photograph must not enter the roll twice. */
+       and the same photograph must not enter the roll twice.
+
+       The first sighting of a tile is the one kept, which is only sound if a
+       tile's document box does not move after it is first mounted — otherwise
+       the band test below runs on stale geometry and can drop a photograph the
+       clip does show. It holds, and not by luck: the vault returns each file's
+       width and height with the page, so rows are laid out before any image is
+       requested and there is no load-time reflow to wait out (grid.py says so
+       in as many words). Measured rather than taken from the comment — over the
+       whole scroll range, 0 of 153 mounted tiles moved between stops. */
     const seen = new Map();
     for (let at = 0; at <= distance; at += STEP) {
       await page.evaluate(`window.__recordScroller.scrollTop = ${at}`);
@@ -207,6 +232,11 @@ if (checking) {
     console.error(`error: no roll at ${out} to check against — run without --check first`);
     process.exit(1);
   }
+  if (!Array.isArray(previous.tiles)) {
+    console.error(`error: ${out} parses but carries no tiles — an interrupted write, or hand-edited`);
+    console.error("       re-collect it: run without --check");
+    process.exit(1);
+  }
   const same = previous.roll_digest === digest;
   const geometry =
     previous.viewport?.width === width &&
@@ -226,6 +256,34 @@ if (checking) {
   }
   console.log("DRIFTED — the confirmed list no longer covers the clip; re-collect and re-review");
   process.exit(1);
+}
+
+/* Replacing the roll orphans any review signed against it, and the review is 73
+   photographs of someone's afternoon. The downstream guards do catch the
+   mismatch — review.mjs refuses a stale digest, --check reports DRIFTED — but
+   they catch it later, and by then the roll it was signed against is gone. So
+   this refuses rather than warns, and says which of the two situations it is:
+   a roll that genuinely drifted needs a re-review either way, while an
+   unchanged one means the re-run was a habit and there is nothing to do. */
+const confirmed = resolve(dirname(out), "censored.json");
+if (!checking) {
+  let signed;
+  try {
+    signed = JSON.parse(await readFile(confirmed, "utf8"));
+  } catch {
+    signed = null;
+  }
+  if (signed && signed.roll_digest !== digest) {
+    console.error(`error: ${confirmed} was signed against a roll this run does not reproduce.`);
+    console.error(`       signed  ${signed.roll_digest}  (${signed.censored}/${signed.reviewed} obscured, by ${signed.confirmed_by})`);
+    console.error(`       now     ${digest}  (${tiles.length} photographs)`);
+    console.error("       the library or the geometry moved, so that review no longer covers the clip.");
+    console.error("       delete both files and review again — there is no partial re-review.");
+    process.exit(1);
+  }
+  if (signed) {
+    console.log(`censored.json is signed against this roll and still stands (${signed.censored}/${signed.reviewed} obscured)`);
+  }
 }
 
 await mkdir(dirname(out), { recursive: true });


### PR DESCRIPTION
Towards #63.

The Panel's recording passes over **73 photographs** of a real personal library. #63 wants the list of which ones get obscured made by looking rather than by a detector. This is that list's machinery and its mechanical half.

**The classifying is not done here, and could not be.** The acceptance criteria are that every photograph was viewed at full size and that *the author* confirmed the result — a model classifying them is the detector the ticket rejects on measured grounds. So this delivers everything up to the looking, and the looking is one command away.

### What is here

| | |
|---|---|
| `design/tools/collect-roll.mjs` | drives the live grid at the recording's geometry, writes the roll |
| `design/censor/roll.json` | the 73 photographs the clip passes over — **committed** |
| `design/censor/review.mjs` + `review.html` | the review surface, and the write that signs the list |
| `design/censor/README.md` | the procedure, and why the decision is a person's |

`censored.json` is deliberately absent: it is written by the review, signed, and committed onto this branch before merge.

### Verified, not assumed

- **The selectors hit exactly the roll.** Checked against the live grid across the clip's scroll range: all 73 match, no tile in the band is missed, nothing outside it is hit. Tiles are targeted by the hash of their own bytes, which is how the vault addresses thumbnails — so the target survives re-sorting, recycling and paging, none of which an index survives.
- **Tile boxes do not move between stops** — 0 of 153 measured — which is what makes keeping a tile's first sighting sound.
- **The guards refuse**: an unsigned list, a list signed against a different roll, an incomplete pass, a mistyped `--check`, and a re-collect that would orphan a signed review.

### Two things #65 will hit

Both found while checking the selectors, both recorded in the README.

1. **The `<style>` element #57 plans to inject the censoring CSS with is refused.** The vault serves `style-src 'self'`; the element's `sheet` comes back null and *no error is thrown* — the page simply does not censor. A constructed stylesheet (`new CSSStyleSheet()` + `adoptedStyleSheets`) works. The same CSP already no-ops record's own `stopSmoothScrolling`, which is built the refused way.
2. **The per-element fallback is wrong here regardless.** The grid recycles tile elements onto new URLs, so an inline `style.filter` hands its blur to the next photograph through the slot and takes it off the one that needed it. A stylesheet rule re-matches on the new `src` and cannot desynchronise.

### Still open on #63

- [ ] Every photograph viewed at full size
- [ ] Each classified
- [x] The list identifies tiles in a form the page can target
- [ ] The author has reviewed and confirmed the list
- [x] Nothing has been captured, encoded or committed

The four unchecked boxes are one review pass: `node design/censor/review.mjs`.
