### PR TITLE
Write down that Closes #n never fires here

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,18 @@ open a PR into `main`.
    gh pr merge --squash --delete-branch
    ```
 
+   That last command **ends in a git error on every change here**, after the merge
+   has already landed: `fatal: 'development' is already used by worktree at ...`.
+   It is `gh` checking the base branch out locally once the forge is done, and the
+   main checkout is standing on it. The merge is not what failed. Ask the forge
+   rather than the exit code — `gh pr view <n> --json state --jq .state` — and
+   carry on.
+
+   **Then close the ticket by hand.** `Closes #n` in a PR body does nothing here:
+   GitHub only auto-closes on merge into the *default* branch, which is `main`,
+   and nothing merges there from here. `docs/agents/issue-tracker.md` has the rest
+   of it, and the comment to leave when closing.
+
 4. One worktree, one branch, one PR, one change. A second, unrelated fix means a
    second worktree and a second PR — the hook denies further edits in a worktree
    whose PR has already merged.
@@ -100,6 +112,15 @@ your reply and stop.
 [chrisJuresh/skills](https://github.com/chrisJuresh/skills). **Do not edit it in
 this repo** — a fix made here is lost at the next resync and leaves the copy
 undatable. Fix it upstream and resync.
+
+One known false positive, so a session that hits it does not spend a turn
+deciding the guard is right: the spent-worktree mark is written whenever `gh pr
+merge` appears **anywhere in a shell command string**, matched by regex rather
+than by what ran. So `grep "gh pr merge" CLAUDE.md` marks the worktree it was run
+in as merged, and the next edit in that tree is denied. The check the denial
+names settles it — `gh pr list --head <branch> --state all` returning `[]` means
+there is no PR to have merged — and the fix is to delete the marker it names.
+Report it upstream; do not patch it here.
 
 `.claude/worktree-per-change.json` records which upstream commit the copy came
 from and the sha256 of its LF-normalised bytes, so "is this current" is a

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -13,6 +13,38 @@ Issues and specs for this repo live as GitHub issues. Use the `gh` CLI for all o
 
 Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
 
+## `Closes #n` never fires here, so closing is a step
+
+GitHub auto-closes a referenced issue only when the PR merges into the repository's
+**default branch**. This repo's default branch is `main` and every PR merges into
+`development` (CLAUDE.md, and `gh pr create --base main` is refused), so a `Closes #65`
+in a PR body is read, linked, displayed — and does nothing. The issue is still open
+after the merge, and looks merged-and-closed to anyone reading the PR.
+
+So write the `Closes #n` line, because it makes the link the tracker shows, and then
+close the issue yourself once the PR reports `MERGED`:
+
+```bash
+gh pr view <n> --json state --jq .state      # expect MERGED
+gh issue close <issue> --comment "Merged as #<pr>. ..."
+```
+
+The comment is where the acceptance criteria get ticked off against what actually
+shipped — that is the record a closed issue is worth having, and it is the thing
+auto-closing would never have written.
+
+The same root cause has a second symptom worth recognising, because it looks like a
+failed merge and is not: `gh pr merge --squash --delete-branch` ends with
+
+```
+failed to run git: fatal: 'development' is already used by worktree at '...'
+```
+
+That is `gh` trying to check the base branch out locally after the merge has already
+happened on the forge, and failing because the main checkout is standing on it. Ask
+the forge, not the exit code — `gh pr view <n> --json state --jq .state` — and carry
+on with the teardown.
+
 ## Pull requests as a triage surface
 
 **PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_


### PR DESCRIPTION
Three traps, all of them consequences of this repo integrating through a branch
that is not its default one, and all three found by walking into them in one
session.

GitHub auto-closes a referenced issue only on a merge into the DEFAULT branch.
That is `main`, and nothing merges there from here, so every `Closes #n` any PR
has ever carried has been read, linked, displayed and ignored. #62, #63 and #64
were closed by hand without the reason being written down anywhere, and #65 was
left open after its PR merged because the line was there and looked like it had
done the job. Closing is a step, and the comment that closes is where the
acceptance criteria get ticked off against what actually shipped.

`gh pr merge --squash --delete-branch` then ends in `fatal: 'development' is
already used by worktree` on every change here — `gh` checking the base branch
out locally after the forge has already merged, and failing because the main
checkout is standing on it. It reads like a refused merge and is not. CLAUDE.md
already says to ask the forge rather than git about a squash merge; this is one
more place that rule applies.

And the guard's spent-worktree mark is written on a regex match for `gh pr
merge` anywhere in a shell command, so grepping for the line above marks the
worktree you are standing in as merged and denies your next edit. That is
upstream's to fix — the note here is so the next session recognises it in one
turn instead of arguing with a hook that cannot be turned off from inside a
session.
