### PR TITLE
Collect the roll against the stacked grid (#63)

### DIFF
--- a/design/censor/README.md
+++ b/design/censor/README.md
@@ -3,7 +3,7 @@
 Dev-only. Nothing here is served: `.vercelignore` excludes `design/` entirely.
 
 The Projects Panel plays a recording of the photo vault's grid ([#57]). The grid
-holds a real personal library, and the clip passes over 73 photographs of it,
+holds a real personal library, and the clip passes over 84 photographs of it,
 some of which contain identifiable members of the public. This folder is the
 record of which of those are obscured before a single frame is captured, and of
 who signed that decision.
@@ -43,7 +43,7 @@ at the size and in the order the recording shows it. **Click a tile to obscure
 it.** Nothing is obscured until you do, and an empty list is a valid answer.
 
 Hovering or arrowing onto a tile shows it at **1536px** in the preview — eight
-times the 162px it gets in the clip, which is the size the judgement actually
+times the 153px it gets in the clip, which is the size the judgement actually
 needs. Looking is not a step you have to take; it happens as the pointer moves.
 `1:1` shows the preview at its own pixels, and `reveal original` opens the file
 in Explorer for the ones 1536px cannot settle. Space toggles, arrows walk.
@@ -62,7 +62,7 @@ list without the roll it decided about says nothing.
 Automated detection is rejected on measured grounds, not on principle. Intel's
 model card for `face-detection-adas-0001` reports average precision falling from
 94.1% at head heights over 100px to **37.4%** over 10px, against a stated
-operating floor of 90×90 on 1080p. The tiles here are 162×216 and a face inside
+operating floor of 90×90 on 1080p. The tiles here are 153×216 and a face inside
 one is a fraction of that, so a detector would be run squarely in the band where
 its own vendor reports it failing roughly two times in three.
 
@@ -86,6 +86,7 @@ the mosaic is weakened, this list stops being a defence.
 | viewport | 1440×900 | `record/projects/photos/project.toml` |
 | scroll | 0 → 1200 | `record/projects/photos/actions/scroll-peek.overrides.toml` |
 | band | document y ∈ [0, 2100] | scroll range plus one viewport |
+| stacking | **on** | the view the Panel is meant to show off |
 
 The vault sorts newest-first, so importing a single photograph shifts the whole
 roll and the confirmed list silently stops covering the clip. Same if record's
@@ -128,12 +129,45 @@ capture-time stylesheet in [#65] hangs its mosaic on. That stylesheet is [#65]'s
 to write; this folder decides only which tiles it applies to.
 
 The selectors were checked against the live grid rather than assumed: across the
-clip's scroll range they match all 73 tiles in the roll, no tile in the band goes
+clip's scroll range they match every tile in the roll, no tile in the band goes
 unmatched, and nothing outside the roll is hit.
 
-### Two things [#65] will hit applying them
+### The clip must be stacked, and nothing makes that happen by itself
 
-Both were found while checking the above, and both are cheap to design around
+The recording shows the grid **stacked** — frames verified to be the same
+photograph drawn as one tile, each carrying the count it stands for. That is the
+view the Panel exists to show off, and the roll is collected against it.
+
+It is not the default and there is no URL for it. The vault keeps the setting in
+**localStorage** under `photos.stack`, read once at mount, defaulting to
+`{on: false}` (photos `ui/src/lib/stack.js`). It has to be seeded into the
+browser profile before the page's script runs; `collect-roll.mjs` does that with
+Playwright's `addInitScript` and then **checks the DOM that it worked**, refusing
+to write a roll if no tile drew a card.
+
+**record cannot do this today.** Its only page hook is the timeline's
+`evaluate`, which runs after navigation — by then the grid has mounted
+unstacked. Navigating a fresh browser at the URL gets the unstacked grid no
+matter how the operator's own browser is set, because the setting lives in a
+profile and not in the server. Left alone, [#65] will produce a clip that looks
+entirely correct and shows the wrong view — and a roll reviewed against the
+stacked grid does not cover it.
+
+The two are genuinely different rolls, not the same photographs regrouped:
+
+| | stacked | unstacked |
+|---|---|---|
+| photographs in the band | **84** | 73 |
+| tile | 153×216 | 162×216 |
+| drawn as a stack | 35 (42%) | — |
+
+So `stacking` is written into `roll.json` and `--check` compares it like
+geometry. `--stack off` collects the other view for comparison; it is not a
+toss-up between them.
+
+### Two more things [#65] will hit applying them
+
+Both were found while checking the selectors, and both are cheap to design around
 and expensive to discover during a capture.
 
 **A `<style>` element is refused.** The vault serves

--- a/design/censor/roll.json
+++ b/design/censor/roll.json
@@ -7,588 +7,677 @@
   },
   "distance": 1200,
   "band": 2100,
-  "roll_digest": "3b968f3ea171e148fb2d82196a5a590e37315a359a09a99a67013290026e2115",
+  "stacking": true,
+  "roll_digest": "e7e9362c51b09e009137200cda34deafe8c46ba0b4a64808693b14ee413a9b65",
   "tiles": [
     {
-      "sha": "0d66290eeef2929f556afcd04eb914b66608dde5e65daf8c700f6d1215ead6d8",
+      "sha": "b5d377028d775dfc2be40cca2d65ada4d4f3c5b21755d81b1b0a51f534122cdd",
       "index": 0,
       "top": 96,
       "left": 14,
-      "width": 162,
-      "height": 216
-    },
-    {
-      "sha": "b5d377028d775dfc2be40cca2d65ada4d4f3c5b21755d81b1b0a51f534122cdd",
-      "index": 1,
-      "top": 96,
-      "left": 180,
-      "width": 162,
-      "height": 216
-    },
-    {
-      "sha": "bbd61b9120d8e6a9d633dc15e8c4df7eaa3fee5f87519ac4ea0cfdb5c0c26cce",
-      "index": 2,
-      "top": 96,
-      "left": 346,
-      "width": 162,
-      "height": 216
+      "width": 153,
+      "height": 204
     },
     {
       "sha": "89536239359ee01e831d7d62e508e50a23f35d14f1ed2a4f2259a56df4238d9f",
-      "index": 3,
+      "index": 1,
       "top": 96,
-      "left": 512,
-      "width": 162,
-      "height": 216
-    },
-    {
-      "sha": "2128157cac21f1caee8815c00776a2f8175d7be1a4dfd7af8a6b8ec45279cba7",
-      "index": 4,
-      "top": 96,
-      "left": 678,
-      "width": 162,
-      "height": 216
+      "left": 171,
+      "width": 153,
+      "height": 204
     },
     {
       "sha": "774832865eb6a8aaaad68c397b73005aac6896c62a7167b2d077fa981bbc6ae3",
-      "index": 5,
+      "index": 2,
       "top": 96,
-      "left": 844,
-      "width": 288,
-      "height": 216
+      "left": 328,
+      "width": 272,
+      "height": 204
     },
     {
       "sha": "0a1429266cdc213cdc6c5a039f887c8312e8ff6cf111681f1882585affcb469d",
-      "index": 6,
+      "index": 3,
       "top": 96,
-      "left": 1136,
-      "width": 290,
-      "height": 216
+      "left": 604,
+      "width": 272,
+      "height": 204
     },
     {
       "sha": "23c34f99af74284413fedc8a2773052533fc512b765399008ca3c7b6c516fcc0",
-      "index": 7,
-      "top": 328,
-      "left": 14,
-      "width": 280,
-      "height": 210
+      "index": 4,
+      "top": 96,
+      "left": 880,
+      "width": 272,
+      "height": 204
     },
     {
       "sha": "39cd43e47cc10c73c4042ccc040de6bb1793fb05c9b8f198a8eb91df9f3d6cfb",
-      "index": 8,
-      "top": 328,
-      "left": 298,
-      "width": 280,
-      "height": 210
-    },
-    {
-      "sha": "886e7d6848e88f27520ef4e3eec436953059c618bf538e9f6655bcc1738f03a5",
-      "index": 9,
-      "top": 328,
-      "left": 582,
-      "width": 280,
-      "height": 210
-    },
-    {
-      "sha": "0db0c95eb8e268a4094d52e419491903da75f724bdf503f3307c642a7ecfece9",
-      "index": 10,
-      "top": 328,
-      "left": 866,
-      "width": 280,
-      "height": 210
+      "index": 5,
+      "top": 96,
+      "left": 1156,
+      "width": 270,
+      "height": 204
     },
     {
       "sha": "ebf79cd7d69613cf3c289359067efd5d08057178fbfe140c1987791e2e048f20",
-      "index": 11,
-      "top": 328,
-      "left": 1150,
-      "width": 276,
-      "height": 210
-    },
-    {
-      "sha": "cbf8472b07784401e19d5dbbb77a2afd2deec782d30ab2be61169cf4664da730",
-      "index": 12,
-      "top": 554,
+      "index": 6,
+      "top": 316,
       "left": 14,
       "width": 288,
       "height": 216
     },
     {
       "sha": "a68b3d983ccc4d7d3c04cbb1e39544dd4d3c6a3ec258d4de550470c13180141f",
-      "index": 13,
-      "top": 554,
+      "index": 7,
+      "top": 316,
       "left": 306,
       "width": 288,
       "height": 216
     },
     {
       "sha": "2b12312e60abab65be7d4f87dad29c233ae342777b440653a8e80ac78df093f2",
-      "index": 14,
-      "top": 554,
+      "index": 8,
+      "top": 316,
       "left": 598,
       "width": 162,
       "height": 216
     },
     {
       "sha": "c4daabdbe0a1cb25af5c9e143a5561ad2c06b006b82b929ad856763268c38eac",
-      "index": 15,
-      "top": 554,
+      "index": 9,
+      "top": 316,
       "left": 764,
       "width": 162,
       "height": 216
     },
     {
       "sha": "60c3f14a957b19c43df4f00404cf0008b859a787ca07c4e59c18ad61c8433833",
-      "index": 16,
-      "top": 554,
+      "index": 10,
+      "top": 316,
       "left": 930,
       "width": 162,
       "height": 216
     },
     {
       "sha": "20ebfe85ab950530eb95a7876540c2183f65dc5b051cb4fb23af1d8b72d5ee48",
-      "index": 17,
-      "top": 554,
+      "index": 11,
+      "top": 316,
       "left": 1096,
       "width": 162,
       "height": 216
     },
     {
       "sha": "c05add34ea277ae19c09e38680a3dd8a91288ec55238b3ef060f7902c685fd5d",
-      "index": 18,
-      "top": 554,
+      "index": 12,
+      "top": 316,
       "left": 1262,
       "width": 164,
       "height": 216
     },
     {
       "sha": "8428637a361801b6324ed14bf3266cf8d78d49d06e2a3a63c1623cd74ff5246a",
-      "index": 19,
-      "top": 786,
+      "index": 13,
+      "top": 548,
       "left": 14,
       "width": 153,
       "height": 204
     },
     {
       "sha": "92aaf8e274fe68801e9dba76fd1e0f33dff9841b7ec87820533ccb1f7932d6bc",
-      "index": 20,
-      "top": 786,
+      "index": 14,
+      "top": 548,
       "left": 171,
       "width": 153,
-      "height": 204
-    },
-    {
-      "sha": "8bcb4a802a33ce7eed0e0d70e58b9528dcf4a50dd253187168802a883349db6c",
-      "index": 21,
-      "top": 786,
-      "left": 328,
-      "width": 153,
-      "height": 204
-    },
-    {
-      "sha": "93ad723c921c2863b18de88932ea26a7e1ec829764a81cab17ca9efbfb8cf2ad",
-      "index": 22,
-      "top": 786,
-      "left": 485,
-      "width": 153,
-      "height": 204
-    },
-    {
-      "sha": "9affc9fbea6ad456364c5820ff3db1e119010d3a768da3d92c556f151e026e2b",
-      "index": 23,
-      "top": 786,
-      "left": 642,
-      "width": 153,
-      "height": 204
-    },
-    {
-      "sha": "970124a5fad48ba2a86fa380d9796660c6d25902c34afd5f2871fa08b40994c4",
-      "index": 24,
-      "top": 786,
-      "left": 799,
-      "width": 153,
-      "height": 204
-    },
-    {
-      "sha": "902818fd5c18a088721ae4a4e80ef2d9156ad7a4eb5708e73cec64218617a4df",
-      "index": 25,
-      "top": 786,
-      "left": 956,
-      "width": 153,
-      "height": 204
-    },
-    {
-      "sha": "6cadd29949b20cd5d5bdc6455befeb2025cb330f173510ff71c4ad2b2b198b65",
-      "index": 26,
-      "top": 786,
-      "left": 1113,
-      "width": 153,
-      "height": 204
-    },
-    {
-      "sha": "b50866ee82e1503ec6f1ed3558a5fcae27e6ee9f47e50db46fd7be2d5bc672f2",
-      "index": 27,
-      "top": 786,
-      "left": 1270,
-      "width": 156,
       "height": 204
     },
     {
       "sha": "147d346fd1b32e66675cc483d19d667a17546639bcb4e3418e07d9e23139f2b9",
-      "index": 28,
-      "top": 1006,
-      "left": 14,
-      "width": 153,
-      "height": 204
-    },
-    {
-      "sha": "ed9128f59a7fc7e9e3a8521e281961edd9badc58d6a3a1bcabcb2185ec88be81",
-      "index": 29,
-      "top": 1006,
-      "left": 171,
-      "width": 153,
-      "height": 204
-    },
-    {
-      "sha": "2ea18be79348c466d8d6d9822c0702fd37e120bf0449cb167d89a41df860ef49",
-      "index": 30,
-      "top": 1006,
+      "index": 15,
+      "top": 548,
       "left": 328,
-      "width": 153,
-      "height": 204
-    },
-    {
-      "sha": "cbc4a29a6464613d29daf3aa334fd8660ba4e9a60d90f377c54cc40830ff63d1",
-      "index": 31,
-      "top": 1006,
-      "left": 485,
-      "width": 153,
-      "height": 204
-    },
-    {
-      "sha": "79b24413c88c08335aa291afde900f6925ad6a6b1cdf6a56137401e41521cd14",
-      "index": 32,
-      "top": 1006,
-      "left": 642,
-      "width": 153,
-      "height": 204
-    },
-    {
-      "sha": "b3949f164181d8c39b4e3900d2ec04e8d7bdbbce71702aeb4905150a1ef20cc6",
-      "index": 33,
-      "top": 1006,
-      "left": 799,
-      "width": 153,
-      "height": 204
-    },
-    {
-      "sha": "8834826bfa74672c777a9074cb5f9f3b401ce368cc8347148ddbc8fcc8f1a4a7",
-      "index": 34,
-      "top": 1006,
-      "left": 956,
-      "width": 153,
-      "height": 204
-    },
-    {
-      "sha": "dea7f09083c8597c5487eebb196bfa75d3af5e8a4165ebd5c6eea9184e1d0d00",
-      "index": 35,
-      "top": 1006,
-      "left": 1113,
-      "width": 153,
-      "height": 204
-    },
-    {
-      "sha": "b520d9128e90f813fd31f26d0ce82ad01499214e50af0bc2d3cf7a50e3536721",
-      "index": 36,
-      "top": 1006,
-      "left": 1270,
-      "width": 156,
-      "height": 204
-    },
-    {
-      "sha": "c1a4146771f2c0741b09857855966f17ce526a010978ac0d3312acaa81cae0cc",
-      "index": 37,
-      "top": 1226,
-      "left": 14,
       "width": 153,
       "height": 204
     },
     {
       "sha": "2f6e5844a933addb06c1b4e9fbde21457a896cc9d51016c1a07988d527f8abcb",
-      "index": 38,
-      "top": 1226,
-      "left": 171,
-      "width": 153,
-      "height": 204
-    },
-    {
-      "sha": "5c536cdb47f84d53e62718778a501654305d8befc96a2e37bc412f1e11a52fbc",
-      "index": 39,
-      "top": 1226,
-      "left": 328,
+      "index": 16,
+      "top": 548,
+      "left": 485,
       "width": 153,
       "height": 204
     },
     {
       "sha": "2c0607f1732c48809cfed512c20be13494a0ee8bb84308bc1bcefd72886dd30a",
-      "index": 40,
-      "top": 1226,
-      "left": 485,
+      "index": 17,
+      "top": 548,
+      "left": 642,
       "width": 153,
       "height": 204
     },
     {
       "sha": "c8b9a0b4da8bc4306091a4b5d13828697322ac0e696594adf252e5f72ea72778",
-      "index": 41,
-      "top": 1226,
-      "left": 642,
-      "width": 153,
-      "height": 204
-    },
-    {
-      "sha": "6ec9f56869cbdfb319f1ee4e94380331837de2918548b7e7eb8737b49fb354e1",
-      "index": 42,
-      "top": 1226,
+      "index": 18,
+      "top": 548,
       "left": 799,
-      "width": 153,
-      "height": 204
-    },
-    {
-      "sha": "1301709ef701bf29898ce7d505c2be5e53a0fff4cc08bcfb52f69017dc6a0587",
-      "index": 43,
-      "top": 1226,
-      "left": 956,
-      "width": 153,
-      "height": 204
-    },
-    {
-      "sha": "98d4700e11e602a71cdd784ab7cda7167fa83e17f26979e39b198c7da7c1db4d",
-      "index": 44,
-      "top": 1226,
-      "left": 1113,
-      "width": 153,
-      "height": 204
-    },
-    {
-      "sha": "89d6235574f651fdd96e949c83e5910ed8313ca3cf9d1680382cff66100345cf",
-      "index": 45,
-      "top": 1226,
-      "left": 1270,
-      "width": 156,
-      "height": 204
-    },
-    {
-      "sha": "e9c1faa35128f63479963f96ad4cc5f6cf2a23b1c0aba06646136df9f33983c8",
-      "index": 46,
-      "top": 1446,
-      "left": 14,
       "width": 153,
       "height": 204
     },
     {
       "sha": "898cf5d314f51257e0884fcb77723cbc2a12bbbeceb7526f4f5588435d1f50a4",
-      "index": 47,
-      "top": 1446,
-      "left": 171,
-      "width": 153,
-      "height": 204
-    },
-    {
-      "sha": "b3b5ec51deaad446c1414f2dacf28265ed6e5f4ddfc997d02e4fec20a2d03082",
-      "index": 48,
-      "top": 1446,
-      "left": 328,
-      "width": 153,
-      "height": 204
-    },
-    {
-      "sha": "f6314d9332a2d196cb0dc89667086dae6be81dc39b4880e0b662538e99220224",
-      "index": 49,
-      "top": 1446,
-      "left": 485,
-      "width": 153,
-      "height": 204
-    },
-    {
-      "sha": "081380a4d44f8f390b716b8bb4a7e1f2370add7f689597a38a0872907559486b",
-      "index": 50,
-      "top": 1446,
-      "left": 642,
-      "width": 153,
-      "height": 204
-    },
-    {
-      "sha": "f9537208acf976baac7d61f8c0a8eabed09bcb39a8e164735ba995fe7f1c07c0",
-      "index": 51,
-      "top": 1446,
-      "left": 799,
+      "index": 19,
+      "top": 548,
+      "left": 956,
       "width": 153,
       "height": 204
     },
     {
       "sha": "4944f0019e720c7af46191d4e1f4e0b98eec2855dcc5280f5ffb1cf05e9f0f92",
-      "index": 52,
-      "top": 1446,
-      "left": 956,
-      "width": 153,
-      "height": 204
-    },
-    {
-      "sha": "502a51b07c59c4cf4256529d00d07bbfb8b6f6ed56cde44c77ae6d5c4cbca0de",
-      "index": 53,
-      "top": 1446,
+      "index": 20,
+      "top": 548,
       "left": 1113,
       "width": 153,
       "height": 204
     },
     {
-      "sha": "58229acfa2efb0690c3dc50d382b1b58793b7516cd11bbf4a712fc42cdf37c72",
-      "index": 54,
-      "top": 1446,
+      "sha": "e59dc5f324dc5d749275a001131ee86c90e1b3e2599a18920ab74749272c5656",
+      "index": 21,
+      "top": 548,
       "left": 1270,
       "width": 156,
       "height": 204
     },
     {
-      "sha": "e59dc5f324dc5d749275a001131ee86c90e1b3e2599a18920ab74749272c5656",
-      "index": 55,
-      "top": 1666,
-      "left": 14,
-      "width": 153,
-      "height": 204
-    },
-    {
-      "sha": "6d21dc8e83ca3fe5cc4229e16e59531b1e8aaf5203053dd29467e708205c79b4",
-      "index": 56,
-      "top": 1666,
-      "left": 171,
-      "width": 153,
-      "height": 204
-    },
-    {
-      "sha": "5ab82a1e59a712431c1dcbc0018f0d8e66370f2cc1a4cebc48788d106c891679",
-      "index": 57,
-      "top": 1666,
-      "left": 328,
-      "width": 153,
-      "height": 204
-    },
-    {
       "sha": "8660e1cfcf16102b34352f181a5ef0d9c6034e5cd8b89701ef70cdeeebdd567f",
-      "index": 58,
-      "top": 1666,
-      "left": 485,
+      "index": 22,
+      "top": 768,
+      "left": 14,
       "width": 153,
       "height": 204
     },
     {
       "sha": "b78f3ed214a35ecab2d5878783013850603bf820d10609801213ef283e8c11aa",
-      "index": 59,
-      "top": 1666,
-      "left": 642,
-      "width": 153,
-      "height": 204
-    },
-    {
-      "sha": "ccbe1494b63d4b8d20fd03b4aa2af43679ee51bc122aeef263a2063706c31bac",
-      "index": 60,
-      "top": 1666,
-      "left": 799,
-      "width": 153,
-      "height": 204
-    },
-    {
-      "sha": "d787a5892e6318a40db2874a99966a21aab5638fc48107b9ee618baf7c833672",
-      "index": 61,
-      "top": 1666,
-      "left": 956,
-      "width": 153,
-      "height": 204
-    },
-    {
-      "sha": "273262739caa093cbeb3df8e12283efa9b1576b575e662a966462e7eb3b3aa9b",
-      "index": 62,
-      "top": 1666,
-      "left": 1113,
-      "width": 153,
-      "height": 204
-    },
-    {
-      "sha": "e4ff5867baa423f3416b1250dbc0fda5fa66e339a389e64000c2bc329970abba",
-      "index": 63,
-      "top": 1666,
-      "left": 1270,
-      "width": 156,
-      "height": 204
-    },
-    {
-      "sha": "5c7abd5baa3bd07fff251a2c45266b09ca2c661687cf78c5f48a6cbd6c9597b8",
-      "index": 64,
-      "top": 1886,
-      "left": 14,
-      "width": 153,
-      "height": 204
-    },
-    {
-      "sha": "407a21d9a12077f3d24832ed676cd698a1515d0f03692442109058357ebefc0b",
-      "index": 65,
-      "top": 1886,
+      "index": 23,
+      "top": 768,
       "left": 171,
       "width": 153,
       "height": 204
     },
     {
-      "sha": "6baa3c35457ce6cb3d6cf883db6af33342997b392b7445fe4b4869fc1bc12ade",
-      "index": 66,
-      "top": 1886,
+      "sha": "d787a5892e6318a40db2874a99966a21aab5638fc48107b9ee618baf7c833672",
+      "index": 24,
+      "top": 768,
       "left": 328,
       "width": 153,
       "height": 204
     },
     {
-      "sha": "18fabd232494fda5b1432db3f0ab829593b256573bb5533741245c404cbbf4b0",
-      "index": 67,
-      "top": 1886,
+      "sha": "6baa3c35457ce6cb3d6cf883db6af33342997b392b7445fe4b4869fc1bc12ade",
+      "index": 25,
+      "top": 768,
       "left": 485,
       "width": 153,
       "height": 204
     },
     {
-      "sha": "26c1dbb0cbfb5952c352c04c623d183bc6b0f0f59fb50f7c3105ff4ac0b6deac",
-      "index": 68,
-      "top": 1886,
+      "sha": "18fabd232494fda5b1432db3f0ab829593b256573bb5533741245c404cbbf4b0",
+      "index": 26,
+      "top": 768,
       "left": 642,
       "width": 153,
       "height": 204
     },
     {
-      "sha": "5dc0e7232671a7147bfadeafb38523b6be46c504bc1f60bf03cefc9a3fc8da74",
-      "index": 69,
-      "top": 1886,
+      "sha": "26c1dbb0cbfb5952c352c04c623d183bc6b0f0f59fb50f7c3105ff4ac0b6deac",
+      "index": 27,
+      "top": 768,
       "left": 799,
       "width": 153,
       "height": 204
     },
     {
-      "sha": "cdd3b16f1a8d41dcf4d86ca4a884cd3a26284d619b918e01eabaa1d72e3eaedf",
-      "index": 70,
-      "top": 1886,
+      "sha": "5dc0e7232671a7147bfadeafb38523b6be46c504bc1f60bf03cefc9a3fc8da74",
+      "index": 28,
+      "top": 768,
       "left": 956,
       "width": 153,
       "height": 204
     },
     {
-      "sha": "bda2d29776363db0e2941ce2423de190ec04c6768c122ef4bcc683cc29314518",
-      "index": 71,
-      "top": 1886,
+      "sha": "cdd3b16f1a8d41dcf4d86ca4a884cd3a26284d619b918e01eabaa1d72e3eaedf",
+      "index": 29,
+      "top": 768,
       "left": 1113,
       "width": 153,
       "height": 204
     },
     {
+      "sha": "bda2d29776363db0e2941ce2423de190ec04c6768c122ef4bcc683cc29314518",
+      "index": 30,
+      "top": 768,
+      "left": 1270,
+      "width": 156,
+      "height": 204
+    },
+    {
       "sha": "5d7a8bdb5fbeea322b67117d4f587f9f222ce731437a18f5e83abf3fd1b36ee1",
+      "index": 31,
+      "top": 988,
+      "left": 14,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "646c94dfe9df2f4d40763e82c32b057b32a53894089c37dfd2e81ba4a42c472a",
+      "index": 32,
+      "top": 988,
+      "left": 171,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "47f63c01dacca71ab23a5415dd551b84797649208c0cec34fc6c80efc336745c",
+      "index": 33,
+      "top": 988,
+      "left": 328,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "89a2e07d9aab602a281ffad322d1cb40a15535ce310fe6c7064104be0c4afc5b",
+      "index": 34,
+      "top": 988,
+      "left": 485,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "dcc0b712d21ea0241cf91df04777bd30d1f95dc894a9e70049f52bc8ad5f1e02",
+      "index": 35,
+      "top": 988,
+      "left": 642,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "62e2ef2a35aff6f4478086b827a75bd8a6d5429f856dfa7963c10de8ddcedaa6",
+      "index": 36,
+      "top": 988,
+      "left": 799,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "f7b47b5ebc84c9b0a3984736886dacc3254edadc1c5b8f2f61275150f86de381",
+      "index": 37,
+      "top": 988,
+      "left": 956,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "a7dad358fa521cb7aa771a92abcedf4f3281ccb2017516fadfd0d8f590429a72",
+      "index": 38,
+      "top": 988,
+      "left": 1113,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "0a77a5886e3704612e1dcef2d547b1ee1969df35a25b781100576f73737201b4",
+      "index": 39,
+      "top": 988,
+      "left": 1270,
+      "width": 156,
+      "height": 204
+    },
+    {
+      "sha": "de19300e733d3a0f1bb68dc417c854d92d86a44c01fe2e88fc4fdd4f59505fb1",
+      "index": 40,
+      "top": 1208,
+      "left": 14,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "0b0e909bd227b7d913cbe25eaaf41606aae0b43da1ed9b4544586c300ed4b7f9",
+      "index": 41,
+      "top": 1208,
+      "left": 171,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "8fa7a0a0bdd2b35d30f9431cc69bcfa569669881a54ac4440a4fd8ae3238a728",
+      "index": 42,
+      "top": 1208,
+      "left": 328,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "bec1013a6184923a567d9c1c888ef463aa10d33e8f70d0c0ad646a8d13966b90",
+      "index": 43,
+      "top": 1208,
+      "left": 485,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "949b6f3a35379378787b7271c0587874dabbb4576fe7d9192755d1153f2cb7d7",
+      "index": 44,
+      "top": 1208,
+      "left": 642,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "e587ca45ff709467a6f97ef708b2fddc3f905922987dc5250efb3684539e8568",
+      "index": 45,
+      "top": 1208,
+      "left": 799,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "7514ed54809837846faf1b3dce9f0fa8804dc061ec3d0e9f2a1fbb91b2a4e248",
+      "index": 46,
+      "top": 1208,
+      "left": 956,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "e918cedafb9f3fc6f6a1c12a142e8c97989f9deb2b2de0712c3f2722d1fff2df",
+      "index": 47,
+      "top": 1208,
+      "left": 1113,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "7c873521699be30a45fff0672714dd296cb0ff4580bc2a66ac5da2d112662853",
+      "index": 48,
+      "top": 1208,
+      "left": 1270,
+      "width": 156,
+      "height": 204
+    },
+    {
+      "sha": "e3831057195f97df867355c6dda910c050d25f50783ceebdd0f7f6d4b4195aa8",
+      "index": 49,
+      "top": 1428,
+      "left": 14,
+      "width": 280,
+      "height": 210
+    },
+    {
+      "sha": "ee7d70ad3a1b723604c1c0d902a85f6f46d96e6dbe1649f678937d2a71e658f1",
+      "index": 50,
+      "top": 1428,
+      "left": 298,
+      "width": 158,
+      "height": 210
+    },
+    {
+      "sha": "6394221fa9e9d7d754a78d35eb1f1aa14de03a766f0cc55bc1b8a32a6ffd8c2e",
+      "index": 51,
+      "top": 1428,
+      "left": 460,
+      "width": 158,
+      "height": 210
+    },
+    {
+      "sha": "87563db123aa9ef8c8edee1bc16ecbffa9d75d8eccd58d7df2adb0b255d345b9",
+      "index": 52,
+      "top": 1428,
+      "left": 622,
+      "width": 158,
+      "height": 210
+    },
+    {
+      "sha": "d478cc69f217ce54846d99c80cbcd8d7c7fb99b4c836bd60449a784bbcd9b048",
+      "index": 53,
+      "top": 1428,
+      "left": 784,
+      "width": 158,
+      "height": 210
+    },
+    {
+      "sha": "ebd54278ac69f33970a31930a536259f74658262499fa05bcc0822dde2525878",
+      "index": 54,
+      "top": 1428,
+      "left": 946,
+      "width": 158,
+      "height": 210
+    },
+    {
+      "sha": "ca74298187ae9df2838c466209b1648df84538e7ae9c2a079b1ef9d4bc05eab8",
+      "index": 55,
+      "top": 1428,
+      "left": 1108,
+      "width": 158,
+      "height": 210
+    },
+    {
+      "sha": "8a98bc27e1e109e97ee1732f909a88010334a8696ac356ebe37ad8a006ad170c",
+      "index": 56,
+      "top": 1428,
+      "left": 1270,
+      "width": 156,
+      "height": 210
+    },
+    {
+      "sha": "a0a8148faae052d4926e20cefd12ccaed346d1d57b1c38103eddc7f3a51a39be",
+      "index": 57,
+      "top": 1654,
+      "left": 14,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "530694eeca1b60d08c27670cd71d5655c515976648c4aab535f5d279878b5ba4",
+      "index": 58,
+      "top": 1654,
+      "left": 171,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "4623c895d764585b0375295edf89f9a8e038d1019b3419cf6d9292fd3b110e75",
+      "index": 59,
+      "top": 1654,
+      "left": 328,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "b8abd98cdb65fb7940d574cb4aa06e18b142617399ae59598604394c0d9524ab",
+      "index": 60,
+      "top": 1654,
+      "left": 485,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "427baa8894cbccea31cda29497748c7c4a2f3197ae329d537398662efb611296",
+      "index": 61,
+      "top": 1654,
+      "left": 642,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "9b0e5f4c2277526400c99e62d390ef976f884a4ec07e358af13a2cc96bcedee0",
+      "index": 62,
+      "top": 1654,
+      "left": 799,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "c0874d17d8fd9db929218c77d1734209a5ca5601ff1d9e7e2ef3472f230d7c1b",
+      "index": 63,
+      "top": 1654,
+      "left": 956,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "289c5c7717d7d742dd9f6a306a9ff8e1a8d122733b19dcce87fb17ec9172ed2e",
+      "index": 64,
+      "top": 1654,
+      "left": 1113,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "e1f6630b21576dea48d7bab6e6e26f071c2cf3d4b7e0b63fc6a3d3a6180ff9be",
+      "index": 65,
+      "top": 1654,
+      "left": 1270,
+      "width": 156,
+      "height": 204
+    },
+    {
+      "sha": "3e0f4b8d9684f8ff7d475d7177060371b577fd189287486a19ef83a475a6c7ae",
+      "index": 66,
+      "top": 1874,
+      "left": 14,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "6fb29c2cb60aabf84847f7b23b7d0f70b3c0baf8078318511901b4a45a9ed022",
+      "index": 67,
+      "top": 1874,
+      "left": 171,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "fb522dd9c495f079a577e1018a558ac08926b09cfee23585e8cfb1725a0cc0a8",
+      "index": 68,
+      "top": 1874,
+      "left": 328,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "1cdfe51f1187a044739e4db5a8e8998e0c8b5251c3f2ec16ec40790e605ccdbe",
+      "index": 69,
+      "top": 1874,
+      "left": 485,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "decb11974936e859f7646afff1b822f97ca4b79d429722830f844c07cd4ce17e",
+      "index": 70,
+      "top": 1874,
+      "left": 642,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "874fef955a87884034089e14a06fa258d28558c02705039c8df949fcd8b32ca9",
+      "index": 71,
+      "top": 1874,
+      "left": 799,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "1e3ba87ce82013b496120910de97f3c1d422d373fc2987cff8bb03ee0e60bf5c",
       "index": 72,
-      "top": 1886,
+      "top": 1874,
+      "left": 956,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "d7f40e55733c6f71f429ae31119f039e55994ded70ef1836bd42be0631f301dc",
+      "index": 73,
+      "top": 1874,
+      "left": 1113,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "db6c4e15c8654f293402342c51b5d589d69a5613ea3f763fb69ee30bc38232e3",
+      "index": 74,
+      "top": 1874,
+      "left": 1270,
+      "width": 156,
+      "height": 204
+    },
+    {
+      "sha": "e38cf628dc1a492df1404949591740465c2450abfce8f4afcd76331bbe4c0523",
+      "index": 75,
+      "top": 2094,
+      "left": 14,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "a1d4d874eff4d7a224536adc99f60b8ea20b8bfe45dedb48ca74e81245261788",
+      "index": 76,
+      "top": 2094,
+      "left": 171,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "8b8b7961dea84acd549ba21cacbe92e46ef7977f5ceeff4373eca0c96a05bd8a",
+      "index": 77,
+      "top": 2094,
+      "left": 328,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "91d16111e68552838e3b553c271f3696597bff1710dcf25192f3bd08cdf08b6f",
+      "index": 78,
+      "top": 2094,
+      "left": 485,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "0181374dc03d29506a76d0142df43903a0324045138e8b153c5b87fbc4a2b192",
+      "index": 79,
+      "top": 2094,
+      "left": 642,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "688d2ae924d6000efb9aebc07293ecd61e2a1b625f30d941425daba34672b561",
+      "index": 80,
+      "top": 2094,
+      "left": 799,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "b1a6d08f7c08bd5d64d1929a71f1b9a16f6d88562e8bf80ba5de5460d661d33d",
+      "index": 81,
+      "top": 2094,
+      "left": 956,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "3fd7df6c270b37e3d76d3fbe04d3f99fddc089b6b142619e4483ede66da4588d",
+      "index": 82,
+      "top": 2094,
+      "left": 1113,
+      "width": 153,
+      "height": 204
+    },
+    {
+      "sha": "41103f61808ef7921612df3fa7a2a584ff63911317118f824d9757778bcbd58a",
+      "index": 83,
+      "top": 2094,
       "left": 1270,
       "width": 156,
       "height": 204

--- a/design/tools/collect-roll.mjs
+++ b/design/tools/collect-roll.mjs
@@ -41,6 +41,30 @@
    written into roll.json, and --check reports a roll assembled at a geometry
    that no longer matches. If record's viewport or distance changes, re-run.
 
+   STACKING, AND WHY IT HAS TO BE SEEDED
+   --------------------------------------
+   The clip shows the grid **stacked** — frames verified to be the same
+   photograph drawn as one tile, which is the view the Panel is meant to show
+   off. That is not a default and not a URL parameter. The vault keeps it in
+   localStorage under `photos.stack`, read once at mount (photos
+   ui/src/lib/stack.js), and its default is `{on: false}`.
+
+   So it has to be seeded into the browser profile BEFORE the page's script
+   runs, which is what addInitScript below does. Any fresh browser that merely
+   navigates to the URL gets the unstacked grid, however the operator's own
+   browser is set — the setting lives in a profile, not in the server.
+
+   Stacked and unstacked are genuinely different rolls, not the same
+   photographs regrouped: 84 tiles against 73, at 153x216 against 162x216,
+   because the justified rows lay out over a different set of aspect ratios.
+   A roll collected one way does not cover a clip captured the other, so
+   `stacking` is written into roll.json and --check compares it like geometry.
+
+   **record cannot do this yet.** Its only page hook is the timeline's
+   `evaluate`, which runs after navigation — too late, since the grid has
+   already mounted unstacked. See design/censor/README.md; this is the thing
+   most likely to produce a correct-looking clip of the wrong view.
+
    WHAT COUNTS AS "PASSED OVER"
    -----------------------------
    The band of the document the camera ever sees is [0, distance + height] —
@@ -69,6 +93,12 @@ const GRID_URL = "http://127.0.0.1:8770/";
 const VIEWPORT = { width: 1440, height: 900 };
 const DISTANCE = 1200;
 
+/* The vault's own key and its own shape — the two knobs stay null, meaning
+   "whichever assignment the server is pointed at", which is what the grid opens
+   at when the reader has never moved them. */
+const STACK_KEY = "photos.stack";
+const STACK_ON = JSON.stringify({ on: true, strictness: null, linkage: null });
+
 /* How far apart the stops are. Only has to be fine enough that the sheet mounts
    every tile in the band on the way past — the band test itself is exact — so
    this is well under a viewport rather than near one. */
@@ -94,7 +124,7 @@ const opt = args(process.argv.slice(2));
    the roll. So a mistyped drift check would replace the roll a confirmed list
    was signed against and report success, which is the one thing this file must
    not do quietly. Fail on anything unrecognised rather than fall through. */
-const KNOWN = new Set(["url", "width", "height", "distance", "out", "check"]);
+const KNOWN = new Set(["url", "width", "height", "distance", "out", "check", "stack"]);
 const unknown = Object.keys(opt).filter((key) => !KNOWN.has(key));
 if (unknown.length) {
   console.error(`error: unknown flag${unknown.length > 1 ? "s" : ""} ${unknown.map((k) => `--${k}`).join(", ")}`);
@@ -108,6 +138,14 @@ const height = Number(opt.height || VIEWPORT.height);
 const distance = Number(opt.distance || DISTANCE);
 const out = resolve(opt.out ? opt.out : resolve(HERE, "..", "censor", "roll.json"));
 const checking = opt.check === "true";
+
+/* Stacked is the default because stacked is what the clip shows. `--stack off`
+   is here so the two views can be compared, not because either is a toss-up. */
+if (opt.stack !== undefined && opt.stack !== "on" && opt.stack !== "off") {
+  console.error(`error: --stack takes "on" or "off", not "${opt.stack}"`);
+  process.exit(2);
+}
+const stacking = opt.stack !== "off";
 
 const band = distance + height;
 
@@ -152,7 +190,16 @@ const COLLECT = `
       const src = img && img.getAttribute("src");
       const match = src && src.match(/([0-9a-f]{64})\\.webp$/);
       if (!match) continue;
-      const box = tile.getBoundingClientRect();
+      /* The photograph's box, not the tile element's. A stacked tile is taller
+         than its picture — the deck draws a sliver of each extra member above
+         it — while the tile-photo child frames the picture exactly where an
+         unstacked tile in the same row frames its own. So the element's top
+         varies within a row by how many members a stack has, and the
+         photograph's does not. This is the box that answers both questions
+         asked of it: what the reader actually sees, and which tiles share a
+         row. (No backticks in here — this whole expression is a template
+         literal, and one would end it.) */
+      const box = (tile.querySelector(".tile-photo") ?? tile).getBoundingClientRect();
       found.push({
         sha: match[1],
         index: Number(tile.dataset.index),
@@ -168,13 +215,25 @@ const COLLECT = `
 
 async function collect() {
   const browser = await chromium.launch();
-  const page = await browser.newPage({
+  /* A context rather than a bare page, because the stacking setting has to be in
+     localStorage before the app's module runs and addInitScript is the only hook
+     that early. */
+  const context = await browser.newContext({
     viewport: { width, height },
     deviceScaleFactor: 1,
   });
+  if (stacking) {
+    await context.addInitScript(`localStorage.setItem(${JSON.stringify(STACK_KEY)}, ${JSON.stringify(STACK_ON)})`);
+  }
+  const page = await context.newPage();
   try {
     await page.goto(url, { waitUntil: "domcontentloaded" });
     await page.waitForSelector(".tile", { timeout: 30_000 });
+    /* Stacked rows are laid out from an assignment the client asks for after
+       mount, so the first tiles on screen can be the unstacked ones for a beat.
+       Collecting those would put photographs in the roll that the clip never
+       shows, and — worse — miss the covers that replace them. */
+    await page.waitForTimeout(1500);
     await page.evaluate(STOP_SMOOTH_SCROLLING);
     await page.evaluate(FIND_SCROLLER);
 
@@ -208,7 +267,16 @@ async function collect() {
       .filter((t) => t.top < band && t.top + t.height > 0)
       .sort((a, b) => a.top - b.top || a.left - b.left);
 
-    return { tiles: inBand, mounted: seen.size };
+    /* Whether stacking actually engaged, asked of the DOM rather than assumed
+       from having set the key — the same instinct render.mjs applies to fonts.
+       A tile draws a card per extra member, so a visible card is the grid
+       saying it is stacked. Without this a renamed key upstream would seed
+       nothing, collect a perfectly good unstacked roll, and say nothing. */
+    const decks = await page.evaluate(
+      `document.querySelectorAll(".tile .card:not([hidden])").length`,
+    );
+
+    return { tiles: inBand, mounted: seen.size, decks };
   } finally {
     await browser.close();
   }
@@ -221,8 +289,16 @@ async function collect() {
 const digestOf = (tiles) =>
   createHash("sha256").update(tiles.map((t) => t.sha).join("\n")).digest("hex");
 
-const { tiles, mounted } = await collect();
+const { tiles, mounted, decks } = await collect();
 const digest = digestOf(tiles);
+
+if (stacking && decks === 0) {
+  console.error("error: asked for the stacked grid and got an unstacked one — no tile drew a card.");
+  console.error(`       the vault keeps this in localStorage under "${STACK_KEY}"; if that key or its`);
+  console.error("       shape has moved, check photos ui/src/lib/stack.js and update STACK_ON here.");
+  console.error("       refusing to write a roll that does not match the clip.");
+  process.exit(1);
+}
 
 if (checking) {
   let previous;
@@ -241,13 +317,15 @@ if (checking) {
   const geometry =
     previous.viewport?.width === width &&
     previous.viewport?.height === height &&
-    previous.distance === distance;
+    previous.distance === distance &&
+    previous.stacking === stacking;
   console.log(`roll on disk   ${previous.tiles.length} tiles  ${previous.roll_digest}`);
   console.log(`roll now       ${tiles.length} tiles  ${digest}`);
   if (!geometry) {
     console.log(
       `geometry       DRIFTED — on disk ${previous.viewport?.width}x${previous.viewport?.height} ` +
-        `distance ${previous.distance}, asked for ${width}x${height} distance ${distance}`,
+        `distance ${previous.distance} stacking ${previous.stacking}, ` +
+        `asked for ${width}x${height} distance ${distance} stacking ${stacking}`,
     );
   }
   if (same && geometry) {
@@ -298,6 +376,7 @@ await writeFile(
       viewport: { width, height },
       distance,
       band,
+      stacking,
       roll_digest: digest,
       tiles,
     },
@@ -307,6 +386,9 @@ await writeFile(
   "utf8",
 );
 
-console.log(`${tiles.length} photographs in the band [0, ${band}] (${mounted} tiles mounted in all)`);
+console.log(
+  `${tiles.length} photographs in the band [0, ${band}] ` +
+    `(${mounted} tiles mounted in all, grid ${stacking ? "stacked" : "unstacked"})`,
+);
 console.log(`roll_digest ${digest}`);
 console.log(`written ${out}`);


### PR DESCRIPTION
Towards #63. Follows #77 and #78.

The recording is meant to show the grid **stacked** — frames verified to be the same photograph drawn as one tile, each carrying the count it stands for. That is the view the Panel exists to show off, and the roll was collected unstacked, so it described a clip nobody intends to make.

They are different rolls, not the same photographs regrouped:

| | stacked | unstacked |
|---|---|---|
| photographs in the band | **84** | 73 |
| tile | 153×204 | 162×216 |
| drawn as a stack | 35 (42%) | — |

### The trap, and why it's the worst one yet

Stacking is **not a default and not a URL parameter**. The vault keeps it in `localStorage` under `photos.stack`, read once at mount, defaulting to `{on: false}`. It has to be seeded into the browser profile *before* the page's script runs.

**record cannot do that today** — its only page hook is the timeline's `evaluate`, which runs after navigation, by which point the grid has mounted unstacked. Navigating a fresh browser at the URL gets the unstacked grid however the operator's own browser is set, because the setting lives in a profile, not the server. Left alone, #65 produces a clip that looks entirely correct and shows the wrong view, against a roll that doesn't cover it.

The collector seeds it with `addInitScript` and then **checks the DOM that it took**, refusing to write a roll if no tile drew a card — a renamed key upstream would otherwise seed nothing and collect a perfectly good roll of the wrong view in silence.

### A real bug this surfaced

The roll recorded the **tile element's** box. A stacked tile is taller than its picture — the deck draws a sliver of each extra member above it — so tiles sharing a row had different `top` values and the review sheet broke into **20 ragged rows instead of 10**. Now it records the `tile-photo` child, which is the box that answers both questions asked of it: what the reader actually sees, and which tiles share a row.

### Verified

84 tiles in 10 rows of 6/7/9/9/9/9/8/9/9/9, evenly spaced tops. Digest stable across runs. Selectors match all 84, nothing in the band unmatched, nothing outside hit. `--check --stack off` correctly reports DRIFTED and exits 1, reproducing the old 73-tile digest exactly. Review sheet renders the 10 rows with nothing pre-selected.
