### PR TITLE
Leave the cut word the size it was and let the section keep its masthead

### DIFF
--- a/portfolio/app.js
+++ b/portfolio/app.js
@@ -72,10 +72,10 @@
   // of the page. It sits OUTSIDE <main class="col">, as a sibling of it — .page
   // is a flex column and the title has to be .page's own child to be held
   // against the bottom edge. On a screen that composes to one page it is pinned
-  // to the fold instead, and one page turn later the whole of it has flown down
-  // onto the projects section and become that section's masthead. Where it
-  // STARTS is all CSS — see --cut-* and the turn block in styles.css; where it
-  // ends is measured, in cut-morph.js.
+  // to the fold instead, and one page turn later the section it names is
+  // standing on the screen with a masthead of its own. It does not move or
+  // resize on the way: all the geometry is CSS — see --cut-* and the turn block
+  // in styles.css — and cut-morph.js only turns its face.
   //
   // THE WORD IS A PICTURE, not type. It is the outlines of PROJECTS set in Friz
   // Quadrata, baked to one SVG path by design/cut-title/build-cut-title.py, and
@@ -490,8 +490,9 @@
     // window — the panel is min-height:--fold but the Frame grows with the width,
     // so past about 1600px the composition stands a few per cent past the fold
     // and the document is longer than the turn. Turning to pageMax() there would
-    // fly the page to the panel's FOOT, overshooting the port, the masthead, and
-    // the word's landing along with it.
+    // fly the page to the panel's FOOT, overshooting the port and the masthead
+    // with it — and the morph reads the same port, so the word would still be
+    // turning after the page had stopped.
     function panelPort() {
       if (!panel) return pageMax();
       return Math.max(0, Math.min(pageMax(),

--- a/portfolio/cut-morph.js
+++ b/portfolio/cut-morph.js
@@ -1,16 +1,28 @@
 /* The cut title's morph — PROJECTS turning from Friz Quadrata into a sans as
- * the page scrolls, and flying out of the CV's bottom-left corner onto the
- * projects section's masthead as it turns. The morph and the flight are two
- * halves of one device and read the same scroll: the word the section is titled
- * with IS the word cut off the foot of the page above it, arriving in the face
- * it turned into. The flight block further down is the whole of the second half.
+ * the page scrolls, and NOTHING ELSE. The word stands in the page's bottom-left
+ * corner at the size CSS gives it, turns face over the one page turn, and never
+ * moves or changes size. The section below prints its own masthead, in the face
+ * the word turned into, at its own size.
+ *
+ * IT USED TO FLY, and the note is here because the flight is the obvious idea
+ * and it has already been tried. #83 carried the word out of that corner onto
+ * the masthead's ink, scaled to the masthead's cap, so that the two PROJECTS
+ * were one; the masthead went `visibility: hidden` under `.cue-fly` so it was
+ * not drawn twice. The scale is what it cost. At 1440 the cut word's cap is 49px
+ * and the masthead's is about 75, so the word grew by half on the way down —
+ * and the word at the fold had been right at its own size since before the
+ * section existed. So the flight came back out and only the turn is left. Gone
+ * with it: the transform and its z-index lift, the colour ramp across the
+ * section's top edge (`--cue-land`, `--cue-land-ink`, `.cue-fly`), and every
+ * measurement that fed them. NOT gone with it: the two snap ports and the
+ * absence of the doorway, which are the page turn and are #83's other half.
  *
  * NOTHING ON THE PAGE DEPENDS ON THIS FILE, the same stance effects.js takes. It
  * is loaded last, and a browser that never runs it — parse error, blocked
  * script, reduced motion — gets the cut title exactly as it was before any of
  * this: the one baked Friz path that app.js puts inline, on screen at first
  * paint. All this does is swap that single path for the same outlines split into
- * eight, and then move them.
+ * eight, and then turn them.
  *
  * WHAT THE TWEEN IS. Both ends are the real typeface: at rest each letter is its
  * own Bezier outline, Friz's at the start and the sans's at the end, and the
@@ -31,11 +43,6 @@
  * width. So the viewBox, --cue-ratio, --cue-ink and --cue-overshoot are all
  * still Friz's and none of them moves during the morph. The cap line stays where
  * the cut is taken from.
- *
- * NOTHING ABOUT THE FLIGHT IS DECLARED IN CSS, and that is not an oversight —
- * where the word lands is another element's ink and only layout knows how wide
- * a word of Host Grotesk is. See the flight block for the measurement, and the
- * turn block in styles.css for the half that IS declared: where the word starts.
  *
  * TO CHANGE THE FACE. design/cut-title/morph-tuner.html previews all of them
  * against the real page; it drives this file through window.__cutMorph. To make
@@ -163,7 +170,6 @@
 
   var root = document.documentElement;
   var panel = document.querySelector(".panel");
-  var masthead = document.querySelector(".panel-masthead");
 
   /* WHERE THE TURN ENDS, in document pixels: the top of the projects section,
      which is the port `scroll-snap-align: start` rests on and the scroll position
@@ -194,227 +200,16 @@
     return t < 0 ? 0 : t > 1 ? 1 : t;
   }
 
-  /* ---- the flight ----------------------------------------------------------
-     The letters turn from Friz into Host Grotesk over the same scroll that
-     carries the page from the CV to the projects section — and at the end of it
-     the section prints PROJECTS, in Host Grotesk, as its masthead. So the word
-     does not turn and then leave. It turns and LANDS: over the turn it travels
-     out of the page's bottom-left corner and onto the masthead's ink, and the
-     masthead itself is hidden under .cue-fly so that the word is not drawn twice.
-
-     WHY THIS IS MEASURED AND NOT DECLARED. Where the word starts is CSS to the
-     pixel — see the turn block in styles.css — but where it ENDS is another
-     element's ink, and how wide a word of Host Grotesk is at a given size is
-     something only layout knows. There is no expression for it, so there is no
-     expression here: both boxes are read off the page, and the one number in
-     between is scroll.
-
-     BOTH BOXES ARE IN DOCUMENT SPACE, which is what keeps this to one transform
-     and no scroll compensation. .cut-title is absolutely positioned inside
-     .page — a box whose document position does not move — and the masthead sits
-     in ordinary flow below it, so the vector between them is a constant of the
-     layout. Ordinary scrolling supplies the rest of the travel for free. At
-     T = 0 the transform is the identity and nothing here has touched the page.
-
-     WHAT IS AIMED AT IS THE CAP, NOT THE ADVANCE. The two words cannot be
-     congruent: the morph solves the sans's tracking so its ink spans the same
-     width as Friz's at the same cap height, and the masthead is set at the
-     composition's own -0.005em, so the same word is about 3% narrower per cap in
-     one than the other. Matching the CAP is the one that keeps the design's
-     size — --panel-masthead-size is 7.3vw off the render and the whole of row
-     one is built on it — and spends the difference on the right-hand edge, which
-     nothing is aligned to. Matched by width instead, the word would land
-     visibly bigger than the masthead it replaces.
-
-     THE CAP HEIGHT is measured rather than declared, off a canvas: for a capital
-     H, actualBoundingBoxAscent IS the cap. That keeps this working if the face
-     or the size ever changes, and it is the only place in the flight where a
-     browser can decline — no canvas metrics, no flight, and the section keeps
-     its own masthead. The baseline it is measured DOWN from comes from the
-     layout instead of from the same canvas, because a canvas's idea of the line
-     box and the layout's can differ by a fraction under font fallback: a
-     zero-sized inline-block on the baseline sits with its box exactly on it, and
-     that is what the probe below is.
-
-     COLOUR is the crossing into dark in miniature and is deliberately no more
-     than that. The word leaves as --ink on paper and lands as the section's own
-     --panel-ink on near-black, and it is ramped between them over the stretch
-     where the word actually crosses the section's top edge — from the moment its
-     lowest visible ink reaches that edge to the moment its highest does. In the
-     middle of that ramp the word genuinely is half on paper and half on the dark,
-     and one colour cannot be right for both; the turn is travelling at about
-     2000 px/s there. #73 is the ticket that owns the crossing properly. */
-
-  var flight = null;
-
-  function px(v) { var n = parseFloat(v); return n === n ? n : 0; }
-
-  /* An element's top-left in DOCUMENT space, walked up the offsetParent chain
-     rather than taken from getBoundingClientRect.
-     THE DIFFERENCE IS NOT PEDANTRY AND THIS IS THE BUG IT FIXES. A client rect
-     is the TRANSFORMED box, and .cut-title lives inside .page, which spends its
-     first 0.9s translated 8px down by the page-in reveal. Measured with rects
-     during that animation — which is exactly when this file first runs, being the
-     last script on the page — the word's document position came out 8px low, the
-     vector to the masthead 8px short, and the word landed 8px above the line it
-     was aimed at, on every load, invisibly. Offsets are layout, so no transform
-     on this element or on anything above it can reach them, and the flight's own
-     transform cannot feed back into its own measurement. */
-  function docTop(el) {
-    var y = 0;
-    for (var n = el; n; n = n.offsetParent) y += n.offsetTop;
-    return y;
-  }
-  function docLeft(el) {
-    var x = 0;
-    for (var n = el; n; n = n.offsetParent) x += n.offsetLeft;
-    return x;
-  }
-
-  /* The cap height of the masthead's own face at its own size, via canvas. */
-  function capHeight(style) {
-    var c;
-    try { c = document.createElement("canvas").getContext("2d"); } catch (_) { return 0; }
-    if (!c) return 0;
-    c.font = style.fontStyle + " " + style.fontWeight + " " +
-             px(style.fontSize) + "px " + style.fontFamily;
-    var m;
-    try { m = c.measureText("H"); } catch (_) { return 0; }
-    return m && m.actualBoundingBoxAscent > 0 ? m.actualBoundingBoxAscent : 0;
-  }
-
-  /* Where the masthead's alphabetic baseline is, in viewport pixels. */
-  function baselineY(el) {
-    var probe = document.createElement("span");
-    probe.setAttribute("aria-hidden", "true");
-    probe.style.cssText = "display:inline-block;width:0;height:0;vertical-align:baseline";
-    el.appendChild(probe);
-    var y = probe.getBoundingClientRect().bottom;
-    el.removeChild(probe);
-    return y;
-  }
-
-  /* Everything the flight needs, taken once per layout. Any of it missing — no
-     section, no masthead, no canvas metrics, or a regime where the word is still
-     a block in the column — leaves `flight` null, .cue-fly off, and the page
-     exactly as CSS alone draws it. */
-  function measure() {
-    flight = null;
-    root.classList.remove("cue-fly");
-    host.style.transform = "";
-    host.style.zIndex = "";
-    host.style.removeProperty("--cue-land");
-    host.style.removeProperty("--cue-land-ink");
-    if (!panel || !masthead) return;
-    // Read off the cascade rather than restated here: `position: absolute` on
-    // .cut-title is written by the one-screen media query and nowhere else.
-    if (window.getComputedStyle(host).position !== "absolute") return;
-
-    var ms = window.getComputedStyle(masthead);
-    var cap = capHeight(ms);
-    if (!cap) return;
-
-    // The cut box IS the cap slab and its width IS the word's ink — see the three
-    // nested boxes in styles.css — so this one box is both ends of the scale.
-    var slab = host.firstElementChild;
-    if (!slab) return;
-    if (!(slab.offsetWidth > 0) || !(slab.offsetHeight > 0)) return;
-    var slabRect = slab.getBoundingClientRect();
-    var pic = svg.getBoundingClientRect();
-
-    /* The masthead's ink and baseline are the two things offsets cannot give, so
-       they are taken from rects and immediately re-expressed as offsets FROM the
-       masthead's own box. Only the deltas inside that one element come from
-       rects, and nothing above .panel is transformed, so they are exact. */
-    var mBox = masthead.getBoundingClientRect();
-    var range = document.createRange();
-    range.selectNodeContents(masthead);
-    var ink = range.getBoundingClientRect();
-
-    flight = {
-      // the cut word's cap box, in document space
-      fromX: docLeft(slab),
-      fromY: docTop(slab),
-      // the masthead's cap box: its ink's left edge, and its baseline less a cap
-      toX: docLeft(masthead) + (ink.width > 0 ? ink.left - mBox.left : 0),
-      toY: docTop(masthead) + (baselineY(masthead) - mBox.top) - cap,
-      scale: cap / slab.offsetHeight,
-      // the origin the scale is taken about — .cut-title's own top-left, which is
-      // what `transform-origin: 0 0` in the sheet names
-      ox: docLeft(host),
-      oy: docTop(host),
-      /* The DRAWING against the cap box, for the colour ramp: it is the picture
-         that crosses the section's edge, and it hangs above and below the slab
-         by the O's overshoot and the J's descender. Rects, and a DIFFERENCE of
-         two of them, because an <svg> is not an HTMLElement and has no offsets
-         to walk — and because a difference taken inside one transform context is
-         immune to a translate above it, which is all the page's reveal is. */
-      picOff: pic.top - slabRect.top,
-      picH: pic.height || slabRect.height,
-      // Leave the z-index alone where the effect stack has already lifted the
-      // word clear. It only has to beat .panel, which takes no z-index of its
-      // own, and --fx-text-z (17) does.
-      lift: window.getComputedStyle(host).zIndex === "auto"
-    };
-    host.style.setProperty("--cue-land-ink", ms.color);
-    root.classList.add("cue-fly");
-  }
-
-  /* One transform and one number, both a pure function of the scroll. The cap
-     box is lerped corner to corner and the scale with it, so both ends are exact
-     rather than merely close: at T = 0 the transform is not written at all, and
-     at T = 1 the word's cap box IS the masthead's cap box. */
-  function fly(T) {
-    if (!flight) return;
-    var f = flight;
-    if (T <= 0) {
-      host.style.transform = "";
-      host.style.zIndex = "";
-      host.style.setProperty("--cue-land", "0");
-      return;
-    }
-    var s = 1 + (f.scale - 1) * T;
-    var x = f.fromX + (f.toX - f.fromX) * T;
-    var y = f.fromY + (f.toY - f.fromY) * T;
-    host.style.transform = "translate(" +
-      (x - (f.ox + (f.fromX - f.ox) * s)).toFixed(2) + "px," +
-      (y - (f.oy + (f.fromY - f.oy) * s)).toFixed(2) + "px) scale(" + s.toFixed(5) + ")";
-    if (f.lift) host.style.zIndex = "20";
-
-    /* The ramp, measured where it is actually happening: the drawing's own
-       crossing of the section's top edge. 0 while every visible pixel of the word
-       is still above that edge, 1 once none of it is. Clipped to the window at
-       the bottom, because below the fold there is nothing to be over — which is
-       also what keeps this exactly 0 at rest, where the J hangs past a fold the
-       section's edge is sitting on.
-       Smoothstep on top, the same curve the letters are eased with. It does not
-       fix the straddle — nothing one colour can do fixes the straddle — but it
-       keeps the word committed to a ground for most of the crossing and spends
-       the ambiguity in the middle, where the word is genuinely half on each. */
-    var scroll = window.pageYOffset || root.scrollTop || 0;
-    var edge = panel.getBoundingClientRect().top;
-    var span = f.picH * s;
-    var top = y - scroll + f.picOff * s;
-    var c = span > 0 ? (Math.min(top + span, window.innerHeight) - edge) / span : 0;
-    c = c < 0 ? 0 : c > 1 ? 1 : c;
-    host.style.setProperty("--cue-land", (c * c * (3 - 2 * c)).toFixed(3));
-  }
-
   var pinned = null;                 // a number while the tuner is holding it
   var queued = false;
 
-  /* The letters take the pinned T when the tuner is holding one; the FLIGHT
-     always takes the real scroll. They are the same number in every case but
-     one, and that one is the tuner: design/cut-title/morph-tuner.html scrubs T
-     without moving the page, and a flight that followed it would carry the word
-     off to a masthead a screen below the window and leave the tuner looking at
-     nothing. Judging the letterforms is what that tool is for; #69's tuner is
-     where the composition gets judged. */
+  /* The letters take the pinned T when the tuner is holding one, and the real
+     scroll otherwise: design/cut-title/morph-tuner.html scrubs T without moving
+     the page, which is what judging the letterforms needs. #69's tuner is where
+     the composition gets judged. */
   function frame() {
     queued = false;
-    var T = progress();                 // read once: it costs a layout to ask
-    draw(pinned === null ? T : pinned);
-    fly(T);
+    draw(pinned === null ? progress() : pinned);
   }
 
   /* Scrolling goes through a frame — it fires far faster than the display and
@@ -429,22 +224,14 @@
 
   var still = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)");
   if (!still || !still.matches) {
-    /* Re-measured whenever the layout under the flight can have moved, and never
-       per frame: both boxes are constants of the layout, and reading them on a
-       scroll would force a style recalc every frame of the turn for numbers that
-       had not changed. The window is the obvious one; `load` is for the corner
-       pictures, which arrive late and settle the CV's height; and the theme
-       carries the colour the word LEAVES as, which is read here rather than
-       lerped from a cached pair — a toggle mid-turn would otherwise strand the
-       word part-way to a colour the page had stopped using. */
+    /* Scroll is the input. `resize` and `load` are here because the LANDING can
+       move without a scroll and T is a fraction of it: a resized window is the
+       obvious one, and `load` is for the corner pictures, which arrive late and
+       settle the CV's height. Neither reads anything but landing(), so neither
+       costs a measurement of its own. */
     window.addEventListener("scroll", kick, { passive: true });
-    window.addEventListener("resize", function () { measure(); kick(); });
-    window.addEventListener("load", function () { measure(); kick(); });
-    if (window.MutationObserver) {
-      new window.MutationObserver(function () { measure(); kick(); })
-        .observe(root, { attributes: true, attributeFilter: ["data-theme"] });
-    }
-    measure();
+    window.addEventListener("resize", kick);
+    window.addEventListener("load", kick);
     kick();
   }
 
@@ -460,9 +247,6 @@
       pinned = t;
       draw(pinned === null ? progress() : pinned);
     },
-    at: function () { return pinned === null ? progress() : pinned; },
-    // For anything that moves the layout under the flight without firing resize
-    // — a tuner swapping the masthead's wording or its size, which is #69.
-    remeasure: function () { measure(); kick(); }
+    at: function () { return pinned === null ? progress() : pinned; }
   };
 })();

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -342,10 +342,10 @@
 
        There used to be a `.doorway` between this and .page — one blank screen
        for the cut word to arrive on as its title, from when the word opened
-       onto nothing. It is gone. The word arrives HERE now, and lands on this
-       section's own masthead: see the turn block in styles.css for the two
-       snap ports it leaves, and the travel block in cut-morph.js for the flight
-       between them. The reason the panel still cannot be a child of .page is
+       onto nothing. It is gone: this section stands directly under the fold, one
+       page turn below the CV, and the cut word stays where it is cut rather than
+       travelling. See the turn block in styles.css for the two snap ports that
+       leaves. The reason the panel still cannot be a child of .page is
        the one the doorway was written for in the first place — in the
        one-screen regime .page is exactly one screen and .cut-title is pinned
        out of flow at `top: 100vh`, so a panel inside .page would land
@@ -382,17 +382,14 @@
     </ul>
     <div class="panel-inner">
       <header class="panel-head">
-        <!-- WHAT THE CUT WORD LANDS ON, and usually not what is drawn. When
-             cut-morph.js takes the flight it puts `.cue-fly` on <html> and this
-             h2 goes `visibility: hidden` — it keeps its box, so it is still what
-             sets row one's height and where the subheading starts, and the
-             flying word is fitted to its ink. Drawn twice would be drawn twice.
-             It stays in the markup rather than becoming a CSS-only slot for two
-             reasons: it is the section's accessible name, referenced by the
-             `aria-labelledby` above, which a hidden-but-referenced element still
-             supplies; and without the script it is simply the masthead, drawn,
-             which is the whole of what a browser that never runs cut-morph.js
-             gets. See the landing block in styles.css. -->
+        <!-- THE SECTION'S OWN MASTHEAD, always drawn. It is the same word as the
+             one cut off the foot of the page above, in the face that word turns
+             into over the scroll, and the two are deliberately left as two: #83
+             flew the cut word down onto this h2 and hid it under `.cue-fly`, and
+             the flight is out again because it had to scale the cut word by half
+             to fit — see the morph block in cut-morph.js. This sets row one's
+             height and is where the subheading starts. It is also the section's
+             accessible name, referenced by the `aria-labelledby` above. -->
         <h2 class="panel-masthead" id="panel-masthead">Projects</h2>
         <!-- Two authored lines, not one string left to wrap. The second line is
              the one the Frame passes in front of, so where it breaks is part of

--- a/portfolio/styles.css
+++ b/portfolio/styles.css
@@ -722,10 +722,8 @@
      built out of.
      There was a --title-top here as well, for the top-left corner the word used
      to come to rest in on a blank second screen. That screen is gone and so is
-     the corner: the word now flies to the projects section's own masthead, and
-     where it lands is that h2's ink, measured at run time rather than declared.
-     See the turn block at the foot of this sheet and the travel in
-     cut-morph.js. */
+     the corner: the projects section stands directly under the fold now, and the
+     word stays where it is cut. See the turn block at the foot of this sheet. */
   --title-left: var(--corner);
 
   /* Everything in the document that is NOT the photo strip and NOT one of the
@@ -1871,41 +1869,57 @@ body::after {
    the end parked the cut word in the top-left corner as that screen's title. It
    was written when the word opened onto nothing, and once the section arrived
    underneath it the page had three resting places and the middle one was an
-   empty sheet with a half-turned word on it. The word never reached its own
-   landing either: it came to rest a whole screen above the fold, out of sight,
-   and the section below printed the SAME WORD again as its masthead in the very
-   face the morph resolves into.
+   empty sheet with a half-turned word on it. The word also came to rest a whole
+   screen above the fold, out of sight, while the section below printed the SAME
+   WORD again as its masthead in the very face the morph resolves into.
 
-   So the landing moved to where it was always going. The word flies to the
-   section's masthead and lands on it — the .panel-masthead h2 goes
-   `visibility: hidden` under `.cue-fly` and the flying word is fitted to its
-   ink — which is the whole of the device the morph was built for: PROJECTS in
-   Friz Quadrata at the foot of the CV turns into PROJECTS in Host Grotesk at the
-   head of the section, once, over one page turn. The flight is measured and
-   drawn by cut-morph.js, off the same T that turns the letters; there is no
-   arithmetic left in this sheet for where the word ends up, because the end is
-   another element's ink and only layout knows how wide that is.
+   So the blank screen went and the section came up to the fold. The word itself
+   does not move. It stays cut in the page's bottom-left corner at the size the
+   two insets below give it, turns face over the page turn, and the section
+   prints its own masthead in the face it turned into — the two of them one page
+   turn apart, which is what the device is: the word cut off the foot of the CV,
+   and then the section it is the title of.
 
-   What this sheet still fixes is the START — the two insets below, the cut, and
-   the two snap ports — and that half is unchanged to the pixel. A browser that
-   never runs cut-morph.js gets exactly this block: the word cut at the fold, the
-   section's own masthead drawn as the section's own masthead, and one page turn
-   between them. Nothing here depends on the flight.
+   IT DID FLY, BRIEFLY. #83 carried the word down onto that masthead and scaled
+   it to the masthead's cap, so that the two PROJECTS were one; the h2 went
+   `visibility: hidden` under `.cue-fly` and the flying word was fitted to its
+   ink. The scale is why that is gone. The cut word's cap is 49px at 1440 against
+   the masthead's 75, so the word grew by half on the way down — and the word at
+   the fold had been the size the composition wanted since before the section
+   existed. A device that resizes it is paying for the meeting with the one thing
+   that was already right. The morph block in cut-morph.js has the rest of that
+   account.
+
+   What this sheet fixes is therefore the whole of the word: the two insets
+   below, the cut, and the two snap ports. Every browser gets the same page, with
+   or without cut-morph.js — the word cut at the fold, the section's own masthead
+   drawn as the section's own masthead, and one page turn between them.
 
    Two consequences worth naming:
-   * The cut becomes REAL. Everywhere else the word is clipped to --cue-clip by
-     its own overflow, because the document ends beneath it and there is no
-     second screen for the rest of the letters to stand on. Here they are all
-     there and the bottom of the window does the cutting, which is what the
-     device was always drawing. So the clip comes off: leave it on and the word
-     would fly to the masthead still guillotined.
+   * The cut moves off the box and onto the fold. Everywhere else the word is
+     clipped to --cue-clip by its own overflow, because the document ends beneath
+     it and there is no second screen for the rest of the letters to stand on.
+     Here the letters are all there, so the overflow clip comes off — what it
+     cuts is the BOX, at the cap line, and it would take the O's overshoot with
+     it — and the clip-path below cuts at the fold instead, which is where the
+     design has always drawn the cut.
+     It has to be a clip and cannot be left to paint order, which is the part
+     worth writing down. The section paints after .page and would cover the tail
+     of the letters on its own — but the effect stack lifts the type to
+     --fx-text-z (17) so that it stands above the layers it is excluded from, and
+     the section takes no z-index of its own, so the lifted word is drawn ON the
+     section instead. Below the fold that costs nothing at rest, which is the
+     trap: it is only during the turn, as the section rises past it, that the
+     bottom of PROJECTS is dragged up the dark composition — bright on near-black
+     in dark mode. Giving .panel a z-index instead would fix the word and break
+     the stack, since the numbers it would have to beat are the film, the grain
+     and the CRT, all of which belong over this section.
    * The word leaves the measure — both of them. It is no longer the last line of
      the column but a word standing in the page's own corner, so it is set to the
      page's margin instead of the text's — --title-left from the window's edge,
      the same measure as the white above it, which is what makes the corner read
      as a corner. And it is no longer the column's width either: it is fitted to
-     the
-     gutter it now stands in, so that the white either side of it is that same
+     the gutter it now stands in, so that the white either side of it is that same
      --title-left twice over — page edge to the P, S to the line the resume
      starts on. See --cue-measure in the one-screen block for the whole of that
      derivation; here it is only placed.
@@ -1939,11 +1953,6 @@ body::after {
    block is what it always was.
    `top`, not `bottom`, because the offset then holds the cap top on that line
    whatever the box's own height turns out to be.
-   IT IS ALSO THE ONLY THING THE FLIGHT HAS TO TRANSFORM. Absolutely positioned
-   in .page, the box has a document position that does not move with the scroll,
-   so cut-morph.js can express the whole travel as one transform on this element
-   against one measurement of the masthead's ink — no fixed positioning, no
-   sticky, and nothing here to undo at T = 0.
 
    These rules sit at the end of the sheet, not up in the :root block that shares
    their gate: every one of them overrides a base rule of the same specificity,
@@ -1975,38 +1984,20 @@ body::after {
     width: auto;
     max-width: none;
     margin: 0;
-    /* The corner the flight's scale is taken about, and the only thing this
-       sheet says about the flight itself. cut-morph.js writes the transform
-       against this origin — see the flight block there — and writes nothing at
-       all at rest, so a page that never runs it never has a transform on this
-       element. `0 0` rather than the default centre because the word is placed
-       by its top-left in both compositions and a centre origin would put the
-       scale's own drift into the landing.
-       It costs nothing when unused: `transform-origin` on an untransformed box
-       has no effect and makes no stacking context. The transform does make one,
-       which is exactly why cut-morph.js also has to hand out a z-index — see
-       the note on `lift` there. */
-    transform-origin: 0 0;
-  }
-  /* The word crosses from the paper onto the near-black section during the turn,
-     so it cannot keep one colour. --cue-land is the crossing, 0 to 1, written by
-     cut-morph.js off where the DRAWING actually is against the section's top
-     edge; --cue-land-ink is the far end, read by that same script off the
-     masthead's own computed colour so that the section's palette stays declared
-     in one place — the .panel block — and is not copied up here as a literal.
-     --ink is the near end and is left to the cascade, so the theme toggle still
-     governs the word it leaves as.
-     Falls back to plain --ink wherever `color-mix` is not understood, which is
-     the same stance as the rest of this file: the flight still happens, the word
-     simply arrives the colour it started. #73 is the crossing proper. */
-  :root.cue-fly .cut-title > a {
-    color: color-mix(in oklab,
-                     var(--cue-land-ink, var(--ink)) calc(var(--cue-land, 0) * 100%),
-                     var(--ink));
+    /* THE CUT, and see the second bullet above for why it is a clip rather than
+       the section simply painting over the word. This box's own top edge IS the
+       fold — `top: 100vh`, with the word lifted back above it by the negative
+       margin below — so the cut is the box's top edge and needs no arithmetic of
+       its own. The other three sides are opened well past the window instead of
+       being left at 0: the chroma and halation effects put a shadow on this
+       element that spills outside its box, and a clip tight to the sides would
+       trim that rather than the section. */
+    clip-path: inset(-100vh -100vw 100% -100vw);
   }
   .cut-title > a {
-    /* The clip comes off — the bottom of the window does the cutting here, and
-       the J's hook and the baseline are meant to be seen on the screen below. */
+    /* The clip comes off — the fold does the cutting here, and the O's overshoot
+       above the cap line is meant to be drawn, not sliced off a few pixels
+       short of it. */
     overflow: visible;
     /* But the BOX stays the cap slab, and is not left to `auto`. Two things
        depend on it: the hover underline, which lands on the box's bottom edge
@@ -2033,33 +2024,15 @@ body::after {
      means the scroller must COME TO REST on a port, and with nothing between
      them there is nowhere to stop half way.
      `start`, so the section arrives with its masthead against the top of the
-     window; the flying word is aimed at that masthead's ink, so this is also
-     what fixes where the word comes down. When the composition is taller than
-     the window the area is larger than the scrollport, which relaxes snapping
-     inside it rather than switching it off — you can read to the bottom of a
-     tall panel without being pulled back up, and app.js hands the wheel back to
-     the browser past this port for exactly that stretch.
+     window — and the masthead is drawn, in every regime and whatever the script
+     does, because the word above no longer comes down onto it. When the
+     composition is taller than the window the area is larger than the
+     scrollport, which relaxes snapping inside it rather than switching it off —
+     you can read to the bottom of a tall panel without being pulled back up, and
+     app.js hands the wheel back to the browser past this port for exactly that
+     stretch.
      What the Rail does, and the crossing into dark, are still #72 and #73. */
   .panel { scroll-snap-align: start; }
-
-  /* ---- the landing ---------------------------------------------------------
-     Only while cut-morph.js is actually flying the word: it writes .cue-fly on
-     <html> when it has measured a flight it can draw, and takes it off when it
-     cannot — reduced motion, a regime with no turn in it, a masthead it could
-     not find. So the fallback is the plain page, with this h2 drawn.
-     `visibility`, NOT `display: none` and not `opacity`. The box has to stay
-     exactly where it is: it is what sets row one's height, what the subheading
-     hangs off, and — the point — the ink the flight is aimed at, which
-     cut-morph.js measures with a Range over this element's own text. A hidden
-     box still measures. `opacity: 0` would measure too and would also still be
-     hit-tested and still be read out; `visibility: hidden` takes it out of the
-     accessibility tree, which is right, because the section's name comes from
-     the `aria-labelledby` reference — and a directly-referenced hidden element
-     still supplies one.
-     Gated inside this media query with the rest of the turn, because outside it
-     there is no flight: on a page that scrolls as a column the word stays in the
-     column and this is the only PROJECTS the section has. */
-  :root.cue-fly .panel-masthead { visibility: hidden; }
 }
 
 /* ============================================================================


### PR DESCRIPTION
#83 flew PROJECTS out of the CV's bottom-left corner onto the projects
section's masthead over the page turn, and to land on that h2's ink it had
to scale the word: the cut word's cap is 49px at 1440 against the
masthead's 75, so the word grew by half on the way down. The word at the
fold has been the size the composition wanted since before the section
existed, and a device that resizes it is spending the one thing that was
already right. So the flight is out. The word stands where it is cut, at
its own size, and turns face over the same scroll; the section prints its
own masthead, always, in the face the word turned into.

Gone with it: the transform and its z-index lift, the colour ramp across
the section's top edge (--cue-land, --cue-land-ink, .cue-fly), the
masthead's `visibility: hidden`, and every measurement that fed them —
the offsetParent walks, the canvas cap height, the baseline probe. Not
gone with it, and deliberately: the two snap ports and the absence of
.doorway, which are the page turn and are #83's other half. app.js keeps
reading the panel's own port for the same reason it did before.

One rule is new rather than removed. `.cut-title` gets

  clip-path: inset(-100vh -100vw 100% -100vw);

which cuts at the box's own top edge — `top: 100vh`, so that edge IS the
fold. It cannot be left to paint order: the effect stack lifts the type to
--fx-text-z (17) so it stands above the layers it is excluded from, the
section takes no z-index of its own, and the lifted word is therefore
drawn ON the section. At rest that costs nothing, which is the trap; it is
during the turn, as the section rises past it, that the bottom of PROJECTS
gets dragged up the dark composition, bright on near-black in dark mode.
Giving .panel a z-index instead would fix the word and break the stack —
the numbers it would have to beat are the film, the grain and the CRT, all
of which belong over this section. The three other sides are opened past
the window so the chroma and halation shadows are not trimmed with it.

Verified at 1440x1000, both themes, against the main checkout side by
side: the word's box at rest is identical to development to the pixel —
x 90, y 968.45, 316.5 x 67.23 — the box does not move or change size at
any T, no ghost of the word reaches the panel at the far port, and no
console errors. check-capture-contract.py green: 592 / 852 / 80 / 80 /
80.4, luminance 188.4 light and 46.1 dark.
