### PR TITLE
Let the cut word take the masthead's place without resizing

### DIFF
--- a/portfolio/app.js
+++ b/portfolio/app.js
@@ -72,9 +72,10 @@
   // of the page. It sits OUTSIDE <main class="col">, as a sibling of it — .page
   // is a flex column and the title has to be .page's own child to be held
   // against the bottom edge. On a screen that composes to one page it is pinned
-  // to the fold instead and the word carries on onto a second screen, where the
-  // whole of it stands as that screen's title. All the geometry is CSS either
-  // way: see --cut-* and the doorway block in styles.css.
+  // to the fold instead, and one page turn later the whole of it has flown down
+  // onto the projects section and become that section's masthead. Where it
+  // STARTS is all CSS — see --cut-* and the turn block in styles.css; where it
+  // ends is measured, in cut-morph.js.
   //
   // THE WORD IS A PICTURE, not type. It is the outlines of PROJECTS set in Friz
   // Quadrata, baked to one SVG path by design/cut-title/build-cut-title.py, and
@@ -402,7 +403,7 @@
     }, { passive: false });
 
     // ---- the page turn -------------------------------------------------------
-    // In the doorway regime the document is two snap ports and nothing between,
+    // In the one-screen regime the document is two snap ports and nothing between,
     // so the browser turns the page with a snap fling of its own — and that fling
     // owns the scroller for as long as it flies. Wheel events that land while it
     // is in the air are filtered out, so the turn back cannot be taken until it
@@ -468,51 +469,33 @@
     // mind while a large force is on it — the page can be carried 26 px past a
     // port and clamped there by the browser for 109 ms, against the cubic's 13 px
     // and 247 ms. Further past, and a third of the time.
-    var doorway = document.querySelector(".doorway");
     var panel = document.querySelector(".panel");
     var TURN = 800;                                     // ms for a whole page turn
     // turnV in px/ms and turnA in px/ms², both signed: the speed and the force
     // this turn is carrying, read by the next one if it interrupts.
     var turnRaf = null, turnTarget = null, turnV = 0, turnA = 0;
-    function inDoorway() {                              // the turn regime, per CSS
-      return doorway && window.getComputedStyle(doorway).display !== "none";
+    // The two-port regime, read off the cascade rather than restated here. The
+    // panel takes `scroll-snap-align: start` inside the one-screen media query
+    // and nowhere else, so this IS that query without a second copy of it to
+    // drift. Deliberately not `scrollSnapType` on <html>, which would have been
+    // the obvious probe and is a trap: turnPage() sets it to "none" for the
+    // length of every ease, so a turn in the air would report the regime off and
+    // a reversal mid-flight would be handed back to the browser.
+    function inTurn() {
+      return !!panel && window.getComputedStyle(panel).scrollSnapAlign !== "none";
     }
     function pageMax() { return document.documentElement.scrollHeight - window.innerHeight; }
-    /* THE RESTING PLACES, in document pixels and in order. The doorway was
-       written when there were two of them and the wheel could simply pick an end
-       of the document; #57's section stands below the doorway now, so the
-       document is three screens and `pageMax()` is the section's foot rather
-       than the word's landing. A wheel notch that aimed at it would fly the page
-       past the doorway — past the whole point of the doorway, which is that the
-       word comes to rest ON it — so the turn walks the ports instead.
-       Read off the layout rather than restated as arithmetic: the doorway's port
-       is its own `scroll-snap-align: end`, which rests its bottom edge on the
-       bottom of the window, and the section's is its `start`. The doorway block
-       in styles.css sizes the first so the word lands exactly on --title-top. */
-    function ports() {
-      var max = pageMax(), y = window.scrollY, out = [0];
-      function add(v) {
-        v = Math.max(0, Math.min(max, Math.round(v)));
-        if (v > out[out.length - 1] + 1) out.push(v);
-      }
-      if (doorway) add(doorway.getBoundingClientRect().bottom + y - window.innerHeight);
-      if (panel) add(panel.getBoundingClientRect().top + y);
-      return out;
-    }
-    /* The next port in the direction the wheel is heading, or null for "not the
-       turn's business". Null past the last port is what lets a section taller
-       than the window be read: the composition grows with the width and stands
-       a few per cent past the fold on a wide one, and down there the wheel is
-       the browser's again. Coming back up, the reader scrolls natively to the
-       port and the next notch turns the page. */
-    function nextPort(down) {
-      var ps = ports(), y = window.scrollY, i;
-      if (down) {
-        for (i = 0; i < ps.length; i++) if (ps[i] > y + 1) return ps[i];
-        return null;
-      }
-      for (i = ps.length - 1; i >= 0; i--) if (ps[i] < y - 1) return ps[i];
-      return null;
+    // The far port: the panel's own top edge, which is where `scroll-snap-align:
+    // start` rests. NOT pageMax(), and the difference is only visible on a wide
+    // window — the panel is min-height:--fold but the Frame grows with the width,
+    // so past about 1600px the composition stands a few per cent past the fold
+    // and the document is longer than the turn. Turning to pageMax() there would
+    // fly the page to the panel's FOOT, overshooting the port, the masthead, and
+    // the word's landing along with it.
+    function panelPort() {
+      if (!panel) return pageMax();
+      return Math.max(0, Math.min(pageMax(),
+        panel.getBoundingClientRect().top + window.scrollY));
     }
     function turnPage(target) {
       var root = document.documentElement;
@@ -563,13 +546,17 @@
     }
     document.addEventListener("wheel", function (e) {
       if (owner === "strip") return;                    // the roll has this gesture
-      if (!inDoorway()) return;
+      if (!inTurn()) return;
       var d = e.deltaY;                                 // the turn is vertical only:
       if (!d) return;                                   // a sideways swipe is the roll's
-      var target = nextPort(d > 0);
-      // nothing to turn: no port that way — the foot of a tall section, or the
-      // top of the document — so leave the event to the browser
-      if (target === null) return;
+      var port = panelPort();
+      // Past the port, inside a panel taller than the window, the wheel is the
+      // browser's again: there is a composition to read down there and the turn
+      // has already done its job. CSS agrees — a snap area larger than the
+      // scrollport relaxes snapping inside itself. Coming back up, the reader
+      // scrolls natively to the port and the next notch turns the page.
+      if (window.scrollY > port + 1) return;
+      var target = d > 0 ? port : 0;
       // nothing to turn: the page is already standing on that port and no turn is
       // in the air, so leave the event alone
       if (turnRaf === null && Math.abs(window.scrollY - target) < 1) return;

--- a/portfolio/cut-morph.js
+++ b/portfolio/cut-morph.js
@@ -1,5 +1,19 @@
 /* The cut title's morph — PROJECTS turning from Friz Quadrata into a sans as
- * the page scrolls.
+ * the page scrolls, and flying out of the CV's bottom-left corner into the
+ * projects section's masthead as it turns. The morph and the flight are two
+ * halves of one device and read the same scroll: the word the section is titled
+ * with IS the word cut off the foot of the page above it, arriving in the face
+ * it turned into. The flight block further down is the whole of the second half.
+ *
+ * ONE PROJECTS, EVER. That is the rule the whole device is built to keep. The
+ * section's own masthead goes `visibility: hidden` under `.cue-fly` and this
+ * word takes its place, so the reader never sees two of the word — not at rest
+ * on either screen, and not at any frame of the turn between them.
+ *
+ * AND THE WORD NEVER RESIZES. It leaves the fold at the size the composition
+ * cut it at and arrives at that same size; the travel is a translation and
+ * nothing else. #83 scaled it to the masthead's cap on the way down, which grew
+ * it by half, and that is the one thing this is not allowed to do.
  *
  * NOTHING ON THE PAGE DEPENDS ON THIS FILE, the same stance effects.js takes. It
  * is loaded last, and a browser that never runs it — parse error, blocked
@@ -27,6 +41,11 @@
  * width. So the viewBox, --cue-ratio, --cue-ink and --cue-overshoot are all
  * still Friz's and none of them moves during the morph. The cap line stays where
  * the cut is taken from.
+ *
+ * NOTHING ABOUT THE FLIGHT IS DECLARED IN CSS, and that is not an oversight —
+ * where the word lands is another element's ink and only layout knows how wide
+ * a word of Host Grotesk is. See the flight block for the measurement, and the
+ * turn block in styles.css for the half that IS declared: where the word starts.
  *
  * TO CHANGE THE FACE. design/cut-title/morph-tuner.html previews all of them
  * against the real page; it drives this file through window.__cutMorph. To make
@@ -152,56 +171,242 @@
 
   // ---- what drives it ------------------------------------------------------
 
-  /* WHERE THE TURN ENDS, in document pixels: the scroll at which the word is
-     home, standing whole in the top-left corner as the doorway's title. That is
-     the doorway's own `scroll-snap-align: end` — its bottom edge on the bottom
-     of the window — and the doorway block in styles.css sizes it precisely so
-     the cap lands on --title-top there.
-     NOT THE END OF THE DOCUMENT, which is what this was when the doorway was the
-     last thing in it. #57's section stands below the doorway now, so the
-     document runs a screen further than the word's landing, and dividing by the
-     whole of it would leave the word a third short of Host Grotesk at the moment
-     it arrives — the turn finishing somewhere down inside the section, where the
-     word is not even on screen.
-     Without a doorway — every regime below the gate, where the word is still the
-     last line of the column — it is the document again, and the whole descent
-     turns the word. */
-  var doorway = document.querySelector(".doorway");
+  var root = document.documentElement;
+  var panel = document.querySelector(".panel");
+  var masthead = document.querySelector(".panel-masthead");
 
+  /* WHERE THE TURN ENDS, in document pixels: the top of the projects section,
+     which is the port `scroll-snap-align: start` rests on and the scroll position
+     at which the word is home. Not the document's own end, which is the same
+     number only when the composition happens to be exactly one screen tall — on
+     a wide window the Frame grows with the width and the panel stands a few per
+     cent past the fold, and dividing by THAT would leave the word still turning
+     after it had landed. */
   function landing() {
-    var doc = document.documentElement;
-    var max = (doc.scrollHeight || 0) - (window.innerHeight || 0);
+    var max = (root.scrollHeight || 0) - (window.innerHeight || 0);
     if (max <= 1) return 0;
-    // `display: none` outside the gate, and a box with no height has no rect to
-    // read either — one layout read rather than a computed style per frame.
-    if (!doorway || !doorway.offsetHeight) return max;
-    var y = window.pageYOffset || doc.scrollTop || 0;
-    var end = doorway.getBoundingClientRect().bottom + y - (window.innerHeight || 0);
-    return Math.max(1, Math.min(max, end));
+    if (!panel) return max;
+    var top = panel.getBoundingClientRect().top + (window.pageYOffset || root.scrollTop || 0);
+    return Math.max(1, Math.min(max, top));
   }
 
   /* HOW FAR THROUGH THE TURN YOU ARE, and not where the word is on the screen.
      Tying it to the word's own position looks like the obvious thing and does
-     not work: the cut title is held against the fold — that is the whole
-     device — so on a composition that does not fit one screen it sits a few
-     pixels above the fold at full scroll and no viewport-relative measure ever
-     leaves zero. Scroll fraction against the landing has no such regime to get
-     wrong: in the doorway, where the word has a screen to travel, it is that
-     screen that turns it; on a long column it is the whole descent.
+     not work: the cut title is held against the fold — that is the whole device —
+     so it never travels up the viewport the way a section does. Scroll fraction
+     against the landing has no such regime to get wrong: where the document is
+     two screens it is the second screen that turns the word, and on a long column
+     it is the whole descent down to the section.
 
      A page too short to scroll stays at Friz rather than dividing by nothing. */
   function progress() {
-    var doc = document.documentElement;
-    var t = (window.pageYOffset || doc.scrollTop || 0) / landing();
+    var t = (window.pageYOffset || root.scrollTop || 0) / landing();
     return t < 0 ? 0 : t > 1 ? 1 : t;
+  }
+
+  /* ---- the flight ----------------------------------------------------------
+     The letters turn from Friz into Host Grotesk over the same scroll that
+     carries the page from the CV to the projects section — and at the end of it
+     the section prints PROJECTS, in Host Grotesk, as its masthead. So the word
+     does not turn and then leave. It turns and LANDS: over the turn it travels
+     out of the page's bottom-left corner and onto the masthead's ink, and the
+     masthead itself is hidden under .cue-fly so that the word is not drawn twice.
+
+     WHY THIS IS MEASURED AND NOT DECLARED. Where the word starts is CSS to the
+     pixel — see the turn block in styles.css — but where it ENDS is another
+     element's ink, and how wide a word of Host Grotesk is at a given size is
+     something only layout knows. There is no expression for it, so there is no
+     expression here: both boxes are read off the page, and the one number in
+     between is scroll.
+
+     BOTH BOXES ARE IN DOCUMENT SPACE, which is what keeps this to one transform
+     and no scroll compensation. .cut-title is absolutely positioned inside
+     .page — a box whose document position does not move — and the masthead sits
+     in ordinary flow below it, so the vector between them is a constant of the
+     layout. Ordinary scrolling supplies the rest of the travel for free. At
+     T = 0 the transform is the identity and nothing here has touched the page.
+
+     THE WORD DOES NOT RESIZE, and that is the one thing this flight is not
+     allowed to do. #83 scaled it to the masthead's cap so the two words would be
+     congruent — at 1440 that is 49px of cap against 75, so the word grew by half
+     on the way down — and the word at the fold is the size the composition wants
+     it. So the travel is a TRANSLATION and nothing else: same size at both ends,
+     same size every frame between them.
+
+     WHAT IS AIMED AT IS THE BASELINE. With the scale gone the two words cannot
+     fill the same box — one is a cap of 49 and the other of 75 — so the landing
+     is the one alignment a line of type has: the word comes to rest ON the
+     masthead's baseline, at its ink's left edge, which is where a line of that
+     size would sit if the h2 were set at it. The cut box IS the cap slab, so its
+     own bottom edge is the word's baseline and no cap height has to be measured
+     at either end.
+     The masthead's baseline comes from the layout rather than from a canvas: a
+     canvas's idea of the line box and the layout's can differ by a fraction
+     under font fallback, and a zero-sized inline-block on the baseline sits with
+     its box exactly on it. That is what the probe below is.
+     What lands where the CAP would have is the top of the word, which now sits
+     about 26px lower in the masthead's slot than the design's own cap line. The
+     slot itself does not move: the h2 keeps its box under `visibility: hidden`,
+     so row one's height and where the subheading starts are the design's still.
+
+     COLOUR is the crossing into dark in miniature and is deliberately no more
+     than that. The word leaves as --ink on paper and lands as the section's own
+     --panel-ink on near-black, and it is ramped between them over the stretch
+     where the word actually crosses the section's top edge — from the moment its
+     lowest visible ink reaches that edge to the moment its highest does. In the
+     middle of that ramp the word genuinely is half on paper and half on the dark,
+     and one colour cannot be right for both; the turn is travelling at about
+     2000 px/s there. #73 is the ticket that owns the crossing properly. */
+
+  var flight = null;
+
+  /* An element's top-left in DOCUMENT space, walked up the offsetParent chain
+     rather than taken from getBoundingClientRect.
+     THE DIFFERENCE IS NOT PEDANTRY AND THIS IS THE BUG IT FIXES. A client rect
+     is the TRANSFORMED box, and .cut-title lives inside .page, which spends its
+     first 0.9s translated 8px down by the page-in reveal. Measured with rects
+     during that animation — which is exactly when this file first runs, being the
+     last script on the page — the word's document position came out 8px low, the
+     vector to the masthead 8px short, and the word landed 8px above the line it
+     was aimed at, on every load, invisibly. Offsets are layout, so no transform
+     on this element or on anything above it can reach them, and the flight's own
+     transform cannot feed back into its own measurement. */
+  function docTop(el) {
+    var y = 0;
+    for (var n = el; n; n = n.offsetParent) y += n.offsetTop;
+    return y;
+  }
+  function docLeft(el) {
+    var x = 0;
+    for (var n = el; n; n = n.offsetParent) x += n.offsetLeft;
+    return x;
+  }
+
+  /* Where the masthead's alphabetic baseline is, in viewport pixels. */
+  function baselineY(el) {
+    var probe = document.createElement("span");
+    probe.setAttribute("aria-hidden", "true");
+    probe.style.cssText = "display:inline-block;width:0;height:0;vertical-align:baseline";
+    el.appendChild(probe);
+    var y = probe.getBoundingClientRect().bottom;
+    el.removeChild(probe);
+    return y;
+  }
+
+  /* Everything the flight needs, taken once per layout. Any of it missing — no
+     section, no masthead, or a regime where the word is still a block in the
+     column — leaves `flight` null, .cue-fly off, and the page exactly as CSS
+     alone draws it, with the section's own masthead drawn. */
+  function measure() {
+    flight = null;
+    root.classList.remove("cue-fly");
+    host.style.transform = "";
+    host.style.zIndex = "";
+    host.style.removeProperty("--cue-land");
+    host.style.removeProperty("--cue-land-ink");
+    if (!panel || !masthead) return;
+    // Read off the cascade rather than restated here: `position: absolute` on
+    // .cut-title is written by the one-screen media query and nowhere else.
+    if (window.getComputedStyle(host).position !== "absolute") return;
+
+    // The cut box IS the cap slab and its bottom edge IS the word's baseline —
+    // see the three nested boxes in styles.css.
+    var slab = host.firstElementChild;
+    if (!slab) return;
+    if (!(slab.offsetWidth > 0) || !(slab.offsetHeight > 0)) return;
+    var slabRect = slab.getBoundingClientRect();
+    var pic = svg.getBoundingClientRect();
+
+    /* The masthead's ink and baseline are the two things offsets cannot give, so
+       they are taken from rects and immediately re-expressed as offsets FROM the
+       masthead's own box. Only the deltas inside that one element come from
+       rects, and nothing above .panel is transformed, so they are exact. */
+    var mBox = masthead.getBoundingClientRect();
+    var range = document.createRange();
+    range.selectNodeContents(masthead);
+    var ink = range.getBoundingClientRect();
+
+    flight = {
+      // the cut word's cap slab, in document space
+      fromX: docLeft(slab),
+      fromY: docTop(slab),
+      // where it is going: the masthead's ink left, and its baseline less the
+      // word's OWN cap, since the word arrives at the size it left at
+      toX: docLeft(masthead) + (ink.width > 0 ? ink.left - mBox.left : 0),
+      toY: docTop(masthead) + (baselineY(masthead) - mBox.top) - slab.offsetHeight,
+      /* The DRAWING against the cap box, for the colour ramp: it is the picture
+         that crosses the section's edge, and it hangs above and below the slab
+         by the O's overshoot and the J's descender. Rects, and a DIFFERENCE of
+         two of them, because an <svg> is not an HTMLElement and has no offsets
+         to walk — and because a difference taken inside one transform context is
+         immune to a translate above it, which is all the page's reveal is. */
+      picOff: pic.top - slabRect.top,
+      picH: pic.height || slabRect.height,
+      // Leave the z-index alone where the effect stack has already lifted the
+      // word clear. It only has to beat .panel, which takes no z-index of its
+      // own, and --fx-text-z (17) does.
+      lift: window.getComputedStyle(host).zIndex === "auto"
+    };
+    host.style.setProperty("--cue-land-ink", window.getComputedStyle(masthead).color);
+    root.classList.add("cue-fly");
+  }
+
+  /* One transform and one number, both a pure function of the scroll. The vector
+     is lerped end to end, so both ends are exact rather than merely close: at
+     T = 0 the transform is not written at all, and at T = 1 the word's baseline
+     and its ink's left edge ARE the masthead's. */
+  function fly(T) {
+    if (!flight) return;
+    var f = flight;
+    if (T <= 0) {
+      host.style.transform = "";
+      host.style.zIndex = "";
+      host.style.setProperty("--cue-land", "0");
+      return;
+    }
+    /* A TRANSLATE AND NOTHING ELSE. With no scale in it the vector is the whole
+       of the transform — the box's own document position cancels out of both
+       ends — so there is no origin to take it about and nothing for a
+       `transform-origin` to get wrong. */
+    var x = (f.toX - f.fromX) * T;
+    var y = (f.toY - f.fromY) * T;
+    host.style.transform = "translate(" + x.toFixed(2) + "px," + y.toFixed(2) + "px)";
+    if (f.lift) host.style.zIndex = "20";
+
+    /* The ramp, measured where it is actually happening: the drawing's own
+       crossing of the section's top edge. 0 while every visible pixel of the word
+       is still above that edge, 1 once none of it is. Clipped to the window at
+       the bottom, because below the fold there is nothing to be over — which is
+       also what keeps this exactly 0 at rest, where the J hangs past a fold the
+       section's edge is sitting on.
+       Smoothstep on top, the same curve the letters are eased with. It does not
+       fix the straddle — nothing one colour can do fixes the straddle — but it
+       keeps the word committed to a ground for most of the crossing and spends
+       the ambiguity in the middle, where the word is genuinely half on each. */
+    var scroll = window.pageYOffset || root.scrollTop || 0;
+    var edge = panel.getBoundingClientRect().top;
+    var span = f.picH;
+    var top = f.fromY + y - scroll + f.picOff;
+    var c = span > 0 ? (Math.min(top + span, window.innerHeight) - edge) / span : 0;
+    c = c < 0 ? 0 : c > 1 ? 1 : c;
+    host.style.setProperty("--cue-land", (c * c * (3 - 2 * c)).toFixed(3));
   }
 
   var pinned = null;                 // a number while the tuner is holding it
   var queued = false;
 
+  /* The letters take the pinned T when the tuner is holding one; the FLIGHT
+     always takes the real scroll. They are the same number in every case but
+     one, and that one is the tuner: design/cut-title/morph-tuner.html scrubs T
+     without moving the page, and a flight that followed it would carry the word
+     off to a masthead a screen below the window and leave the tuner looking at
+     nothing. Judging the letterforms is what that tool is for; #69's tuner is
+     where the composition gets judged. */
   function frame() {
     queued = false;
-    draw(pinned === null ? progress() : pinned);
+    var T = progress();                 // read once: it costs a layout to ask
+    draw(pinned === null ? T : pinned);
+    fly(T);
   }
 
   /* Scrolling goes through a frame — it fires far faster than the display and
@@ -216,8 +421,22 @@
 
   var still = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)");
   if (!still || !still.matches) {
+    /* Re-measured whenever the layout under the flight can have moved, and never
+       per frame: both boxes are constants of the layout, and reading them on a
+       scroll would force a style recalc every frame of the turn for numbers that
+       had not changed. The window is the obvious one; `load` is for the corner
+       pictures, which arrive late and settle the CV's height; and the theme
+       carries the colour the word LEAVES as, which is read here rather than
+       lerped from a cached pair — a toggle mid-turn would otherwise strand the
+       word part-way to a colour the page had stopped using. */
     window.addEventListener("scroll", kick, { passive: true });
-    window.addEventListener("resize", kick);
+    window.addEventListener("resize", function () { measure(); kick(); });
+    window.addEventListener("load", function () { measure(); kick(); });
+    if (window.MutationObserver) {
+      new window.MutationObserver(function () { measure(); kick(); })
+        .observe(root, { attributes: true, attributeFilter: ["data-theme"] });
+    }
+    measure();
     kick();
   }
 
@@ -233,6 +452,9 @@
       pinned = t;
       draw(pinned === null ? progress() : pinned);
     },
-    at: function () { return pinned === null ? progress() : pinned; }
+    at: function () { return pinned === null ? progress() : pinned; },
+    // For anything that moves the layout under the flight without firing resize
+    // — a tuner swapping the masthead's wording or its size, which is #69.
+    remeasure: function () { measure(); kick(); }
   };
 })();

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -315,9 +315,6 @@
        the ascii block in styles.css and drawAscii() in effects.js. -->
   <canvas class="fx-ascii" aria-hidden="true"></canvas>
   <div class="page" id="page"></div>
-  <!-- The second screen the cut title opens onto. Empty, and sized entirely in
-       CSS: see the doorway block in styles.css. -->
-  <div class="doorway"></div>
   <!-- ====================================================================
        THE PROJECTS PANEL
        ====================================================================
@@ -327,9 +324,9 @@
        and — for now — a placeholder standing where the browser Frame will.
        The panel block in styles.css is the whole of the geometry.
 
-       STATIC MARKUP, NOT BUILT BY app.js, and the two reasons are the same
-       two the doorway above is static for. It is one composition with no
-       repetition in it, so there is nothing for a template to earn; and it is
+       STATIC MARKUP, NOT BUILT BY app.js, for two reasons. It is one
+       composition with no repetition in it, so there is nothing for a template
+       to earn; and it is
        on screen at first paint, which is what the rest of this page spends so
        much of its <head> buying. app.js owns the CV because the CV is data.
 
@@ -343,19 +340,18 @@
        exactly as it would one level in: the panel is below the fold, far below
        the 852px crop, and the capture never reaches it.
 
-       What does not survive the letter of it is the doorway. In the regime
-       where the composition fits one screen — see the doorway block — .page is
-       exactly one screen, .cut-title is pinned out of flow at `top: 100vh`,
-       and .doorway is the blank screen the word arrives on as its title. A
-       panel inside .page lands underneath that pinned word and pushes nothing
-       out of the way, so the word would be printed across the top of this
-       section and the blank screen would follow it. After .doorway the reading
-       order is the one the design asks for in every regime: the CV, the word
-       standing whole as a title, and then the section it is the title of.
-       The doorway's own arithmetic is untouched by anything that follows it —
-       it snaps on `scroll-snap-align: end`, which measures its own box and not
-       the end of the document. See the panel block in styles.css for the third
-       snap port this adds so mandatory snapping still has somewhere to rest.
+       There used to be a `.doorway` between this and .page — one blank screen
+       for the cut word to arrive on as its title, from when the word opened
+       onto nothing. It is gone. The word arrives HERE now, and lands on this
+       section's own masthead: see the turn block in styles.css for the two
+       snap ports it leaves, and the travel block in cut-morph.js for the flight
+       between them. The reason the panel still cannot be a child of .page is
+       the one the doorway was written for in the first place — in the
+       one-screen regime .page is exactly one screen and .cut-title is pinned
+       out of flow at `top: 100vh`, so a panel inside .page would land
+       underneath that pinned word and push nothing out of the way. Outside it,
+       the reading order is the one the design asks for in every regime: the CV,
+       and then the section the cut word turns into the title of.
 
        DARK IN BOTH THEMES, and nothing in here reads --ink, --bg or any of the
        six other properties the capture overrides by name. The palette is
@@ -386,6 +382,19 @@
     </ul>
     <div class="panel-inner">
       <header class="panel-head">
+        <!-- WHAT THE CUT WORD TAKES THE PLACE OF, and usually not what is drawn.
+             When cut-morph.js takes the flight it puts `.cue-fly` on <html> and
+             this h2 goes `visibility: hidden` — it keeps its box, so it is still
+             what sets row one's height and where the subheading starts, and the
+             cut word comes to rest on its baseline at its own size. There is one
+             PROJECTS on the page and this is where it ends up. Drawn twice would
+             be drawn twice.
+             It stays in the markup rather than becoming a CSS-only slot for two
+             reasons: it is the section's accessible name, referenced by the
+             `aria-labelledby` above, which a hidden-but-referenced element still
+             supplies; and without the script it is simply the masthead, drawn,
+             which is the whole of what a browser that never runs cut-morph.js
+             gets. See the landing block in styles.css. -->
         <h2 class="panel-masthead" id="panel-masthead">Projects</h2>
         <!-- Two authored lines, not one string left to wrap. The second line is
              the one the Frame passes in front of, so where it breaks is part of
@@ -514,6 +523,6 @@
        only ever replaces one <svg>'s contents, so a browser that skips it —
        blocked, errored, or asking for reduced motion — keeps the baked Friz
        path exactly as it is inline. -->
-  <script src="cut-morph.js?v=3"></script>
+  <script src="cut-morph.js?v=4"></script>
 </body>
 </html>

--- a/portfolio/styles.css
+++ b/portfolio/styles.css
@@ -577,7 +577,7 @@
      the max() in the one-screen block below). The two are the same number on
      every ordinary display and part company only above ~1250px of height, where
      --rhyme keeps growing and --corner stops. Anything that wants "the page's
-     margin" as a fixed inset — the doorway title's corner — has to read --corner,
+     margin" as a fixed inset — the cut word's corner — has to read --corner,
      because a margin that tracks 100vh is a vertical idea and reads as an error
      the moment it is used horizontally: at 2160px tall --rhyme is 605px, which
      would put a left-hand title in the middle of the screen. */
@@ -662,8 +662,8 @@
      where Georgia's J sits on it. The cut box is the cap slab, cap top to
      baseline, so no value of --cue-show can reach the hook: cut, the J is a bare
      stem at 0.62 and at 1.0 alike, and the word reads PRO|ECTS. It comes back
-     whole in the doorway regime, where the clip comes off and the descender has
-     somewhere to hang. That is a property of the drawing, not a number to tune.
+     whole in the one-screen regime, where the clip comes off and the descender
+     has somewhere to hang. That is a property of the drawing, not a number to tune.
 
      The tracking that used to be here — --cue-track, 0.02em, positive because
      this face's caps are fitted tight and its wedge arms overhang their own
@@ -695,8 +695,8 @@
      the cut itself is taken from, and it replaces `1cap` exactly.
      --cue-fit and --cue-cap are its twin as a LENGTH, and the reason for a twin
      is that a container-query unit resolves against .cut-title and cannot be
-     spent by boxes that are not inside it — the height budget below, --slide-h,
-     .doorway. So the same arithmetic is written again against --col, which is
+     spent by boxes that are not inside it — the height budget below, --slide-h
+     and --rhyme. So the same arithmetic is written again against --col, which is
      what the container resolves to on every window wide enough to fill it:
      0.977592 x 27rem of ink, x 0.154521 of cap = 4.0786rem, which is the 4.079
      this replaces to within a hundredth of a pixel. Below --col the twin is a
@@ -705,7 +705,7 @@
      the clip, so a change to the cut word's height falls outside it.
      --cue-clip is then the visible slice: the part of the word that survives the
      cut. Both regimes hold the word's cap top exactly --cue-clip above the fold;
-     they differ only in what does the cutting (see the doorway block below).
+     they differ only in what does the cutting (see the turn block below).
      Like --cue-ink, these are the values for a word set to the COLUMN. In the
      one-screen band the word is fitted to the gutter instead and --cue-fit is
      re-pointed there; the two lines below are written once and hold in both. */
@@ -714,15 +714,18 @@
   --cue-cap:  calc(var(--cue-cap-share) * var(--cue-fit));
   --cue-clip: calc(var(--cue-show) * var(--cue-cap));
 
-  /* ---- where the word lands once it is a title -----------------------------
-     Scrolled home, the cut word stands in the top-left corner of the second
-     screen as a plain title. Both insets come off --corner, so the corner is one
-     measure square and the title's cap top lands on the same line the name's ink
-     starts on one screen above — the page's one margin, reused rather than
-     re-chosen. --title-top carries the half-leading because --corner is measured
-     to the name's INK, and a display word trimmed to its cap slab has no leading
-     of its own to stand the difference. */
-  --title-top:  calc(var(--corner) + var(--name-half-leading));
+  /* ---- where the word STARTS out in the gutter -----------------------------
+     At rest the cut word stands on the page's own margin in the bottom-left
+     corner, cut by the fold. --corner is that margin, reused rather than
+     re-chosen, and it is spent twice: once as the inset itself and once as the
+     white on the far side of the word, which is what --cue-measure below is
+     built out of.
+     There was a --title-top here as well, for the top-left corner the word used
+     to come to rest in on a blank second screen. That screen is gone and so is
+     the corner: the word now flies to the projects section's own masthead, and
+     where it lands is that h2's ink, measured at run time rather than declared.
+     See the turn block at the foot of this sheet and the travel in
+     cut-morph.js. */
   --title-left: var(--corner);
 
   /* Everything in the document that is NOT the photo strip and NOT one of the
@@ -873,14 +876,15 @@
    the profile-README capture in chrisJuresh/chrisJuresh probes at, 1000px and
    592px, whose hardcoded 592 divisor is derived from the photo width.
 
-   The same gate appears once more at the foot of this sheet, for the doorway —
-   the second screen the cut title opens onto. It has to be down there to win the
-   cascade; the two blocks are one idea and the gates must be kept in step. */
+   The same gate appears once more at the foot of this sheet, for the turn — the
+   page turn out of the CV and into the projects section, which is what the cut
+   title opens onto. It has to be down there to win the cascade; the two blocks
+   are one idea and the gates must be kept in step. */
 @media (min-width: 1100px) and (min-height: 983px) {
   :root {
     /* ---- the cut word's measure, out in the gutter -------------------------
        This is the band where the word leaves the column and stands in the
-       page's bottom-left corner instead (see the doorway block at the foot of
+       page's bottom-left corner instead (see the turn block at the foot of
        this sheet, which does the moving). Out there it has a measure of its
        own, and one rule sets it: the white to the LEFT of the word — page edge
        to the P — and the white to its RIGHT — the S to the line the resume
@@ -900,15 +904,15 @@
        centred in the width WITHOUT it, so --cue-measure runs half a scrollbar
        wide of the true gutter — 7.5px on Windows, nothing at all where
        scrollbars are overlaid, and this band always has a scrollbar because
-       the doorway gives it one. The word itself does not inherit that error.
+       the projects section gives it one. The word itself does not inherit
+       that error.
        Both of the things that have to be exact are held off something else:
        the two margins off percentages of the containing block, which do not
        count the scrollbar, and the CUT off the word's own `cap`, read from the
        face at the size it actually resolved to. What is left reading the vw
-       twin is the height BUDGET alone — .doorway's height, --slide-h,
-       --rhyme — where being 0.72px out (0.62 x 0.1545 x 7.5) puts the second
-       screen's title that far below --title-top and takes that much off the
-       photo strip. Constant at every window size, and not worth a script.
+       twin is the height BUDGET alone — --slide-h and --rhyme — where being
+       0.72px out (0.62 x 0.1545 x 7.5) takes that much off the photo strip.
+       Constant at every window size, and not worth a script.
        It is worth knowing WHY the cut is not allowed to spend it, because the
        number looks harmless: 0.72px is 0.9% of the cap at 1920 but 3.9% of it
        at the narrow end of this band, where the word is a quarter the size. Off
@@ -1159,7 +1163,7 @@ body::after {
    and is gone by the second screen. Its foot lands well above that line at every
    size the ceiling on --car-w allows, so in practice the clip never fires; it is
    there so that a hand-tuned --car-fill or --car-y cannot hang a photograph into
-   the doorway.
+   the projects section below.
 
    --car-crop cuts the TOP rather than the foot, which is the corner it is
    anchored to — same arithmetic as --plate-crop with the sign of the edge
@@ -1782,13 +1786,6 @@ body::after {
   max-width: var(--col);                 /* sized and centred exactly like .col */
   margin: var(--cue-gap) auto 0;
 }
-/* The second screen, and nothing else — it exists to give the document a length
-   to scroll and a second place to rest. It is empty on purpose: what arrives on
-   it is the cut word, which is not its child. Off in every regime but the one
-   that composes to a screen; a column that already scrolls has no page turn to
-   offer, and the profile-README capture probes at 1000px and 592px, where this
-   has to add exactly nothing to the document. */
-.doorway { display: none; }
 .cut-title > a {
   display: block;
   overflow: clip;
@@ -1802,7 +1799,7 @@ body::after {
 /* The word is clickable, and a display word gives nothing to underline — its
    baseline is below the cut. So the site's 1px link rule goes on the cut itself,
    drawn as an inset shadow rather than a border so it costs the clip box no
-   height and the geometry above stays exact. In the doorway regime the same
+   height and the geometry above stays exact. In the one-screen regime the same
    shadow lands on the baseline instead, because the box is then the cap slab and
    is not clipped — the one place the word is whole is the one place it can take
    an ordinary underline, and it is also the place you would click it. Cut, it
@@ -1821,7 +1818,7 @@ body::after {
    edge is the highest ink in the word, which is the O's overshoot, so the
    drawing is lifted by exactly that much and the cut is then taken from the cap.
    RELATIVE, not a negative margin, and this is not a preference — a margin is
-   wrong in the doorway regime and wrong silently. There the link runs
+   wrong in the one-screen regime and wrong silently. There the link runs
    `overflow: visible`, so it is no longer a block formatting context and its
    first child's top margin COLLAPSES into its own: the two negative margins
    would not add, the larger (the link's own lift) would simply win, and the
@@ -1859,29 +1856,50 @@ body::after {
   border: 0 !important;
 }
 
-/* ---- the doorway ----------------------------------------------------------
+/* ---- the turn ---------------------------------------------------------------
    The cut word is a promise that there is more below the page, and in this
    regime — the only one where the composition fits a screen exactly, so the same
-   gate as "composing to one screen" above — the page keeps it. One screen of
-   paper follows, and the document holds exactly two resting places: the CV, and
-   the word standing uncut in the top-left corner as the title of the screen it
-   opens onto. Mandatory snap with two snap ports and nothing between them means
-   one notch of the wheel travels the whole length of the document; there is
-   nowhere to come to rest half way, so it is a page turn rather than a scroll.
+   gate as "composing to one screen" above — the page keeps it. The projects
+   section follows, and the document holds exactly two resting places: the CV,
+   and the section. Mandatory snap with two snap ports and nothing between them
+   means one notch of the wheel travels the whole way; there is nowhere to come
+   to rest half way, so it is a page turn rather than a scroll.
 
-   The arithmetic is one line. Call the word's cap top Y = 100vh - --cue-clip —
-   that IS the cut, --cue-clip of the letters above the fold and the rest below —
-   and the title's landing T = --title-top. Scrolling to the end lifts everything
-   by exactly the document's overflow, so the overflow has to be Y - T, which is
-   what .doorway is tall. The document is then 100vh + (Y - T), and the word
-   arrives at T on the nose at every window height, with no script and no
-   scroll-driven animation.
-   One footnote on Y, since two things now measure it. The word is CUT off its
-   own `cap` and .doorway is tall off --cue-clip, which is the same line arrived
-   at twice — exactly, wherever scrollbars are overlaid, and 0.72px apart where
-   they are not, in the direction of resting the title that far under T. See the
-   scrollbar paragraph at --cue-measure for why the cut is the one that gets to
-   be exact.
+   WHAT USED TO BE HERE, AND WHY IT IS NOT. Between those two there was a
+   `.doorway` — one blank screen, sized `100vh - --cue-clip - --title-top`, whose
+   only job was to give the document exactly enough overflow that scrolling to
+   the end parked the cut word in the top-left corner as that screen's title. It
+   was written when the word opened onto nothing, and once the section arrived
+   underneath it the page had three resting places and the middle one was an
+   empty sheet with a half-turned word on it. The word never reached its own
+   landing either: it came to rest a whole screen above the fold, out of sight,
+   and the section below printed the SAME WORD again as its masthead in the very
+   face the morph resolves into.
+
+   So the landing moved to where it was always going. The word flies to the
+   section's masthead and TAKES ITS PLACE — the .panel-masthead h2 goes
+   `visibility: hidden` under `.cue-fly` and this word stands where it stood —
+   which is the whole of the device the morph was built for: PROJECTS in Friz
+   Quadrata at the foot of the CV turns into PROJECTS in Host Grotesk at the head
+   of the section, once, over one page turn. There is only ever ONE of the word
+   on the page, at rest on either screen and at every frame of the turn between
+   them. The flight is measured and drawn by cut-morph.js, off the same T that
+   turns the letters; there is no arithmetic left in this sheet for where the
+   word ends up, because the end is another element's baseline and only layout
+   knows where that is.
+
+   IT ARRIVES AT THE SIZE IT LEFT AT. #83 fitted it to the masthead's cap, which
+   at 1440 is 75px against the cut word's 49, so the word grew by half on the way
+   down; the size the composition cut it at is the size it keeps, and the travel
+   is a translation and nothing else. What that costs is congruence — the two
+   words cannot fill the same box — so the landing is a baseline rather than a
+   box, and the flight block in cut-morph.js has that reasoning.
+
+   What this sheet still fixes is the START — the two insets below, the cut, and
+   the two snap ports — and that half is unchanged to the pixel. A browser that
+   never runs cut-morph.js gets exactly this block: the word cut at the fold, the
+   section's own masthead drawn as the section's own masthead, and one page turn
+   between them. Nothing here depends on the flight.
 
    Two consequences worth naming:
    * The cut becomes REAL. Everywhere else the word is clipped to --cue-clip by
@@ -1889,12 +1907,13 @@ body::after {
      second screen for the rest of the letters to stand on. Here they are all
      there and the bottom of the window does the cutting, which is what the
      device was always drawing. So the clip comes off: leave it on and the word
-     would arrive in the corner still guillotined.
+     would fly to the masthead still guillotined.
    * The word leaves the measure — both of them. It is no longer the last line of
-     the column but the title of its own screen, so it is set to the page's
-     margin instead of the text's — --title-left from the window's edge, the same
-     measure as the white above it, which is what makes the corner read as a
-     corner. And it is no longer the column's width either: it is fitted to the
+     the column but a word standing in the page's own corner, so it is set to the
+     page's margin instead of the text's — --title-left from the window's edge,
+     the same measure as the white above it, which is what makes the corner read
+     as a corner. And it is no longer the column's width either: it is fitted to
+     the
      gutter it now stands in, so that the white either side of it is that same
      --title-left twice over — page edge to the P, S to the line the resume
      starts on. See --cue-measure in the one-screen block for the whole of that
@@ -1920,14 +1939,20 @@ body::after {
      margin, and --cue-ink goes to a flat 100cqw with --cue-lead at zero.
 
    .cut-title is positioned rather than laid out for one reason: .page is exactly
-   one screen and the doorway is the next, so the title can be a flex item of
-   neither — as .page's it would be pushed down by the second screen, and as the
-   doorway's it could not stand above its own top edge. Pinned to the fold it is
-   in neither, which is also the truth of it. It lands in the same place the flow
-   put it: --slide-h is sized so the column plus --cue-gap reaches exactly Y, so
-   the two agree, and the gap under the contact block is what it always was.
-   `top`, not `bottom`, because the offset then holds the cap top at Y whatever
-   the box's own height turns out to be.
+   one screen and the panel is the next, so the word can be a flex item of
+   neither — as .page's it would be pushed down by the section below, and as the
+   panel's it could not stand above its own top edge. Pinned to the fold it is in
+   neither, which is also the truth of it. It lands in the same place the flow
+   put it: --slide-h is sized so the column plus --cue-gap reaches exactly the
+   cap top at 100vh - --cue-clip, so the two agree, and the gap under the contact
+   block is what it always was.
+   `top`, not `bottom`, because the offset then holds the cap top on that line
+   whatever the box's own height turns out to be.
+   IT IS ALSO THE ONLY THING THE FLIGHT HAS TO TRANSFORM. Absolutely positioned
+   in .page, the box has a document position that does not move with the scroll,
+   so cut-morph.js can express the whole travel as one translate on this element
+   against one measurement of the masthead's baseline — no fixed positioning, no
+   sticky, no transform-origin to get wrong, and nothing here to undo at T = 0.
 
    These rules sit at the end of the sheet, not up in the :root block that shares
    their gate: every one of them overrides a base rule of the same specificity,
@@ -1951,11 +1976,6 @@ body::after {
      which would switch the snapping off rather than pin it. body itself is
      therefore no good either; it is the whole document tall. */
   body::before { content: ""; display: block; height: 0; scroll-snap-align: start; }
-  .doorway {
-    display: block;
-    height: calc(100vh - var(--cue-clip) - var(--title-top));
-    scroll-snap-align: end;
-  }
   .cut-title {
     position: absolute;
     top: 100vh;
@@ -1964,6 +1984,22 @@ body::after {
     width: auto;
     max-width: none;
     margin: 0;
+  }
+  /* The word crosses from the paper onto the near-black section during the turn,
+     so it cannot keep one colour. --cue-land is the crossing, 0 to 1, written by
+     cut-morph.js off where the DRAWING actually is against the section's top
+     edge; --cue-land-ink is the far end, read by that same script off the
+     masthead's own computed colour so that the section's palette stays declared
+     in one place — the .panel block — and is not copied up here as a literal.
+     --ink is the near end and is left to the cascade, so the theme toggle still
+     governs the word it leaves as.
+     Falls back to plain --ink wherever `color-mix` is not understood, which is
+     the same stance as the rest of this file: the flight still happens, the word
+     simply arrives the colour it started. #73 is the crossing proper. */
+  :root.cue-fly .cut-title > a {
+    color: color-mix(in oklab,
+                     var(--cue-land-ink, var(--ink)) calc(var(--cue-land, 0) * 100%),
+                     var(--ink));
   }
   .cut-title > a {
     /* The clip comes off — the bottom of the window does the cutting here, and
@@ -1988,20 +2024,40 @@ body::after {
        is not clipped. */
     margin-top: calc(-1 * var(--cue-show) * var(--cue-slab));
   }
-  /* The third resting place, and it is not optional. The two ports above are
-     `body::before` at the top and .doorway at the end, and `scroll-snap-type: y
-     mandatory` means the scroller must COME TO REST on a port — so a section
-     added past the last one is not merely un-snapped, it is unreachable: every
-     scroll into it is snapped straight back to the doorway. This is what makes
-     it reachable at all in this regime. Movement — what the Rail does, and what
-     the crossing into dark does — is #72 and #73; this is the floor under both.
-     `start`, so the panel arrives with its masthead against the top of the
-     window, the same edge the doorway's title stands on. When the composition is
-     taller than the window the area is larger than the scrollport, which relaxes
-     snapping inside it rather than switching it off — you can read to the bottom
-     of a tall panel without being pulled back up, which is the behaviour wanted
-     here anyway. */
+  /* The second resting place, and the far end of the turn. With .doorway gone
+     these are the only two ports in the document — `body::before` at the top and
+     this — which is what makes the turn a turn: `scroll-snap-type: y mandatory`
+     means the scroller must COME TO REST on a port, and with nothing between
+     them there is nowhere to stop half way.
+     `start`, so the section arrives with its masthead against the top of the
+     window; the flying word is aimed at that masthead's baseline, so this is
+     also what fixes where the word comes down. When the composition is taller than
+     the window the area is larger than the scrollport, which relaxes snapping
+     inside it rather than switching it off — you can read to the bottom of a
+     tall panel without being pulled back up, and app.js hands the wheel back to
+     the browser past this port for exactly that stretch.
+     What the Rail does, and the crossing into dark, are still #72 and #73. */
   .panel { scroll-snap-align: start; }
+
+  /* ---- the landing ---------------------------------------------------------
+     Only while cut-morph.js is actually flying the word: it writes .cue-fly on
+     <html> when it has measured a flight it can draw, and takes it off when it
+     cannot — reduced motion, a regime with no turn in it, a masthead it could
+     not find. So the fallback is the plain page, with this h2 drawn.
+     `visibility`, NOT `display: none` and not `opacity`. The box has to stay
+     exactly where it is: it is what sets row one's height, what the subheading
+     hangs off, and — the point — what the flight is aimed at, which cut-morph.js
+     measures off this element itself: a Range over its own text for the ink's
+     left edge, and a zero-sized probe for the baseline. A hidden box still
+     measures. `opacity: 0` would measure too and would also still be
+     hit-tested and still be read out; `visibility: hidden` takes it out of the
+     accessibility tree, which is right, because the section's name comes from
+     the `aria-labelledby` reference — and a directly-referenced hidden element
+     still supplies one.
+     Gated inside this media query with the rest of the turn, because outside it
+     there is no flight: on a page that scrolls as a column the word stays in the
+     column and this is the only PROJECTS the section has. */
+  :root.cue-fly .panel-masthead { visibility: hidden; }
 }
 
 /* ============================================================================
@@ -2009,8 +2065,8 @@ body::after {
    ============================================================================
    The dark composition at the foot of the document: one project shown rather
    than described. The markup is static and lives in index.html — the comment
-   above it says why it is there and why it stands after .doorway rather than
-   inside .page — and this block is the whole of the geometry.
+   above it says why it is there and why it stands outside .page rather than
+   inside it — and this block is the whole of the geometry.
 
    WHAT IS HERE AND WHAT IS NOT. This is the skeleton (#64): the masthead, the
    subheading, the Rail, the body copy, the four engineering points, and a
@@ -2035,7 +2091,7 @@ body::after {
    capture hides everything after the Work Experience listing by walking
    `nextElementSibling` from it — inside .col — so nothing here is hidden by
    that pass. It stays out of the shot by falling below cropHeight (852), a
-   whole screen and a doorway further down. design/tools/check-capture-contract.py
+   whole screen further down. design/tools/check-capture-contract.py
    is what proves it: 592 / 852 / 80 / 80 and a light mean luminance, unchanged.
 
    THE EFFECT STACK DOES NOT REACH IT. .fx is --fx-band tall — the fold — so the
@@ -2123,8 +2179,8 @@ body::after {
      exists to show stops filling the composition. #67 builds the real Frame and
      #70 does the reflow; between them is where a ceiling belongs, if one does. */
   min-height: var(--fold);
-  /* --corner is the page's own margin: the measure the doorway's title stands
-     off and the one the CV's gutters are cut to. The panel is a different
+  /* --corner is the page's own margin: the measure the cut word stands off in
+     its corner and the one the CV's gutters are cut to. The panel is a different
      composition but it is the same sheet of paper, so it keeps that inset
      rather than inventing one. */
   padding: var(--corner);
@@ -2395,8 +2451,9 @@ body::after {
    would be laid over blank paper and would read as a filter on a browser window
    rather than as a treatment of a print.
 
-   The doorway below the fold is therefore untouched, deliberately. It is the
-   clean sheet the cut title opens onto.
+   The projects section below the fold is therefore untouched, deliberately. It
+   is not a print — see the panel block — and the cut word, once it has flown
+   down onto it, is not being printed either.
 
    --fx-fade softens that ending over the last stretch of the band. It defaults
    to 0, because the pictures themselves stop dead there and an effect layer that
@@ -2734,7 +2791,7 @@ body::after {
      an element's own mask is applied before the blend and is harmless.
 
      Nothing is lost. .fx is the last positioned element in the body, so with
-     z-index auto it paints after .page and .doorway on DOM order alone, which is
+     z-index auto it paints after .page and .panel on DOM order alone, which is
      the whole of what the 2 was buying.
 
      If this stack ever looks like a flat grey wash again, measure a bare patch of
@@ -3329,12 +3386,8 @@ body::after {
   .carousel { display: none !important; }
   .site-footer { display: none !important; }
   .cut-title { display: none !important; }   /* a scroll cue means nothing on paper */
-  /* ...and the screen it opens onto is a blank sheet. The gate on the doorway is
-     min-width/min-height, which in print is measured against the PAGE box — a
-     large enough sheet matches it and prints one. */
-  .doorway { display: none !important; }
-  /* ...and so is the section past it. The panel is a screen composition all the
-     way down — a full-bleed near-black ground, a placeholder standing in for a
+  /* ...and so is the section it opens onto. The panel is a screen composition
+     all the way down — a full-bleed near-black ground, a placeholder standing in for a
      video, and type sized as a share of the WINDOW, which on paper is a share of
      the sheet. Printing it would cost a cartridge and say nothing the CV above
      does not. What it holds that a reader might want — the four figures and the


### PR DESCRIPTION
One PROJECTS on the page, at rest and at every frame of the turn. The word
cut off the foot of the CV travels down into the projects section's masthead
as it turns, the h2 goes `visibility: hidden` under `.cue-fly`, and the word
stands where it stood. It arrives at the size it left at.

This is #83's landing with the scale taken out of it, and #86's revert
undone. portfolio/{app.js,cut-morph.js,index.html,styles.css} start from
1295e52 — so the doorway and its blank screen are gone again, and the
document is the CV and the section with one page turn between them — and
the flight is then reduced to a translation:

  * NO SCALE. #83 fitted the word to the masthead's cap, 49px against 75 at
    1440, which grew it by half on the way down. `fly()` writes
    `translate(x, y)` and nothing else now, so the vector is the whole of
    the transform: the box's own document position cancels out of both ends,
    there is no origin to take it about, and `transform-origin` comes off
    the sheet. Swept at every tenth of the turn the drawing measures
    324 x 68.8 at all eleven stops, the same as at rest.
  * AIMED AT THE BASELINE, not the cap box. With the scale gone the two
    words cannot fill the same box, so the landing is the one alignment a
    line of type has: the word comes to rest on the masthead's baseline at
    its ink's left edge. The cut box IS the cap slab and its bottom edge is
    the word's baseline, so nothing has to measure a cap at either end — the
    canvas probe from #83 is gone with it, and with it the one path where a
    browser could decline the flight for want of text metrics.

Measured at 1440x1000, both themes, with a frame allowed to run after each
scroll: the word lands 0.2px off the masthead's baseline and 0.11px off its
ink's left edge, the h2 reads `visibility: hidden` throughout, and the
colour ramp reaches 1 by the port. The word's top in the masthead's slot
sits about 26px below where the design's own cap line is, which is the
price of not resizing; the slot itself does not move, since the hidden h2
keeps its box and row one's height with it.

check-capture-contract.py green: 592 / 852 / 80 / 80 / 80.4, luminance
188.4 light and 46.1 dark.
