### PR TITLE
Put the cut word back the way it worked before the Panel

### DIFF
--- a/portfolio/app.js
+++ b/portfolio/app.js
@@ -72,10 +72,9 @@
   // of the page. It sits OUTSIDE <main class="col">, as a sibling of it — .page
   // is a flex column and the title has to be .page's own child to be held
   // against the bottom edge. On a screen that composes to one page it is pinned
-  // to the fold instead, and one page turn later the section it names is
-  // standing on the screen with a masthead of its own. It does not move or
-  // resize on the way: all the geometry is CSS — see --cut-* and the turn block
-  // in styles.css — and cut-morph.js only turns its face.
+  // to the fold instead and the word carries on onto a second screen, where the
+  // whole of it stands as that screen's title. All the geometry is CSS either
+  // way: see --cut-* and the doorway block in styles.css.
   //
   // THE WORD IS A PICTURE, not type. It is the outlines of PROJECTS set in Friz
   // Quadrata, baked to one SVG path by design/cut-title/build-cut-title.py, and
@@ -403,7 +402,7 @@
     }, { passive: false });
 
     // ---- the page turn -------------------------------------------------------
-    // In the one-screen regime the document is two snap ports and nothing between,
+    // In the doorway regime the document is two snap ports and nothing between,
     // so the browser turns the page with a snap fling of its own — and that fling
     // owns the scroller for as long as it flies. Wheel events that land while it
     // is in the air are filtered out, so the turn back cannot be taken until it
@@ -469,34 +468,51 @@
     // mind while a large force is on it — the page can be carried 26 px past a
     // port and clamped there by the browser for 109 ms, against the cubic's 13 px
     // and 247 ms. Further past, and a third of the time.
+    var doorway = document.querySelector(".doorway");
     var panel = document.querySelector(".panel");
     var TURN = 800;                                     // ms for a whole page turn
     // turnV in px/ms and turnA in px/ms², both signed: the speed and the force
     // this turn is carrying, read by the next one if it interrupts.
     var turnRaf = null, turnTarget = null, turnV = 0, turnA = 0;
-    // The two-port regime, read off the cascade rather than restated here. The
-    // panel takes `scroll-snap-align: start` inside the one-screen media query
-    // and nowhere else, so this IS that query without a second copy of it to
-    // drift. Deliberately not `scrollSnapType` on <html>, which would have been
-    // the obvious probe and is a trap: turnPage() sets it to "none" for the
-    // length of every ease, so a turn in the air would report the regime off and
-    // a reversal mid-flight would be handed back to the browser.
-    function inTurn() {
-      return !!panel && window.getComputedStyle(panel).scrollSnapAlign !== "none";
+    function inDoorway() {                              // the turn regime, per CSS
+      return doorway && window.getComputedStyle(doorway).display !== "none";
     }
     function pageMax() { return document.documentElement.scrollHeight - window.innerHeight; }
-    // The far port: the panel's own top edge, which is where `scroll-snap-align:
-    // start` rests. NOT pageMax(), and the difference is only visible on a wide
-    // window — the panel is min-height:--fold but the Frame grows with the width,
-    // so past about 1600px the composition stands a few per cent past the fold
-    // and the document is longer than the turn. Turning to pageMax() there would
-    // fly the page to the panel's FOOT, overshooting the port and the masthead
-    // with it — and the morph reads the same port, so the word would still be
-    // turning after the page had stopped.
-    function panelPort() {
-      if (!panel) return pageMax();
-      return Math.max(0, Math.min(pageMax(),
-        panel.getBoundingClientRect().top + window.scrollY));
+    /* THE RESTING PLACES, in document pixels and in order. The doorway was
+       written when there were two of them and the wheel could simply pick an end
+       of the document; #57's section stands below the doorway now, so the
+       document is three screens and `pageMax()` is the section's foot rather
+       than the word's landing. A wheel notch that aimed at it would fly the page
+       past the doorway — past the whole point of the doorway, which is that the
+       word comes to rest ON it — so the turn walks the ports instead.
+       Read off the layout rather than restated as arithmetic: the doorway's port
+       is its own `scroll-snap-align: end`, which rests its bottom edge on the
+       bottom of the window, and the section's is its `start`. The doorway block
+       in styles.css sizes the first so the word lands exactly on --title-top. */
+    function ports() {
+      var max = pageMax(), y = window.scrollY, out = [0];
+      function add(v) {
+        v = Math.max(0, Math.min(max, Math.round(v)));
+        if (v > out[out.length - 1] + 1) out.push(v);
+      }
+      if (doorway) add(doorway.getBoundingClientRect().bottom + y - window.innerHeight);
+      if (panel) add(panel.getBoundingClientRect().top + y);
+      return out;
+    }
+    /* The next port in the direction the wheel is heading, or null for "not the
+       turn's business". Null past the last port is what lets a section taller
+       than the window be read: the composition grows with the width and stands
+       a few per cent past the fold on a wide one, and down there the wheel is
+       the browser's again. Coming back up, the reader scrolls natively to the
+       port and the next notch turns the page. */
+    function nextPort(down) {
+      var ps = ports(), y = window.scrollY, i;
+      if (down) {
+        for (i = 0; i < ps.length; i++) if (ps[i] > y + 1) return ps[i];
+        return null;
+      }
+      for (i = ps.length - 1; i >= 0; i--) if (ps[i] < y - 1) return ps[i];
+      return null;
     }
     function turnPage(target) {
       var root = document.documentElement;
@@ -547,17 +563,13 @@
     }
     document.addEventListener("wheel", function (e) {
       if (owner === "strip") return;                    // the roll has this gesture
-      if (!inTurn()) return;
+      if (!inDoorway()) return;
       var d = e.deltaY;                                 // the turn is vertical only:
       if (!d) return;                                   // a sideways swipe is the roll's
-      var port = panelPort();
-      // Past the port, inside a panel taller than the window, the wheel is the
-      // browser's again: there is a composition to read down there and the turn
-      // has already done its job. CSS agrees — a snap area larger than the
-      // scrollport relaxes snapping inside itself. Coming back up, the reader
-      // scrolls natively to the port and the next notch turns the page.
-      if (window.scrollY > port + 1) return;
-      var target = d > 0 ? port : 0;
+      var target = nextPort(d > 0);
+      // nothing to turn: no port that way — the foot of a tall section, or the
+      // top of the document — so leave the event to the browser
+      if (target === null) return;
       // nothing to turn: the page is already standing on that port and no turn is
       // in the air, so leave the event alone
       if (turnRaf === null && Math.abs(window.scrollY - target) < 1) return;

--- a/portfolio/cut-morph.js
+++ b/portfolio/cut-morph.js
@@ -1,29 +1,12 @@
 /* The cut title's morph — PROJECTS turning from Friz Quadrata into a sans as
- * the page scrolls, and NOTHING ELSE MOVES. The word is held at the fold by CSS
- * — `position: fixed` in the turn block of styles.css — so it keeps its corner
- * of the screen, its size and its cut for the whole page turn while the CV
- * scrolls out from under it and the section arrives behind it. All this file
- * does is turn the letterforms, and ramp the word's colour where the section's
- * top edge passes it, because past that edge the ground is near-black and one
- * colour cannot serve both. The section prints its own masthead.
- *
- * TWO WAYS OF MOVING THE WORD HAVE BEEN TRIED AND ARE NOT COMING BACK, which is
- * worth knowing before writing a third. The doorway parked it in the top-left
- * corner of a blank screen; #83 flew it out of its corner onto the masthead's
- * ink, scaled to that h2's cap, and hid the masthead under `.cue-fly` so the
- * word was not drawn twice. The scale is what the second cost: at 1440 the cut
- * word's cap is 49px and the masthead's is about 75, so the word grew by half on
- * the way down, and the word at the fold had been right at its own size since
- * before the section existed. What the scroll is for is the turn.
+ * the page scrolls.
  *
  * NOTHING ON THE PAGE DEPENDS ON THIS FILE, the same stance effects.js takes. It
  * is loaded last, and a browser that never runs it — parse error, blocked
- * script — gets the cut title exactly as it was before any of this: the one
- * baked Friz path that app.js puts inline, held at the fold by the sheet, on
- * screen at first paint. All this does is swap that single path for the same
- * outlines split into eight, and then turn them. Reduced motion is the one case
- * that is not all-or-nothing; see the note further down for why the colour is
- * still written there.
+ * script, reduced motion — gets the cut title exactly as it was before any of
+ * this: the one baked Friz path that app.js puts inline, on screen at first
+ * paint. All this does is swap that single path for the same outlines split into
+ * eight, and then move them.
  *
  * WHAT THE TWEEN IS. Both ends are the real typeface: at rest each letter is its
  * own Bezier outline, Friz's at the start and the sans's at the end, and the
@@ -169,114 +152,56 @@
 
   // ---- what drives it ------------------------------------------------------
 
-  var root = document.documentElement;
-  var panel = document.querySelector(".panel");
+  /* WHERE THE TURN ENDS, in document pixels: the scroll at which the word is
+     home, standing whole in the top-left corner as the doorway's title. That is
+     the doorway's own `scroll-snap-align: end` — its bottom edge on the bottom
+     of the window — and the doorway block in styles.css sizes it precisely so
+     the cap lands on --title-top there.
+     NOT THE END OF THE DOCUMENT, which is what this was when the doorway was the
+     last thing in it. #57's section stands below the doorway now, so the
+     document runs a screen further than the word's landing, and dividing by the
+     whole of it would leave the word a third short of Host Grotesk at the moment
+     it arrives — the turn finishing somewhere down inside the section, where the
+     word is not even on screen.
+     Without a doorway — every regime below the gate, where the word is still the
+     last line of the column — it is the document again, and the whole descent
+     turns the word. */
+  var doorway = document.querySelector(".doorway");
 
-  /* WHERE THE TURN ENDS, in document pixels: the top of the projects section,
-     which is the port `scroll-snap-align: start` rests on and the scroll position
-     at which the word is home. Not the document's own end, which is the same
-     number only when the composition happens to be exactly one screen tall — on
-     a wide window the Frame grows with the width and the panel stands a few per
-     cent past the fold, and dividing by THAT would leave the word still turning
-     after it had landed. */
   function landing() {
-    var max = (root.scrollHeight || 0) - (window.innerHeight || 0);
+    var doc = document.documentElement;
+    var max = (doc.scrollHeight || 0) - (window.innerHeight || 0);
     if (max <= 1) return 0;
-    if (!panel) return max;
-    var top = panel.getBoundingClientRect().top + (window.pageYOffset || root.scrollTop || 0);
-    return Math.max(1, Math.min(max, top));
+    // `display: none` outside the gate, and a box with no height has no rect to
+    // read either — one layout read rather than a computed style per frame.
+    if (!doorway || !doorway.offsetHeight) return max;
+    var y = window.pageYOffset || doc.scrollTop || 0;
+    var end = doorway.getBoundingClientRect().bottom + y - (window.innerHeight || 0);
+    return Math.max(1, Math.min(max, end));
   }
 
   /* HOW FAR THROUGH THE TURN YOU ARE, and not where the word is on the screen.
      Tying it to the word's own position looks like the obvious thing and does
-     not work: the cut title is held against the fold — that is the whole device —
-     so it never travels up the viewport the way a section does. Scroll fraction
-     against the landing has no such regime to get wrong: where the document is
-     two screens it is the second screen that turns the word, and on a long column
-     it is the whole descent down to the section.
+     not work: the cut title is held against the fold — that is the whole
+     device — so on a composition that does not fit one screen it sits a few
+     pixels above the fold at full scroll and no viewport-relative measure ever
+     leaves zero. Scroll fraction against the landing has no such regime to get
+     wrong: in the doorway, where the word has a screen to travel, it is that
+     screen that turns it; on a long column it is the whole descent.
 
      A page too short to scroll stays at Friz rather than dividing by nothing. */
   function progress() {
-    var t = (window.pageYOffset || root.scrollTop || 0) / landing();
+    var doc = document.documentElement;
+    var t = (window.pageYOffset || doc.scrollTop || 0) / landing();
     return t < 0 ? 0 : t > 1 ? 1 : t;
-  }
-
-  /* ---- the crossing --------------------------------------------------------
-     The word is fixed to the fold — see the turn block in styles.css — so it
-     holds its corner of the SCREEN while the section slides up behind it. That
-     is one word on two grounds: paper until the section's top edge passes it,
-     near-black after, and in the light theme --ink on --panel-bg is a word that
-     goes out. So the colour crosses with the ground.
-
-     WHAT IS RAMPED AGAINST WHAT. The band that matters is the word's VISIBLE
-     ink: from the top of the drawing down to the bottom of the window, since
-     what is under the fold is under the window and there is nothing there to be
-     over. The section's edge sweeps that band — about 32px of it at 1440, so
-     about 3% of the turn, right at the end — and the ramp is where the edge is
-     inside it. Both are read per frame, and deliberately: the word is fixed and
-     the section's top is a constant of the layout, but the page-in reveal
-     translates .page for its first 0.9s and this file runs during exactly that,
-     so a cached rect is a rect measured 8px out. Two rects a frame is what the
-     flight cost too.
-
-     Smoothstep on top, the same curve the letters are eased with. It does not
-     fix the straddle — nothing one colour can do fixes the straddle, and in the
-     middle of that band the word genuinely is half on each — it only keeps the
-     word committed to a ground for most of the crossing. #73 owns it properly.
-
-     The COLOUR it crosses to is the masthead's own, read off the cascade so the
-     section's palette stays declared in one place: the .panel block. --ink is
-     the near end and is left to the cascade too, so the theme toggle still
-     governs the word on the paper. */
-  var masthead = document.querySelector(".panel-masthead");
-  var crossing = false;
-
-  /* Whether there is a crossing here at all, and the colour of its far end.
-     Taken once per layout rather than per frame: `position` and a computed
-     colour both cost a style recalc, and neither moves while the page sits
-     still. Outside the turn — a window below the gate, where the word is still
-     a block in the column — this stays false, nothing is written, and the word
-     keeps --ink through the cascade alone. */
-  function measure() {
-    crossing = false;
-    host.style.removeProperty("--cue-land");
-    host.style.removeProperty("--cue-land-ink");
-    if (!panel || !masthead) return;
-    if (window.getComputedStyle(host).position !== "fixed") return;
-    host.style.setProperty("--cue-land-ink", window.getComputedStyle(masthead).color);
-    crossing = true;
-  }
-
-  function land() {
-    if (!crossing) return;
-    var pic = svg.getBoundingClientRect();
-    var hi = Math.min(pic.bottom, window.innerHeight || 0);
-    var span = hi - pic.top;
-    var c = span > 0 ? (hi - panel.getBoundingClientRect().top) / span : 0;
-    c = c < 0 ? 0 : c > 1 ? 1 : c;
-    host.style.setProperty("--cue-land", (c * c * (3 - 2 * c)).toFixed(3));
   }
 
   var pinned = null;                 // a number while the tuner is holding it
   var queued = false;
 
-  /* REDUCED MOTION STOPS THE LETTERS AND NOT THE COLOUR, and the split is the
-     point. Turning eight letterforms as the page scrolls is motion and is what
-     the setting is asking about; a word going out against the ground it is
-     standing on is legibility, and it is exactly as wrong for a reader who asked
-     for less movement. So the word stays in Friz for them, held at the fold by
-     CSS as it is for everyone, and still crosses. */
-  var still = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)");
-  var motion = !still || !still.matches;
-
-  /* The letters take the pinned T when the tuner is holding one, and the real
-     scroll otherwise: design/cut-title/morph-tuner.html scrubs T without moving
-     the page, which is what judging the letterforms needs. #69's tuner is where
-     the composition gets judged. */
   function frame() {
     queued = false;
-    if (motion) draw(pinned === null ? progress() : pinned);
-    land();
+    draw(pinned === null ? progress() : pinned);
   }
 
   /* Scrolling goes through a frame — it fires far faster than the display and
@@ -289,21 +214,12 @@
 
   build(FACE);
 
-  /* Scroll is the input. `resize` and `load` are here because both the LANDING
-     and the crossing can move without one: a resized window is the obvious case,
-     and `load` is for the corner pictures, which arrive late and settle the CV's
-     height. The theme carries the colour the word crosses FROM, and the one it
-     crosses to is read at measure time, so a toggle mid-turn re-reads rather
-     than stranding the word part-way to a colour the page has stopped using. */
-  window.addEventListener("scroll", kick, { passive: true });
-  window.addEventListener("resize", function () { measure(); kick(); });
-  window.addEventListener("load", function () { measure(); kick(); });
-  if (window.MutationObserver) {
-    new window.MutationObserver(function () { measure(); kick(); })
-      .observe(root, { attributes: true, attributeFilter: ["data-theme"] });
+  var still = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)");
+  if (!still || !still.matches) {
+    window.addEventListener("scroll", kick, { passive: true });
+    window.addEventListener("resize", kick);
+    kick();
   }
-  measure();
-  kick();
 
   /* The tuner's handle on this, and the only reason any of it is exposed.
      design/cut-title/morph-tuner.html iframes the real page and reaches in. */

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -315,6 +315,9 @@
        the ascii block in styles.css and drawAscii() in effects.js. -->
   <canvas class="fx-ascii" aria-hidden="true"></canvas>
   <div class="page" id="page"></div>
+  <!-- The second screen the cut title opens onto. Empty, and sized entirely in
+       CSS: see the doorway block in styles.css. -->
+  <div class="doorway"></div>
   <!-- ====================================================================
        THE PROJECTS PANEL
        ====================================================================
@@ -324,9 +327,9 @@
        and — for now — a placeholder standing where the browser Frame will.
        The panel block in styles.css is the whole of the geometry.
 
-       STATIC MARKUP, NOT BUILT BY app.js, for two reasons. It is one
-       composition with no repetition in it, so there is nothing for a template
-       to earn; and it is
+       STATIC MARKUP, NOT BUILT BY app.js, and the two reasons are the same
+       two the doorway above is static for. It is one composition with no
+       repetition in it, so there is nothing for a template to earn; and it is
        on screen at first paint, which is what the rest of this page spends so
        much of its <head> buying. app.js owns the CV because the CV is data.
 
@@ -340,19 +343,19 @@
        exactly as it would one level in: the panel is below the fold, far below
        the 852px crop, and the capture never reaches it.
 
-       There used to be a `.doorway` between this and .page — one blank screen
-       for the cut word to arrive on as its title, from when the word opened
-       onto nothing. It is gone: this section stands directly under the fold, one
-       page turn below the CV, and the cut word does not arrive anywhere. It is
-       fixed to the fold and holds that corner of the screen while this section
-       comes up behind it, turning as it goes. See the turn block in styles.css.
-       The reason the panel still cannot be a child of .page is
-       the one the doorway was written for in the first place — in the
-       one-screen regime .page is exactly one screen and .cut-title is pinned
-       out of flow at the fold, so a panel inside .page would land
-       underneath that pinned word and push nothing out of the way. Outside it,
-       the reading order is the one the design asks for in every regime: the CV,
-       and then the section the cut word turns into the title of.
+       What does not survive the letter of it is the doorway. In the regime
+       where the composition fits one screen — see the doorway block — .page is
+       exactly one screen, .cut-title is pinned out of flow at `top: 100vh`,
+       and .doorway is the blank screen the word arrives on as its title. A
+       panel inside .page lands underneath that pinned word and pushes nothing
+       out of the way, so the word would be printed across the top of this
+       section and the blank screen would follow it. After .doorway the reading
+       order is the one the design asks for in every regime: the CV, the word
+       standing whole as a title, and then the section it is the title of.
+       The doorway's own arithmetic is untouched by anything that follows it —
+       it snaps on `scroll-snap-align: end`, which measures its own box and not
+       the end of the document. See the panel block in styles.css for the third
+       snap port this adds so mandatory snapping still has somewhere to rest.
 
        DARK IN BOTH THEMES, and nothing in here reads --ink, --bg or any of the
        six other properties the capture overrides by name. The palette is
@@ -383,19 +386,6 @@
     </ul>
     <div class="panel-inner">
       <header class="panel-head">
-        <!-- THE SECTION'S OWN MASTHEAD, always drawn. It is the same word as the
-             one cut off the foot of the page above, in the face that word turns
-             into over the scroll, and the two are deliberately left as two: #83
-             flew the cut word down onto this h2 and hid it under `.cue-fly`, and
-             that is out again because it had to scale the cut word by half to
-             fit — see the morph block in cut-morph.js. The cut word holds the
-             fold instead, so on this screen it is standing in the bottom-left
-             corner while this h2 is at the top. cut-morph.js reads this
-             element's computed colour, and only that: it is the far end of the
-             crossing the word makes onto this section's ground, which keeps the
-             palette declared once, in the .panel block. This also sets row one's
-             height and is where the subheading starts, and it is the section's
-             accessible name, referenced by the `aria-labelledby` above. -->
         <h2 class="panel-masthead" id="panel-masthead">Projects</h2>
         <!-- Two authored lines, not one string left to wrap. The second line is
              the one the Frame passes in front of, so where it breaks is part of
@@ -524,6 +514,6 @@
        only ever replaces one <svg>'s contents, so a browser that skips it —
        blocked, errored, or asking for reduced motion — keeps the baked Friz
        path exactly as it is inline. -->
-  <script src="cut-morph.js?v=4"></script>
+  <script src="cut-morph.js?v=3"></script>
 </body>
 </html>

--- a/portfolio/styles.css
+++ b/portfolio/styles.css
@@ -577,7 +577,7 @@
      the max() in the one-screen block below). The two are the same number on
      every ordinary display and part company only above ~1250px of height, where
      --rhyme keeps growing and --corner stops. Anything that wants "the page's
-     margin" as a fixed inset — the cut word's corner — has to read --corner,
+     margin" as a fixed inset — the doorway title's corner — has to read --corner,
      because a margin that tracks 100vh is a vertical idea and reads as an error
      the moment it is used horizontally: at 2160px tall --rhyme is 605px, which
      would put a left-hand title in the middle of the screen. */
@@ -662,8 +662,8 @@
      where Georgia's J sits on it. The cut box is the cap slab, cap top to
      baseline, so no value of --cue-show can reach the hook: cut, the J is a bare
      stem at 0.62 and at 1.0 alike, and the word reads PRO|ECTS. It comes back
-     whole in the one-screen regime, where the clip comes off and the descender
-     has somewhere to hang. That is a property of the drawing, not a number to tune.
+     whole in the doorway regime, where the clip comes off and the descender has
+     somewhere to hang. That is a property of the drawing, not a number to tune.
 
      The tracking that used to be here — --cue-track, 0.02em, positive because
      this face's caps are fitted tight and its wedge arms overhang their own
@@ -695,8 +695,8 @@
      the cut itself is taken from, and it replaces `1cap` exactly.
      --cue-fit and --cue-cap are its twin as a LENGTH, and the reason for a twin
      is that a container-query unit resolves against .cut-title and cannot be
-     spent by boxes that are not inside it — the height budget below, --slide-h
-     and --rhyme. So the same arithmetic is written again against --col, which is
+     spent by boxes that are not inside it — the height budget below, --slide-h,
+     .doorway. So the same arithmetic is written again against --col, which is
      what the container resolves to on every window wide enough to fill it:
      0.977592 x 27rem of ink, x 0.154521 of cap = 4.0786rem, which is the 4.079
      this replaces to within a hundredth of a pixel. Below --col the twin is a
@@ -705,7 +705,7 @@
      the clip, so a change to the cut word's height falls outside it.
      --cue-clip is then the visible slice: the part of the word that survives the
      cut. Both regimes hold the word's cap top exactly --cue-clip above the fold;
-     they differ only in what does the cutting (see the turn block below).
+     they differ only in what does the cutting (see the doorway block below).
      Like --cue-ink, these are the values for a word set to the COLUMN. In the
      one-screen band the word is fitted to the gutter instead and --cue-fit is
      re-pointed there; the two lines below are written once and hold in both. */
@@ -714,16 +714,15 @@
   --cue-cap:  calc(var(--cue-cap-share) * var(--cue-fit));
   --cue-clip: calc(var(--cue-show) * var(--cue-cap));
 
-  /* ---- where the word STARTS out in the gutter -----------------------------
-     At rest the cut word stands on the page's own margin in the bottom-left
-     corner, cut by the fold. --corner is that margin, reused rather than
-     re-chosen, and it is spent twice: once as the inset itself and once as the
-     white on the far side of the word, which is what --cue-measure below is
-     built out of.
-     There was a --title-top here as well, for the top-left corner the word used
-     to come to rest in on a blank second screen. That screen is gone and so is
-     the corner: the projects section stands directly under the fold now, and the
-     word stays where it is cut. See the turn block at the foot of this sheet. */
+  /* ---- where the word lands once it is a title -----------------------------
+     Scrolled home, the cut word stands in the top-left corner of the second
+     screen as a plain title. Both insets come off --corner, so the corner is one
+     measure square and the title's cap top lands on the same line the name's ink
+     starts on one screen above — the page's one margin, reused rather than
+     re-chosen. --title-top carries the half-leading because --corner is measured
+     to the name's INK, and a display word trimmed to its cap slab has no leading
+     of its own to stand the difference. */
+  --title-top:  calc(var(--corner) + var(--name-half-leading));
   --title-left: var(--corner);
 
   /* Everything in the document that is NOT the photo strip and NOT one of the
@@ -874,15 +873,14 @@
    the profile-README capture in chrisJuresh/chrisJuresh probes at, 1000px and
    592px, whose hardcoded 592 divisor is derived from the photo width.
 
-   The same gate appears once more at the foot of this sheet, for the turn — the
-   page turn out of the CV and into the projects section, which is what the cut
-   title opens onto. It has to be down there to win the cascade; the two blocks
-   are one idea and the gates must be kept in step. */
+   The same gate appears once more at the foot of this sheet, for the doorway —
+   the second screen the cut title opens onto. It has to be down there to win the
+   cascade; the two blocks are one idea and the gates must be kept in step. */
 @media (min-width: 1100px) and (min-height: 983px) {
   :root {
     /* ---- the cut word's measure, out in the gutter -------------------------
        This is the band where the word leaves the column and stands in the
-       page's bottom-left corner instead (see the turn block at the foot of
+       page's bottom-left corner instead (see the doorway block at the foot of
        this sheet, which does the moving). Out there it has a measure of its
        own, and one rule sets it: the white to the LEFT of the word — page edge
        to the P — and the white to its RIGHT — the S to the line the resume
@@ -902,15 +900,15 @@
        centred in the width WITHOUT it, so --cue-measure runs half a scrollbar
        wide of the true gutter — 7.5px on Windows, nothing at all where
        scrollbars are overlaid, and this band always has a scrollbar because
-       the projects section gives it one. The word itself does not inherit
-       that error.
+       the doorway gives it one. The word itself does not inherit that error.
        Both of the things that have to be exact are held off something else:
        the two margins off percentages of the containing block, which do not
        count the scrollbar, and the CUT off the word's own `cap`, read from the
        face at the size it actually resolved to. What is left reading the vw
-       twin is the height BUDGET alone — --slide-h and --rhyme — where being
-       0.72px out (0.62 x 0.1545 x 7.5) takes that much off the photo strip.
-       Constant at every window size, and not worth a script.
+       twin is the height BUDGET alone — .doorway's height, --slide-h,
+       --rhyme — where being 0.72px out (0.62 x 0.1545 x 7.5) puts the second
+       screen's title that far below --title-top and takes that much off the
+       photo strip. Constant at every window size, and not worth a script.
        It is worth knowing WHY the cut is not allowed to spend it, because the
        number looks harmless: 0.72px is 0.9% of the cap at 1920 but 3.9% of it
        at the narrow end of this band, where the word is a quarter the size. Off
@@ -1161,7 +1159,7 @@ body::after {
    and is gone by the second screen. Its foot lands well above that line at every
    size the ceiling on --car-w allows, so in practice the clip never fires; it is
    there so that a hand-tuned --car-fill or --car-y cannot hang a photograph into
-   the projects section below.
+   the doorway.
 
    --car-crop cuts the TOP rather than the foot, which is the corner it is
    anchored to — same arithmetic as --plate-crop with the sign of the edge
@@ -1784,6 +1782,13 @@ body::after {
   max-width: var(--col);                 /* sized and centred exactly like .col */
   margin: var(--cue-gap) auto 0;
 }
+/* The second screen, and nothing else — it exists to give the document a length
+   to scroll and a second place to rest. It is empty on purpose: what arrives on
+   it is the cut word, which is not its child. Off in every regime but the one
+   that composes to a screen; a column that already scrolls has no page turn to
+   offer, and the profile-README capture probes at 1000px and 592px, where this
+   has to add exactly nothing to the document. */
+.doorway { display: none; }
 .cut-title > a {
   display: block;
   overflow: clip;
@@ -1797,7 +1802,7 @@ body::after {
 /* The word is clickable, and a display word gives nothing to underline — its
    baseline is below the cut. So the site's 1px link rule goes on the cut itself,
    drawn as an inset shadow rather than a border so it costs the clip box no
-   height and the geometry above stays exact. In the one-screen regime the same
+   height and the geometry above stays exact. In the doorway regime the same
    shadow lands on the baseline instead, because the box is then the cap slab and
    is not clipped — the one place the word is whole is the one place it can take
    an ordinary underline, and it is also the place you would click it. Cut, it
@@ -1816,7 +1821,7 @@ body::after {
    edge is the highest ink in the word, which is the O's overshoot, so the
    drawing is lifted by exactly that much and the cut is then taken from the cap.
    RELATIVE, not a negative margin, and this is not a preference — a margin is
-   wrong in the one-screen regime and wrong silently. There the link runs
+   wrong in the doorway regime and wrong silently. There the link runs
    `overflow: visible`, so it is no longer a block formatting context and its
    first child's top margin COLLAPSES into its own: the two negative margins
    would not add, the larger (the link's own lift) would simply win, and the
@@ -1854,67 +1859,43 @@ body::after {
   border: 0 !important;
 }
 
-/* ---- the turn ---------------------------------------------------------------
+/* ---- the doorway ----------------------------------------------------------
    The cut word is a promise that there is more below the page, and in this
    regime — the only one where the composition fits a screen exactly, so the same
-   gate as "composing to one screen" above — the page keeps it. The projects
-   section follows, and the document holds exactly two resting places: the CV,
-   and the section. Mandatory snap with two snap ports and nothing between them
-   means one notch of the wheel travels the whole way; there is nowhere to come
-   to rest half way, so it is a page turn rather than a scroll.
+   gate as "composing to one screen" above — the page keeps it. One screen of
+   paper follows, and the document holds exactly two resting places: the CV, and
+   the word standing uncut in the top-left corner as the title of the screen it
+   opens onto. Mandatory snap with two snap ports and nothing between them means
+   one notch of the wheel travels the whole length of the document; there is
+   nowhere to come to rest half way, so it is a page turn rather than a scroll.
 
-   WHAT USED TO BE HERE, AND WHY IT IS NOT. Between those two there was a
-   `.doorway` — one blank screen, sized `100vh - --cue-clip - --title-top`, whose
-   only job was to give the document exactly enough overflow that scrolling to
-   the end parked the cut word in the top-left corner as that screen's title. It
-   was written when the word opened onto nothing, and once the section arrived
-   underneath it the page had three resting places and the middle one was an
-   empty sheet with a half-turned word on it. The word also came to rest a whole
-   screen above the fold, out of sight, while the section below printed the SAME
-   WORD again as its masthead in the very face the morph resolves into.
-
-   So the blank screen went and the section came up to the fold. THE WORD HOLDS
-   ITS PLACE. It is cut at the fold, in the page's bottom-left corner, and it
-   stays exactly there on the SCREEN for the whole turn — same corner, same size,
-   same cut — while the CV scrolls out from under it and the section arrives
-   behind it. The one thing that happens to it is the one thing it is for: it
-   turns from Friz Quadrata into the sans. `position: fixed` below is the whole
-   of that, and the note on it is where the reasoning sits.
-
-   TWO THINGS HAVE BEEN TRIED HERE AND ARE NOT COMING BACK, both of which moved
-   the word instead of the page. The doorway parked it in a top-left corner a
-   screen down; #83 flew it onto the section's masthead and scaled it to that
-   h2's cap, which grew the word by half on the way — 49px of cap against 75 at
-   1440 — when the word at the fold had been the size the composition wanted
-   since before the section existed. The word was right where it was and at the
-   size it was; what the scroll is for is the turn.
-
-   What this sheet fixes is therefore the whole of the word: the two insets
-   below, the cut, and the two snap ports. Every browser gets the same page, with
-   or without cut-morph.js — the word held at the fold, the section's own
-   masthead drawn as the section's own masthead, and one page turn between them.
+   The arithmetic is one line. Call the word's cap top Y = 100vh - --cue-clip —
+   that IS the cut, --cue-clip of the letters above the fold and the rest below —
+   and the title's landing T = --title-top. Scrolling to the end lifts everything
+   by exactly the document's overflow, so the overflow has to be Y - T, which is
+   what .doorway is tall. The document is then 100vh + (Y - T), and the word
+   arrives at T on the nose at every window height, with no script and no
+   scroll-driven animation.
+   One footnote on Y, since two things now measure it. The word is CUT off its
+   own `cap` and .doorway is tall off --cue-clip, which is the same line arrived
+   at twice — exactly, wherever scrollbars are overlaid, and 0.72px apart where
+   they are not, in the direction of resting the title that far under T. See the
+   scrollbar paragraph at --cue-measure for why the cut is the one that gets to
+   be exact.
 
    Two consequences worth naming:
-   * The cut becomes REAL, and the window makes it. Everywhere else the word is
-     clipped to --cue-clip by its own overflow, because the document ends beneath
-     it and there is no second screen for the rest of the letters to stand on.
-     Here the letters are all there and the box is fixed to the fold, so what is
-     under the cut is under the WINDOW: the bottom of the screen does the cutting
-     at every scroll position, and it is the same line at every one of them. So
-     the overflow clip comes off — what it cuts is the BOX, at the cap line, and
-     it would take the O's overshoot with it.
-     It also settles what the word is drawn over. The effect stack lifts the type
-     to --fx-text-z (17) so that it stands above the layers it is excluded from,
-     and the section takes no z-index of its own, so the word is drawn ON the
-     section rather than under it — which is what a word that holds its place
-     while a composition slides in behind it has to be. What that costs is the
-     colour, and the ramp below is the answer to it.
+   * The cut becomes REAL. Everywhere else the word is clipped to --cue-clip by
+     its own overflow, because the document ends beneath it and there is no
+     second screen for the rest of the letters to stand on. Here they are all
+     there and the bottom of the window does the cutting, which is what the
+     device was always drawing. So the clip comes off: leave it on and the word
+     would arrive in the corner still guillotined.
    * The word leaves the measure — both of them. It is no longer the last line of
-     the column but a word standing in the page's own corner, so it is set to the
-     page's margin instead of the text's — --title-left from the window's edge,
-     the same measure as the white above it, which is what makes the corner read
-     as a corner. And it is no longer the column's width either: it is fitted to
-     the gutter it now stands in, so that the white either side of it is that same
+     the column but the title of its own screen, so it is set to the page's
+     margin instead of the text's — --title-left from the window's edge, the same
+     measure as the white above it, which is what makes the corner read as a
+     corner. And it is no longer the column's width either: it is fitted to the
+     gutter it now stands in, so that the white either side of it is that same
      --title-left twice over — page edge to the P, S to the line the resume
      starts on. See --cue-measure in the one-screen block for the whole of that
      derivation; here it is only placed.
@@ -1939,15 +1920,14 @@ body::after {
      margin, and --cue-ink goes to a flat 100cqw with --cue-lead at zero.
 
    .cut-title is positioned rather than laid out for one reason: .page is exactly
-   one screen and the panel is the next, so the word can be a flex item of
-   neither — as .page's it would be pushed down by the section below, and as the
-   panel's it could not stand above its own top edge. Pinned to the fold it is in
-   neither, which is also the truth of it. It lands in the same place the flow
-   put it: --slide-h is sized so the column plus --cue-gap reaches exactly the
-   cap top at 100vh - --cue-clip, so the two agree, and the gap under the contact
-   block is what it always was.
-   `top`, not `bottom`, because the offset then holds the cap top on that line
-   whatever the box's own height turns out to be.
+   one screen and the doorway is the next, so the title can be a flex item of
+   neither — as .page's it would be pushed down by the second screen, and as the
+   doorway's it could not stand above its own top edge. Pinned to the fold it is
+   in neither, which is also the truth of it. It lands in the same place the flow
+   put it: --slide-h is sized so the column plus --cue-gap reaches exactly Y, so
+   the two agree, and the gap under the contact block is what it always was.
+   `top`, not `bottom`, because the offset then holds the cap top at Y whatever
+   the box's own height turns out to be.
 
    These rules sit at the end of the sheet, not up in the :root block that shares
    their gate: every one of them overrides a base rule of the same specificity,
@@ -1971,25 +1951,13 @@ body::after {
      which would switch the snapping off rather than pin it. body itself is
      therefore no good either; it is the whole document tall. */
   body::before { content: ""; display: block; height: 0; scroll-snap-align: start; }
+  .doorway {
+    display: block;
+    height: calc(100vh - var(--cue-clip) - var(--title-top));
+    scroll-snap-align: end;
+  }
   .cut-title {
-    /* FIXED, AND THAT IS THE DEVICE. The word is cut by the fold and it holds
-       that spot on the SCREEN for the whole turn: the CV scrolls out from under
-       it, the section arrives beneath it, and the only thing that happens to the
-       word is that it turns from Friz into the sans. It does not travel, it does
-       not resize, and the cut never moves off the line it was made on.
-       `absolute` was the old spelling of this and cannot say it. Absolutely
-       positioned in .page the box has a fixed DOCUMENT position, which is a
-       different claim: the word is then part of the page above and rides up the
-       window with it, so what the reader sees is the cut word leaving and the
-       section's own masthead arriving where it was.
-       Everything else here is the same declaration it was when the box was
-       absolute — `top: 100vh` is still the fold, since a fixed box's containing
-       block is the viewport and the viewport's own top edge is where 100vh is
-       measured from.
-       THE CUT COMES FREE. What is below the fold is below the WINDOW now, so the
-       bottom of the screen does the cutting; there is nothing to clip and no
-       edge to keep the word above. */
-    position: fixed;
+    position: absolute;
     top: 100vh;
     left: var(--title-left);
     right: calc(50% + var(--col) / 2 + var(--title-left));
@@ -1997,25 +1965,9 @@ body::after {
     max-width: none;
     margin: 0;
   }
-  /* The word holds its place while a near-black composition slides in behind it,
-     so it cannot hold one colour: --ink on the paper is the section's own ground
-     once the section is there, and in the light theme it would simply go out.
-     --cue-land is that crossing, 0 to 1, written by cut-morph.js off where the
-     section's top edge actually is against the word's ink; --cue-land-ink is the
-     far end, read by that same script off the masthead's own computed colour, so
-     the section's palette stays declared in one place — the .panel block — and is
-     not copied up here as a literal. --ink is the near end and is left to the
-     cascade, so the theme toggle still governs the word on the paper.
-     Both ends of the ramp are ordinary CSS, so a browser that never runs the
-     script, or one without `color-mix`, keeps the word at --ink and loses nothing
-     but the crossing. #73 is the ticket that owns that crossing properly. */
   .cut-title > a {
-    color: color-mix(in oklab,
-                     var(--cue-land-ink, var(--ink)) calc(var(--cue-land, 0) * 100%),
-                     var(--ink));
     /* The clip comes off — the bottom of the window does the cutting here, and
-       the O's overshoot above the cap line is meant to be drawn, not sliced off
-       a few pixels short of it. */
+       the J's hook and the baseline are meant to be seen on the screen below. */
     overflow: visible;
     /* But the BOX stays the cap slab, and is not left to `auto`. Two things
        depend on it: the hover underline, which lands on the box's bottom edge
@@ -2036,20 +1988,19 @@ body::after {
        is not clipped. */
     margin-top: calc(-1 * var(--cue-show) * var(--cue-slab));
   }
-  /* The second resting place, and the far end of the turn. With .doorway gone
-     these are the only two ports in the document — `body::before` at the top and
-     this — which is what makes the turn a turn: `scroll-snap-type: y mandatory`
-     means the scroller must COME TO REST on a port, and with nothing between
-     them there is nowhere to stop half way.
-     `start`, so the section arrives with its masthead against the top of the
-     window — and the masthead is drawn, in every regime and whatever the script
-     does, because the word above no longer comes down onto it. When the
-     composition is taller than the window the area is larger than the
-     scrollport, which relaxes snapping inside it rather than switching it off —
-     you can read to the bottom of a tall panel without being pulled back up, and
-     app.js hands the wheel back to the browser past this port for exactly that
-     stretch.
-     What the Rail does, and the crossing into dark, are still #72 and #73. */
+  /* The third resting place, and it is not optional. The two ports above are
+     `body::before` at the top and .doorway at the end, and `scroll-snap-type: y
+     mandatory` means the scroller must COME TO REST on a port — so a section
+     added past the last one is not merely un-snapped, it is unreachable: every
+     scroll into it is snapped straight back to the doorway. This is what makes
+     it reachable at all in this regime. Movement — what the Rail does, and what
+     the crossing into dark does — is #72 and #73; this is the floor under both.
+     `start`, so the panel arrives with its masthead against the top of the
+     window, the same edge the doorway's title stands on. When the composition is
+     taller than the window the area is larger than the scrollport, which relaxes
+     snapping inside it rather than switching it off — you can read to the bottom
+     of a tall panel without being pulled back up, which is the behaviour wanted
+     here anyway. */
   .panel { scroll-snap-align: start; }
 }
 
@@ -2058,8 +2009,8 @@ body::after {
    ============================================================================
    The dark composition at the foot of the document: one project shown rather
    than described. The markup is static and lives in index.html — the comment
-   above it says why it is there and why it stands outside .page rather than
-   inside it — and this block is the whole of the geometry.
+   above it says why it is there and why it stands after .doorway rather than
+   inside .page — and this block is the whole of the geometry.
 
    WHAT IS HERE AND WHAT IS NOT. This is the skeleton (#64): the masthead, the
    subheading, the Rail, the body copy, the four engineering points, and a
@@ -2084,7 +2035,7 @@ body::after {
    capture hides everything after the Work Experience listing by walking
    `nextElementSibling` from it — inside .col — so nothing here is hidden by
    that pass. It stays out of the shot by falling below cropHeight (852), a
-   whole screen further down. design/tools/check-capture-contract.py
+   whole screen and a doorway further down. design/tools/check-capture-contract.py
    is what proves it: 592 / 852 / 80 / 80 and a light mean luminance, unchanged.
 
    THE EFFECT STACK DOES NOT REACH IT. .fx is --fx-band tall — the fold — so the
@@ -2172,8 +2123,8 @@ body::after {
      exists to show stops filling the composition. #67 builds the real Frame and
      #70 does the reflow; between them is where a ceiling belongs, if one does. */
   min-height: var(--fold);
-  /* --corner is the page's own margin: the measure the cut word stands off in
-     its corner and the one the CV's gutters are cut to. The panel is a different
+  /* --corner is the page's own margin: the measure the doorway's title stands
+     off and the one the CV's gutters are cut to. The panel is a different
      composition but it is the same sheet of paper, so it keeps that inset
      rather than inventing one. */
   padding: var(--corner);
@@ -2444,9 +2395,8 @@ body::after {
    would be laid over blank paper and would read as a filter on a browser window
    rather than as a treatment of a print.
 
-   The projects section below the fold is therefore untouched, deliberately. It
-   is not a print — see the panel block — and the cut word, once it has flown
-   down onto it, is not being printed either.
+   The doorway below the fold is therefore untouched, deliberately. It is the
+   clean sheet the cut title opens onto.
 
    --fx-fade softens that ending over the last stretch of the band. It defaults
    to 0, because the pictures themselves stop dead there and an effect layer that
@@ -2784,7 +2734,7 @@ body::after {
      an element's own mask is applied before the blend and is harmless.
 
      Nothing is lost. .fx is the last positioned element in the body, so with
-     z-index auto it paints after .page and .panel on DOM order alone, which is
+     z-index auto it paints after .page and .doorway on DOM order alone, which is
      the whole of what the 2 was buying.
 
      If this stack ever looks like a flat grey wash again, measure a bare patch of
@@ -3379,8 +3329,12 @@ body::after {
   .carousel { display: none !important; }
   .site-footer { display: none !important; }
   .cut-title { display: none !important; }   /* a scroll cue means nothing on paper */
-  /* ...and so is the section it opens onto. The panel is a screen composition
-     all the way down — a full-bleed near-black ground, a placeholder standing in for a
+  /* ...and the screen it opens onto is a blank sheet. The gate on the doorway is
+     min-width/min-height, which in print is measured against the PAGE box — a
+     large enough sheet matches it and prints one. */
+  .doorway { display: none !important; }
+  /* ...and so is the section past it. The panel is a screen composition all the
+     way down — a full-bleed near-black ground, a placeholder standing in for a
      video, and type sized as a share of the WINDOW, which on paper is a share of
      the sheet. Printing it would cost a cartridge and say nothing the CV above
      does not. What it holds that a reader might want — the four figures and the


### PR DESCRIPTION
Revert of #83, #84 and #85. portfolio/{app.js,cut-morph.js,index.html,
styles.css} are checked out at 8070f4b — the last commit before any of this
started — so the cut title is the device it was before issue #57: PROJECTS
cut at the fold in Friz Quadrata, and one page turn later standing whole in
the top-left corner, in Host Grotesk, as the title of the screen it opens
onto. The .doorway is that screen and it comes back with it. Nothing else
in those files moved: #80's Panel and #82's retirement of /projects are
untouched, and no other commit has been near them.

Three attempts sat on top of that and all three were wrong. #83 flew the
word onto the section's masthead and scaled it by half to fit. #84 left it
where it was cut, which meant it rode up with the page and the section's
masthead arrived where it had been. #85 fixed it to the fold, which stuck
it to the screen and put two PROJECTS on the panel at once. The word is
supposed to travel up the page and come to rest at the top of it, turning
as it goes, and there is only ever one of it on screen.

Two things had to be adapted rather than reverted, both because the Panel
now stands below the doorway and did not exist when this was written:

  * THE TURN WALKS THE PORTS. `pageMax()` was the word's landing when the
    doorway was the last thing in the document; it is the section's foot
    now, and a wheel notch aimed at it flew the page straight past the
    doorway — past the whole point of the doorway. app.js reads the three
    resting places off the layout instead (0, the doorway's own
    `scroll-snap-align: end`, the section's `start`) and turns to the next
    one in the direction of the wheel. Past the last, inside a section
    taller than the window, the wheel is the browser's again, which is what
    lets a tall composition be read.
  * THE MORPH FINISHES ON THE DOORWAY. progress() divided by the document,
    which now runs a screen further than the word's landing: the word
    arrived in the corner a third short of Host Grotesk and finished
    turning somewhere down inside the section, off screen. landing() is the
    doorway's port, and below the gate — no doorway — it is the document
    again.

Measured at 1440x1000: document 2875 = the CV, an 875px doorway and the
section; ports at 0, 875, 1875. At 0 the word is cut at the fold with T=0;
at 438 it is half turned; at 875 its cap sits on --title-top with T=1,
whole and fully Host Grotesk, and the section's masthead is off screen. The
two PROJECTS are both on screen for 36px of the 1000px second turn — about
17ms at the turn's peak speed, and never at rest.

check-capture-contract.py green: 592 / 852 / 80 / 80 / 80.4, luminance
188.4 light and 46.1 dark.
