### PR TITLE
Hold the cut word at the fold and let it turn where it stands

### DIFF
--- a/portfolio/cut-morph.js
+++ b/portfolio/cut-morph.js
@@ -1,28 +1,29 @@
 /* The cut title's morph — PROJECTS turning from Friz Quadrata into a sans as
- * the page scrolls, and NOTHING ELSE. The word stands in the page's bottom-left
- * corner at the size CSS gives it, turns face over the one page turn, and never
- * moves or changes size. The section below prints its own masthead, in the face
- * the word turned into, at its own size.
+ * the page scrolls, and NOTHING ELSE MOVES. The word is held at the fold by CSS
+ * — `position: fixed` in the turn block of styles.css — so it keeps its corner
+ * of the screen, its size and its cut for the whole page turn while the CV
+ * scrolls out from under it and the section arrives behind it. All this file
+ * does is turn the letterforms, and ramp the word's colour where the section's
+ * top edge passes it, because past that edge the ground is near-black and one
+ * colour cannot serve both. The section prints its own masthead.
  *
- * IT USED TO FLY, and the note is here because the flight is the obvious idea
- * and it has already been tried. #83 carried the word out of that corner onto
- * the masthead's ink, scaled to the masthead's cap, so that the two PROJECTS
- * were one; the masthead went `visibility: hidden` under `.cue-fly` so it was
- * not drawn twice. The scale is what it cost. At 1440 the cut word's cap is 49px
- * and the masthead's is about 75, so the word grew by half on the way down —
- * and the word at the fold had been right at its own size since before the
- * section existed. So the flight came back out and only the turn is left. Gone
- * with it: the transform and its z-index lift, the colour ramp across the
- * section's top edge (`--cue-land`, `--cue-land-ink`, `.cue-fly`), and every
- * measurement that fed them. NOT gone with it: the two snap ports and the
- * absence of the doorway, which are the page turn and are #83's other half.
+ * TWO WAYS OF MOVING THE WORD HAVE BEEN TRIED AND ARE NOT COMING BACK, which is
+ * worth knowing before writing a third. The doorway parked it in the top-left
+ * corner of a blank screen; #83 flew it out of its corner onto the masthead's
+ * ink, scaled to that h2's cap, and hid the masthead under `.cue-fly` so the
+ * word was not drawn twice. The scale is what the second cost: at 1440 the cut
+ * word's cap is 49px and the masthead's is about 75, so the word grew by half on
+ * the way down, and the word at the fold had been right at its own size since
+ * before the section existed. What the scroll is for is the turn.
  *
  * NOTHING ON THE PAGE DEPENDS ON THIS FILE, the same stance effects.js takes. It
  * is loaded last, and a browser that never runs it — parse error, blocked
- * script, reduced motion — gets the cut title exactly as it was before any of
- * this: the one baked Friz path that app.js puts inline, on screen at first
- * paint. All this does is swap that single path for the same outlines split into
- * eight, and then turn them.
+ * script — gets the cut title exactly as it was before any of this: the one
+ * baked Friz path that app.js puts inline, held at the fold by the sheet, on
+ * screen at first paint. All this does is swap that single path for the same
+ * outlines split into eight, and then turn them. Reduced motion is the one case
+ * that is not all-or-nothing; see the note further down for why the colour is
+ * still written there.
  *
  * WHAT THE TWEEN IS. Both ends are the real typeface: at rest each letter is its
  * own Bezier outline, Friz's at the start and the sans's at the end, and the
@@ -200,8 +201,73 @@
     return t < 0 ? 0 : t > 1 ? 1 : t;
   }
 
+  /* ---- the crossing --------------------------------------------------------
+     The word is fixed to the fold — see the turn block in styles.css — so it
+     holds its corner of the SCREEN while the section slides up behind it. That
+     is one word on two grounds: paper until the section's top edge passes it,
+     near-black after, and in the light theme --ink on --panel-bg is a word that
+     goes out. So the colour crosses with the ground.
+
+     WHAT IS RAMPED AGAINST WHAT. The band that matters is the word's VISIBLE
+     ink: from the top of the drawing down to the bottom of the window, since
+     what is under the fold is under the window and there is nothing there to be
+     over. The section's edge sweeps that band — about 32px of it at 1440, so
+     about 3% of the turn, right at the end — and the ramp is where the edge is
+     inside it. Both are read per frame, and deliberately: the word is fixed and
+     the section's top is a constant of the layout, but the page-in reveal
+     translates .page for its first 0.9s and this file runs during exactly that,
+     so a cached rect is a rect measured 8px out. Two rects a frame is what the
+     flight cost too.
+
+     Smoothstep on top, the same curve the letters are eased with. It does not
+     fix the straddle — nothing one colour can do fixes the straddle, and in the
+     middle of that band the word genuinely is half on each — it only keeps the
+     word committed to a ground for most of the crossing. #73 owns it properly.
+
+     The COLOUR it crosses to is the masthead's own, read off the cascade so the
+     section's palette stays declared in one place: the .panel block. --ink is
+     the near end and is left to the cascade too, so the theme toggle still
+     governs the word on the paper. */
+  var masthead = document.querySelector(".panel-masthead");
+  var crossing = false;
+
+  /* Whether there is a crossing here at all, and the colour of its far end.
+     Taken once per layout rather than per frame: `position` and a computed
+     colour both cost a style recalc, and neither moves while the page sits
+     still. Outside the turn — a window below the gate, where the word is still
+     a block in the column — this stays false, nothing is written, and the word
+     keeps --ink through the cascade alone. */
+  function measure() {
+    crossing = false;
+    host.style.removeProperty("--cue-land");
+    host.style.removeProperty("--cue-land-ink");
+    if (!panel || !masthead) return;
+    if (window.getComputedStyle(host).position !== "fixed") return;
+    host.style.setProperty("--cue-land-ink", window.getComputedStyle(masthead).color);
+    crossing = true;
+  }
+
+  function land() {
+    if (!crossing) return;
+    var pic = svg.getBoundingClientRect();
+    var hi = Math.min(pic.bottom, window.innerHeight || 0);
+    var span = hi - pic.top;
+    var c = span > 0 ? (hi - panel.getBoundingClientRect().top) / span : 0;
+    c = c < 0 ? 0 : c > 1 ? 1 : c;
+    host.style.setProperty("--cue-land", (c * c * (3 - 2 * c)).toFixed(3));
+  }
+
   var pinned = null;                 // a number while the tuner is holding it
   var queued = false;
+
+  /* REDUCED MOTION STOPS THE LETTERS AND NOT THE COLOUR, and the split is the
+     point. Turning eight letterforms as the page scrolls is motion and is what
+     the setting is asking about; a word going out against the ground it is
+     standing on is legibility, and it is exactly as wrong for a reader who asked
+     for less movement. So the word stays in Friz for them, held at the fold by
+     CSS as it is for everyone, and still crosses. */
+  var still = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)");
+  var motion = !still || !still.matches;
 
   /* The letters take the pinned T when the tuner is holding one, and the real
      scroll otherwise: design/cut-title/morph-tuner.html scrubs T without moving
@@ -209,7 +275,8 @@
      the composition gets judged. */
   function frame() {
     queued = false;
-    draw(pinned === null ? progress() : pinned);
+    if (motion) draw(pinned === null ? progress() : pinned);
+    land();
   }
 
   /* Scrolling goes through a frame — it fires far faster than the display and
@@ -222,18 +289,21 @@
 
   build(FACE);
 
-  var still = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)");
-  if (!still || !still.matches) {
-    /* Scroll is the input. `resize` and `load` are here because the LANDING can
-       move without a scroll and T is a fraction of it: a resized window is the
-       obvious one, and `load` is for the corner pictures, which arrive late and
-       settle the CV's height. Neither reads anything but landing(), so neither
-       costs a measurement of its own. */
-    window.addEventListener("scroll", kick, { passive: true });
-    window.addEventListener("resize", kick);
-    window.addEventListener("load", kick);
-    kick();
+  /* Scroll is the input. `resize` and `load` are here because both the LANDING
+     and the crossing can move without one: a resized window is the obvious case,
+     and `load` is for the corner pictures, which arrive late and settle the CV's
+     height. The theme carries the colour the word crosses FROM, and the one it
+     crosses to is read at measure time, so a toggle mid-turn re-reads rather
+     than stranding the word part-way to a colour the page has stopped using. */
+  window.addEventListener("scroll", kick, { passive: true });
+  window.addEventListener("resize", function () { measure(); kick(); });
+  window.addEventListener("load", function () { measure(); kick(); });
+  if (window.MutationObserver) {
+    new window.MutationObserver(function () { measure(); kick(); })
+      .observe(root, { attributes: true, attributeFilter: ["data-theme"] });
   }
+  measure();
+  kick();
 
   /* The tuner's handle on this, and the only reason any of it is exposed.
      design/cut-title/morph-tuner.html iframes the real page and reaches in. */

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -343,12 +343,13 @@
        There used to be a `.doorway` between this and .page — one blank screen
        for the cut word to arrive on as its title, from when the word opened
        onto nothing. It is gone: this section stands directly under the fold, one
-       page turn below the CV, and the cut word stays where it is cut rather than
-       travelling. See the turn block in styles.css for the two snap ports that
-       leaves. The reason the panel still cannot be a child of .page is
+       page turn below the CV, and the cut word does not arrive anywhere. It is
+       fixed to the fold and holds that corner of the screen while this section
+       comes up behind it, turning as it goes. See the turn block in styles.css.
+       The reason the panel still cannot be a child of .page is
        the one the doorway was written for in the first place — in the
        one-screen regime .page is exactly one screen and .cut-title is pinned
-       out of flow at `top: 100vh`, so a panel inside .page would land
+       out of flow at the fold, so a panel inside .page would land
        underneath that pinned word and push nothing out of the way. Outside it,
        the reading order is the one the design asks for in every regime: the CV,
        and then the section the cut word turns into the title of.
@@ -386,9 +387,14 @@
              one cut off the foot of the page above, in the face that word turns
              into over the scroll, and the two are deliberately left as two: #83
              flew the cut word down onto this h2 and hid it under `.cue-fly`, and
-             the flight is out again because it had to scale the cut word by half
-             to fit — see the morph block in cut-morph.js. This sets row one's
-             height and is where the subheading starts. It is also the section's
+             that is out again because it had to scale the cut word by half to
+             fit — see the morph block in cut-morph.js. The cut word holds the
+             fold instead, so on this screen it is standing in the bottom-left
+             corner while this h2 is at the top. cut-morph.js reads this
+             element's computed colour, and only that: it is the far end of the
+             crossing the word makes onto this section's ground, which keeps the
+             palette declared once, in the .panel block. This also sets row one's
+             height and is where the subheading starts, and it is the section's
              accessible name, referenced by the `aria-labelledby` above. -->
         <h2 class="panel-masthead" id="panel-masthead">Projects</h2>
         <!-- Two authored lines, not one string left to wrap. The second line is

--- a/portfolio/styles.css
+++ b/portfolio/styles.css
@@ -1873,47 +1873,42 @@ body::after {
    screen above the fold, out of sight, while the section below printed the SAME
    WORD again as its masthead in the very face the morph resolves into.
 
-   So the blank screen went and the section came up to the fold. The word itself
-   does not move. It stays cut in the page's bottom-left corner at the size the
-   two insets below give it, turns face over the page turn, and the section
-   prints its own masthead in the face it turned into — the two of them one page
-   turn apart, which is what the device is: the word cut off the foot of the CV,
-   and then the section it is the title of.
+   So the blank screen went and the section came up to the fold. THE WORD HOLDS
+   ITS PLACE. It is cut at the fold, in the page's bottom-left corner, and it
+   stays exactly there on the SCREEN for the whole turn — same corner, same size,
+   same cut — while the CV scrolls out from under it and the section arrives
+   behind it. The one thing that happens to it is the one thing it is for: it
+   turns from Friz Quadrata into the sans. `position: fixed` below is the whole
+   of that, and the note on it is where the reasoning sits.
 
-   IT DID FLY, BRIEFLY. #83 carried the word down onto that masthead and scaled
-   it to the masthead's cap, so that the two PROJECTS were one; the h2 went
-   `visibility: hidden` under `.cue-fly` and the flying word was fitted to its
-   ink. The scale is why that is gone. The cut word's cap is 49px at 1440 against
-   the masthead's 75, so the word grew by half on the way down — and the word at
-   the fold had been the size the composition wanted since before the section
-   existed. A device that resizes it is paying for the meeting with the one thing
-   that was already right. The morph block in cut-morph.js has the rest of that
-   account.
+   TWO THINGS HAVE BEEN TRIED HERE AND ARE NOT COMING BACK, both of which moved
+   the word instead of the page. The doorway parked it in a top-left corner a
+   screen down; #83 flew it onto the section's masthead and scaled it to that
+   h2's cap, which grew the word by half on the way — 49px of cap against 75 at
+   1440 — when the word at the fold had been the size the composition wanted
+   since before the section existed. The word was right where it was and at the
+   size it was; what the scroll is for is the turn.
 
    What this sheet fixes is therefore the whole of the word: the two insets
    below, the cut, and the two snap ports. Every browser gets the same page, with
-   or without cut-morph.js — the word cut at the fold, the section's own masthead
-   drawn as the section's own masthead, and one page turn between them.
+   or without cut-morph.js — the word held at the fold, the section's own
+   masthead drawn as the section's own masthead, and one page turn between them.
 
    Two consequences worth naming:
-   * The cut moves off the box and onto the fold. Everywhere else the word is
+   * The cut becomes REAL, and the window makes it. Everywhere else the word is
      clipped to --cue-clip by its own overflow, because the document ends beneath
      it and there is no second screen for the rest of the letters to stand on.
-     Here the letters are all there, so the overflow clip comes off — what it
-     cuts is the BOX, at the cap line, and it would take the O's overshoot with
-     it — and the clip-path below cuts at the fold instead, which is where the
-     design has always drawn the cut.
-     It has to be a clip and cannot be left to paint order, which is the part
-     worth writing down. The section paints after .page and would cover the tail
-     of the letters on its own — but the effect stack lifts the type to
-     --fx-text-z (17) so that it stands above the layers it is excluded from, and
-     the section takes no z-index of its own, so the lifted word is drawn ON the
-     section instead. Below the fold that costs nothing at rest, which is the
-     trap: it is only during the turn, as the section rises past it, that the
-     bottom of PROJECTS is dragged up the dark composition — bright on near-black
-     in dark mode. Giving .panel a z-index instead would fix the word and break
-     the stack, since the numbers it would have to beat are the film, the grain
-     and the CRT, all of which belong over this section.
+     Here the letters are all there and the box is fixed to the fold, so what is
+     under the cut is under the WINDOW: the bottom of the screen does the cutting
+     at every scroll position, and it is the same line at every one of them. So
+     the overflow clip comes off — what it cuts is the BOX, at the cap line, and
+     it would take the O's overshoot with it.
+     It also settles what the word is drawn over. The effect stack lifts the type
+     to --fx-text-z (17) so that it stands above the layers it is excluded from,
+     and the section takes no z-index of its own, so the word is drawn ON the
+     section rather than under it — which is what a word that holds its place
+     while a composition slides in behind it has to be. What that costs is the
+     colour, and the ramp below is the answer to it.
    * The word leaves the measure — both of them. It is no longer the last line of
      the column but a word standing in the page's own corner, so it is set to the
      page's margin instead of the text's — --title-left from the window's edge,
@@ -1977,27 +1972,50 @@ body::after {
      therefore no good either; it is the whole document tall. */
   body::before { content: ""; display: block; height: 0; scroll-snap-align: start; }
   .cut-title {
-    position: absolute;
+    /* FIXED, AND THAT IS THE DEVICE. The word is cut by the fold and it holds
+       that spot on the SCREEN for the whole turn: the CV scrolls out from under
+       it, the section arrives beneath it, and the only thing that happens to the
+       word is that it turns from Friz into the sans. It does not travel, it does
+       not resize, and the cut never moves off the line it was made on.
+       `absolute` was the old spelling of this and cannot say it. Absolutely
+       positioned in .page the box has a fixed DOCUMENT position, which is a
+       different claim: the word is then part of the page above and rides up the
+       window with it, so what the reader sees is the cut word leaving and the
+       section's own masthead arriving where it was.
+       Everything else here is the same declaration it was when the box was
+       absolute — `top: 100vh` is still the fold, since a fixed box's containing
+       block is the viewport and the viewport's own top edge is where 100vh is
+       measured from.
+       THE CUT COMES FREE. What is below the fold is below the WINDOW now, so the
+       bottom of the screen does the cutting; there is nothing to clip and no
+       edge to keep the word above. */
+    position: fixed;
     top: 100vh;
     left: var(--title-left);
     right: calc(50% + var(--col) / 2 + var(--title-left));
     width: auto;
     max-width: none;
     margin: 0;
-    /* THE CUT, and see the second bullet above for why it is a clip rather than
-       the section simply painting over the word. This box's own top edge IS the
-       fold — `top: 100vh`, with the word lifted back above it by the negative
-       margin below — so the cut is the box's top edge and needs no arithmetic of
-       its own. The other three sides are opened well past the window instead of
-       being left at 0: the chroma and halation effects put a shadow on this
-       element that spills outside its box, and a clip tight to the sides would
-       trim that rather than the section. */
-    clip-path: inset(-100vh -100vw 100% -100vw);
   }
+  /* The word holds its place while a near-black composition slides in behind it,
+     so it cannot hold one colour: --ink on the paper is the section's own ground
+     once the section is there, and in the light theme it would simply go out.
+     --cue-land is that crossing, 0 to 1, written by cut-morph.js off where the
+     section's top edge actually is against the word's ink; --cue-land-ink is the
+     far end, read by that same script off the masthead's own computed colour, so
+     the section's palette stays declared in one place — the .panel block — and is
+     not copied up here as a literal. --ink is the near end and is left to the
+     cascade, so the theme toggle still governs the word on the paper.
+     Both ends of the ramp are ordinary CSS, so a browser that never runs the
+     script, or one without `color-mix`, keeps the word at --ink and loses nothing
+     but the crossing. #73 is the ticket that owns that crossing properly. */
   .cut-title > a {
-    /* The clip comes off — the fold does the cutting here, and the O's overshoot
-       above the cap line is meant to be drawn, not sliced off a few pixels
-       short of it. */
+    color: color-mix(in oklab,
+                     var(--cue-land-ink, var(--ink)) calc(var(--cue-land, 0) * 100%),
+                     var(--ink));
+    /* The clip comes off — the bottom of the window does the cutting here, and
+       the O's overshoot above the cap line is meant to be drawn, not sliced off
+       a few pixels short of it. */
     overflow: visible;
     /* But the BOX stays the cap slab, and is not left to `auto`. Two things
        depend on it: the hover underline, which lands on the box's bottom edge


### PR DESCRIPTION
The word was cut at the fold and then rode up the window with the page it
belonged to, so what the reader saw was the cut word leaving the screen and
the section's own masthead arriving where it had been. The turn was
happening to the page rather than to the word.

`position: fixed` instead of `absolute` on .cut-title, and that is the
whole of it. The word keeps its corner of the SCREEN for the entire page
turn — same corner, same size, same cut — while the CV scrolls out from
under it and the section arrives behind it. The one thing that happens to
it is the one thing it is for: Friz Quadrata turns into Host Grotesk. Every
other declaration in the block is untouched: `top: 100vh` is still the
fold, since a fixed box is positioned against the viewport, and the two
insets still resolve to the same pixels because they are percentages of a
containing block that does not count the scrollbar either way. Measured
side by side against development at 1440x1000: the word's resting box is
identical to the pixel — x 90, top 967.703125, 324 x 68.828125 — and the
document is the same 2000 tall, so both snap ports are where they were.

The clip-path from #84 comes off with it. What is under the cut is now
under the WINDOW at every scroll position rather than only at rest, so the
bottom of the screen does the cutting and there is nothing left to clip.

The colour crossing comes back, and this time it is not decoration. A word
that holds its place while a near-black composition slides in behind it
changes ground: in the light theme --ink on --panel-bg is a word that goes
out. --cue-land ramps over the section's top edge crossing the word's
visible ink — about 32px of it at 1440, so the first sliver of the turn,
which is exactly as fast as the ground itself changes — and --cue-land-ink
is read off the masthead's computed colour so the section's palette stays
declared once, in the .panel block. Both ends are ordinary CSS: no script,
or no `color-mix`, and the word stays --ink. #73 still owns the crossing
properly.

Reduced motion now stops the letters and not the colour. Turning eight
letterforms as the page scrolls is motion; a word going out against its own
ground is legibility, and the word is held at the fold by the sheet for
those readers too. So they get Friz, standing still, still legible.

Two rect reads a frame and no cached geometry, deliberately: the page-in
reveal translates .page for its first 0.9s and this file runs during
exactly that, which is where #83's landing came out 8px high.

check-capture-contract.py green: 592 / 852 / 80 / 80 / 80.4, luminance
188.4 light and 46.1 dark.
