### PR TITLE
Build the browser Frame from the tuned glass, with its fallback ladder

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ of images, served statically from Vercel.
 │   ├── effects.js      # the effect stack's runtime half — optional, loaded last
 │   ├── cut-morph.js    # the cut title turning into a sans — optional, loaded last
 │   ├── panel-clip.js   # gives the Panel's <video> its sources — optional, loaded last
+│   ├── frame-glass.js  # the browser Frame's glass titlebar — optional, loaded last
 │   ├── styles.css      # layout, warm light/dark palettes, fades, print CV
 │   ├── img/            # web-optimised photographs
 │   │   └── tex/        # the two baked textures — see its README

--- a/design/glass-tuner.html
+++ b/design/glass-tuner.html
@@ -339,6 +339,7 @@ uniform float u_glareHardness;
 uniform float u_glareAngle;
 uniform int u_blurEdge;
 uniform int u_showShape1;
+uniform float u_rimReference;
 uniform int STEP;
 
 out vec4 fragColor;
@@ -638,6 +639,25 @@ void main() {
       } else {
         float edgeH = nmerged / u_refThickness;
         vec2 normal = getNormal(p1, p2, gl_FragCoord.xy);
+        /* THE ONE LINE IN THIS SHADER THAT IS NOT UPSTREAM'S, added by #67 and
+           the only change the material has taken since #66 settled it.
+           getNormal returns the SDF's gradient, and the SDF is normalised by
+           u_resolution.y — so |normal| is 1414.2/u_resolution.y rather than 1,
+           and the two mixes below use it as their GAIN. That quietly made the
+           material a function of THE SIZE OF THIS WINDOW: the stage is whatever
+           is left beside the control panel, so the same settings gave a gain of
+           1.366 at 1552x1035 and 2.16 at 656x655, and an export judged in one
+           window did not reproduce in another.
+           #67 is where it stopped being survivable, because the shipping canvas
+           is the titlebar itself — 63px tall, gain 22 — and mix() past 1 does
+           not saturate, it extrapolates: white rims, and a glare whose LCh lands
+           so far out of gamut that the corners come back black.
+           Dividing by the height the material was settled at pins the gain at
+           the 1.366 it had there, at every stage size and on the page. This file
+           at 1552x1035 therefore renders exactly what it rendered before —
+           body (43,37,47), top rim 68, side rims 87, which is #92's table — and
+           at every other size it now renders that too. */
+        float rim = length(normal) * u_resolution.y / u_rimReference;
         vec4 blurredPixel = getTextureDispersion(
           u_bg,
           u_blurredBg,
@@ -672,7 +692,7 @@ void main() {
         outColor = mix(
           outColor,
           vec4(LCH_TO_SRGB(fresnelTintLCH), 1.0),
-          fresnelFactor * u_refFresnelFactor * 0.7 * length(normal)
+          fresnelFactor * u_refFresnelFactor * 0.7 * rim
         );
 
         float glareGeoFactor = clamp(
@@ -710,7 +730,7 @@ void main() {
         outColor = mix(
           outColor,
           vec4(LCH_TO_SRGB(glareTintLCH), 1.0),
-          glareAngleFactor * glareGeoFactor * length(normal)
+          glareAngleFactor * glareGeoFactor * rim
         );
       }
     } else {
@@ -927,6 +947,21 @@ function drawCover(src, x, y, w, h, anchorY) {
    half the Frame minus it, and `corner radius` is a percentage of half the
    shape — and a constant that disagrees with a slider by a hundredth of a
    pixel is a discrepancy someone has to spend a minute disproving. */
+/* THE STAGE HEIGHT THE RIMS WERE SETTLED AT, in device px, and the one constant
+   here that is about this tool rather than about the Frame. The `rim` line in
+   FRAG_MAIN says why it is needed; this says where the number came from.
+   It is a measurement of this file's own canvas, not a chosen round number: at a
+   1920x1080 window with one device pixel per CSS pixel the stage is 1552x1035,
+   and reading the canvas back there gives a body of (43,37,47), a top rim
+   peaking at 68 and both side rims at 87 — #92's recorded table to the integer.
+   So 1035 is the height that table is true at, and pinning it is what stops
+   every other number in the export drifting with the window.
+   portfolio/frame-glass.js carries the same constant, and has to: it is the
+   material's second reference, beside the Frame 1200 wide that the lengths are
+   stated at. Moving one without the other is how the page and this tool would
+   start showing different glass. */
+var RIM_REFERENCE = 1035;
+
 var FRAME_W = 1200;
 var FRAME_RATIO = 1.945;
 var FRAME_H = Math.round(FRAME_W / FRAME_RATIO);   /* 617 */
@@ -1456,6 +1491,11 @@ function draw(now) {
   u1f(progMain, "u_glareFactor", state.glareFactor / 100);
   u1f(progMain, "u_glareAngle", state.glareAngle * Math.PI / 180);
   u1i(progMain, "u_blurEdge", state.blurEdge ? 1 : 0);
+  /* The stage height the material was settled at — see the `rim` line in
+     FRAG_MAIN, which is the whole of why this exists. Not a control: it is the
+     datum every other number in the export is true against, and moving it would
+     silently rescale all of them. */
+  u1f(progMain, "u_rimReference", RIM_REFERENCE);
   u1i(progMain, "STEP", Math.round(state.step));
   gl.activeTexture(gl.TEXTURE0);
   gl.bindTexture(gl.TEXTURE_2D, tH.tex);

--- a/design/tools/render.mjs
+++ b/design/tools/render.mjs
@@ -8,6 +8,7 @@
      node render.mjs --variants cm,cmfix --themes dark
      node render.mjs --viewports desktop,mobile --pages panel,portfolio,portal
      node render.mjs --format jpeg --quality 90     # smaller files
+     node render.mjs --pages panel --glass blur     # see the Frame's second rung
 
    Variants come from design/variants.css — this script does not define any
    styling of its own, it only toggles data-variant on the real pages.
@@ -85,6 +86,50 @@ const viewKeys  = list(opt.viewports, ["desktop"]);
 const scale     = Number(opt.scale || 2);
 const format    = (opt.format || "auto").toLowerCase();
 const quality   = Number(opt.quality || 92);
+
+/* ---- which rung of the Frame's glass to shoot -------------------------------
+   The Panel's titlebar is drawn three ways and #67 asks for each one to have
+   been SEEN rather than assumed — so this takes the top two away rather than
+   trusting a note that says what would happen if they were gone.
+
+     auto   whatever this browser does. Headless Chromium has WebGL2 through
+            SwiftShader, so it is the top rung, which is the trap: a run that
+            only ever shoots `auto` has never once looked at a fallback.
+     blur   WebGL2 removed at the browser. Chromium's --disable-webgl2 is a real
+            switch and getContext("webgl2") returns null under it, which is the
+            same thing frame-glass.js sees on a browser that never had it.
+     flat   that, and the backdrop-filter declaration overridden away.
+
+   THE BOTTOM RUNG CANNOT BE FORCED THE SAME WAY, and the asymmetry is worth
+   writing down because the obvious flag does not work.
+   --disable-blink-features=CSSBackdropFilter leaves CSS.supports() answering
+   true and the @supports block applying, so the page is unchanged and the shot
+   would be captioned `flat` while showing a blur. The declarations have to be
+   overridden instead — and they have to land BEFORE the page's own script runs,
+   because frame-glass.js reads the computed value to decide what to report.
+   addStyleTag is after load and therefore too late; the init script below is
+   the earliest a stylesheet can be got in.
+
+   BOTH DECLARATIONS, NOT JUST THE BLUR. A browser without backdrop-filter never
+   applies that @supports block at all, so it gets neither the blur nor the two
+   rings inside it — and overriding only the blur would shoot a bar wearing rims
+   no such browser would ever draw, captioned `flat`. */
+const GLASS_MODES = ["auto", "blur", "flat"];
+const glass = (opt.glass || "auto").toLowerCase();
+if (!GLASS_MODES.includes(glass)) fail(`glass must be one of: ${GLASS_MODES.join(", ")}`);
+
+const LAUNCH_ARGS = glass === "auto" ? [] : ["--disable-webgl2"];
+const FLATTEN = `
+  new MutationObserver((_, o) => {
+    if (!document.documentElement) return;
+    const s = document.createElement("style");
+    s.textContent = ".frame-bar { backdrop-filter: none !important;" +
+                    " -webkit-backdrop-filter: none !important;" +
+                    " box-shadow: none !important }";
+    (document.head || document.documentElement).appendChild(s);
+    o.disconnect();
+  }).observe(document, { childList: true, subtree: true });
+`;
 
 /* Pick the codec that actually wins for the content. The portal page and the
    Panel are flat colour and type, where PNG beats JPEG outright (399 KB vs
@@ -195,7 +240,18 @@ async function capture(page, origin, pagePath, variant, theme, clipProbe) {
     const width = w(cs.fontFamily);
     let hit = "unrecognised";
     for (const k in known) if (Math.abs(width - known[k]) < 0.01) { hit = k; break; }
-    return { probe: sel, face: hit, size: Math.round(parseFloat(cs.fontSize) * 10) / 10 };
+
+    /* WHICH RUNG OF THE FRAME'S GLASS ACTUALLY ENGAGED — read off the page, not
+       predicted from it. frame-glass.js writes this attribute from the computed
+       `backdrop-filter` of the bar that is on screen and from whether its four
+       passes really drew, so a shot captioned `blur` is one where the blur is in
+       the picture. A bar with no attribute at all is a bar the script never
+       reached, which is its own answer and is reported as `no script` rather
+       than guessed at. `—` is a page with no Frame in it. */
+    const bar = document.querySelector(".frame-bar");
+    const tier = !bar ? "—" : (bar.dataset.glass || "no script");
+
+    return { probe: sel, face: hit, size: Math.round(parseFloat(cs.fontSize) * 10) / 10, tier };
   }, clipProbe);
 }
 
@@ -209,7 +265,8 @@ async function contactSheet(rows) {
   const section = (key) => {
     const items = groups[key].map((r) => `
         <figure>
-          <figcaption><b>${r.variant}</b> <span>${r.face} ${r.size}px</span></figcaption>
+          <figcaption><b>${r.variant}</b> <span>${r.face} ${r.size}px${
+            r.tier === "—" ? "" : ` · glass ${r.tier}`}</span></figcaption>
           <a href="${r.file}" target="_blank" rel="noopener"><img src="${r.file}" alt="${r.variant}" loading="lazy"></a>
         </figure>`).join("");
     return `    <section><h2>${key}</h2><div class="strip">${items}</div></section>`;
@@ -233,7 +290,8 @@ async function contactSheet(rows) {
 <body>
   <h1>Typography variants</h1>
   <p class="meta">${rows.length} renders · generated by <code>design/tools/render.mjs</code> · scale ${scale}x ·
-     click any image for full size. Definitions live in <code>design/variants.css</code>.</p>
+     glass <code>${glass}</code> · click any image for full size.
+     Definitions live in <code>design/variants.css</code>.</p>
 ${Object.keys(groups).sort().map(section).join("\n")}
 </body></html>
 `;
@@ -245,7 +303,7 @@ const server = await serve();
 const origin = `http://127.0.0.1:${server.address().port}`;
 await mkdir(SHOTS, { recursive: true });
 
-const browser = await chromium.launch();
+const browser = await chromium.launch({ args: LAUNCH_ARGS });
 const rows = [];
 let n = 0;
 const total = pageKeys.length * variants.length * themes.length * viewKeys.length;
@@ -264,11 +322,19 @@ for (const viewport of viewKeys) {
       });
       // the pages read this on boot, before any of our JS could run
       await context.addInitScript(`try { localStorage.setItem("portfolio-theme", "${theme}"); } catch (e) {}`);
+      if (glass === "flat") await context.addInitScript(FLATTEN);
       const page = await context.newPage();
 
       for (const variant of variants) {
         const ext = formatFor(pageKey);
-        const name = `${pageKey}__${variant}__${theme}__${viewport}.${ext}`;
+        /* The glass mode is in the filename whenever it is not the default, for
+           the reason the page-key comment above gives at length: shots are
+           addressed by name, and a forced rung written over the same name as the
+           unforced one destroys the only picture of the top rung while looking
+           like an ordinary re-run. `auto` keeps the bare name so the committed
+           set does not churn. */
+        const suffix = glass === "auto" ? "" : `__glass-${glass}`;
+        const name = `${pageKey}__${variant}__${theme}__${viewport}${suffix}.${ext}`;
         const clip = CLIP[pageKey];
         const info = await capture(page, origin, PAGES[pageKey], variant, theme, clip && clip.probe);
         const shot = {
@@ -282,7 +348,9 @@ for (const viewport of viewKeys) {
         const bytes = (await stat(join(SHOTS, name))).size;
         rows.push({ page: pageKey, variant, theme, viewport, file: name, ...info });
         console.log(`  [${String(++n).padStart(String(total).length)}/${total}] ${name}` +
-                    `  ${info.probe} → ${info.face} ${info.size}px  (${Math.round(bytes / 1024)} KB)`);
+                    `  ${info.probe} → ${info.face} ${info.size}px` +
+                    (info.tier === "—" ? "" : `  glass → ${info.tier}`) +
+                    `  (${Math.round(bytes / 1024)} KB)`);
       }
       await context.close();
     }

--- a/portfolio/frame-glass.js
+++ b/portfolio/frame-glass.js
@@ -651,6 +651,13 @@
 
   /* ---- render --------------------------------------------------------------- */
   var W = 0, H = 0;
+  /* What is already on the canvas. RENDERING ONCE IS THE POINT OF THIS FILE, and
+     without this it renders twice on every visit: ResizeObserver delivers a
+     callback for the element's initial size the moment observe() is called, so
+     the four passes run again immediately for the box attempt() has just drawn.
+     Nothing about the result changes, which is exactly why it would never have
+     been noticed. */
+  var drawn = { w: 0, h: 0, ok: false };
 
   function render() {
     var m = metrics();
@@ -664,6 +671,12 @@
     var dpr = Math.min(window.devicePixelRatio || 1, 2);
     var w = Math.max(1, Math.round(m.w * dpr));
     var h = Math.max(1, Math.round(m.h * dpr));
+
+    /* Same pixels as last time, so the canvas already holds the right picture.
+       Device px and not CSS px, because that is what actually decides whether a
+       redraw would differ — a fractional CSS width that rounds to the same
+       device size is the same canvas. */
+    if (drawn.ok && drawn.w === w && drawn.h === h) return true;
 
     /* THE EXPORT'S LENGTHS ARE PX AT A FRAME 1200 WIDE. This is the ratio that
        makes them px at the Frame that is actually on screen. */
@@ -788,10 +801,20 @@
     /* A GL error means some part of the four passes did not happen, and a
        half-drawn titlebar is exactly the "broken chrome" #57's user story 9 is
        about. Better to hand the reader the rung below, which cannot fail. */
-    return gl.getError() === gl.NO_ERROR;
+    drawn.w = w;
+    drawn.h = h;
+    drawn.ok = gl.getError() === gl.NO_ERROR;
+    return drawn.ok;
   }
 
+  /* Set once the context has gone for good — see the handler at the foot of the
+     file. Without it the ResizeObserver goes on calling render() for the rest of
+     the session, driving programs and textures that no longer exist, once per
+     resize, to reach a conclusion that cannot change. */
+  var dead = false;
+
   function attempt() {
+    if (dead) return false;
     var ok = false;
     try { ok = render(); } catch (e) { ok = false; }
     if (ok) {
@@ -838,6 +861,7 @@
      the same reason: without it the browser does not offer a restore, and there
      is nothing here that wants one. */
   canvas.addEventListener("webglcontextlost", function () {
+    dead = true;
     if (canvas.parentNode) canvas.parentNode.removeChild(canvas);
     setTier(false);
   });

--- a/portfolio/frame-glass.js
+++ b/portfolio/frame-glass.js
@@ -1,0 +1,844 @@
+/* The browser Frame's titlebar, made of glass.
+ *
+ * WHAT THIS FILE IS. Four WebGL2 passes — background, two halves of a separable
+ * gaussian, and the glass itself — rendered ONCE into a canvas the size of the
+ * titlebar. The shaders are the ones design/glass-tuner.html carries, which are
+ * iyinchao/liquid-glass-studio's src/shaders/*.glsl with their `#include`s
+ * inlined (MIT). The parameters are the ones #66 settled against the design
+ * render and exported through the tuner's drawer. Neither is invented here, and
+ * neither should be edited here: the tuner is where the material is judged,
+ * because it is the only place the result can be compared with the render.
+ *
+ * ONE RUNG OF A LADDER, AND THE ONE THAT MIGHT NOT ARRIVE. styles.css paints a
+ * titlebar without any of this — a flat translucent fill, and a blurred one with
+ * two rings where the browser has `backdrop-filter` — and both are in the
+ * cascade rather than behind a script, so a reader with no JavaScript gets the
+ * best of the two their browser can actually draw. All this file does is put a
+ * better one on top when it can, and say which one happened:
+ *
+ *     bar.dataset.glass = "webgl" | "blur" | "flat"
+ *
+ * THAT ATTRIBUTE IS READ BACK OFF THE PAGE, NOT PREDICTED. `blur` is not "the
+ * browser claims to support backdrop-filter", it is `getComputedStyle` returning
+ * something other than `none` for the bar that is actually on screen — so the
+ * attribute cannot say a tier engaged that did not. design/tools/render.mjs
+ * reports it beside every shot and can force the lower two, which is what
+ * #67 means by each tier having been seen rather than assumed.
+ *
+ * IT RENDERS ONCE, which is the promise #57 makes about this Frame. What sits
+ * behind the titlebar is the Frame's own fill and the page's backdrop outside
+ * its corners — both constant — so there is nothing to redraw until the box
+ * changes size. #66 built three treatments of that backdrop and measured them:
+ * the render cannot tell the Frame's fill from the page showing through it,
+ * because it is near-black behind its own titlebar either way, and only the
+ * recording carrying on up under the chrome is visibly not the render. The
+ * recording is also the only one of the three that costs anything — a moving
+ * backdrop is four passes a frame, forever, on a page that promises none. So the
+ * static one ships. #68 puts marble behind the Frame and is where the first half
+ * of that stops being true; the recording is a change to paintScene() and to
+ * this paragraph, and the tuner's `panel · recording` chip is where to look at it
+ * before making it.
+ */
+(function () {
+  "use strict";
+
+  var bar = document.querySelector(".frame-bar");
+  if (!bar) return;
+
+  /* ---- the settled material ------------------------------------------------
+     #66's export, verbatim, minus the rows that only ever drove the tuner (the
+     backdrop chips, the drag spring, the debug step). The five that describe the
+     SHAPE are gone too and are computed from the Frame below instead — the tuner
+     has to be told what it is drawing and this file can measure it.
+
+     EVERY LENGTH HERE IS A CSS PX AT A FRAME 1200 WIDE, which is what the export
+     says and what REFERENCE_W is. The Frame on this page is nine of twelve
+     columns and is nothing like 1200 at most window widths, so they are scaled
+     by the ratio on the way in — halve the Frame and the bevel, the blur and the
+     rims all halve with it, which is the only way a material holds its look
+     across sizes. Missing that is how a bevel tuned at 1200 becomes a smear at
+     600. */
+  var REFERENCE_W = 1200;
+  var GLASS = {
+    refThickness: 10,
+    refFactor: 1.5,
+    refDispersion: 7,
+    refFresnelRange: 34,
+    refFresnelHardness: 20,
+    refFresnelFactor: 11.5,
+    glareRange: 34,
+    glareHardness: 20,
+    glareFactor: 26,
+    glareConvergence: 50,
+    glareOppositeFactor: 100,
+    glareAngle: 90,
+    blurRadius: 24,
+    blurEdge: true,
+    tintColor: "#fab2ff",
+    tintAlpha: 0.135,
+    /* Intensity is at the render's own value, which is none, and the other three
+       are inert while it is — carried anyway so this and the tuner's export list
+       the same rows. FRAG_BG spreads the shadow symmetrically about the WHOLE
+       doubled shape, so raising the intensity gives no shadow under the titlebar
+       and a phantom band a strip-height below it — measured in #66 and written
+       down on that control. Whoever wants a shadow has to clip it inside FRAG_BG
+       first. */
+    shadowExpand: 25,
+    shadowFactor: 0,
+    shadowX: 0,
+    shadowY: -10
+  };
+  /* The superellipse the render's two top corners fit, to within half a pixel of
+     rms over 32 sampled columns. The studio's default is 5; this is all but a
+     circular arc, and it is the single most surprising number #66 produced. */
+  var ROUNDNESS = 2.2;
+  /* THE CANVAS HEIGHT #66'S RIMS WERE SETTLED AT, in device px, and the second
+     reference this file needs after REFERENCE_W. See the `rim` line in FRAG_MAIN
+     for what goes wrong without it.
+     It is a measurement and not a round number: the tuner's stage is whatever is
+     left of the window beside its control panel, and at 1920x1080 with one
+     device pixel per CSS pixel that is 1552x1035. Reading the tuner's own canvas
+     back at that size gives a body of (43,37,47), a top rim peaking at 68 and
+     both side rims at 87 — which is #92's table to the integer, so 1035 is the
+     height those numbers are true at. Upstream's own `1.414 * 1000.0` implies it
+     meant 1414, where the normal would be exactly unit length; nothing was ever
+     judged there, so the settled height is what is pinned. */
+  var REFERENCE_H = 1035;
+  var frame = bar.parentNode;
+
+  /* NOT ONE GEOMETRY NUMBER IS REPEATED FROM THE STYLESHEET. The bar's height,
+     its width and its corner are read back off the laid-out element, so a glass
+     that disagreed with the chrome standing on it by a pixel is not a thing this
+     file can produce. It also sidesteps a trap worth naming: --frame-bar is
+     `3.4583cqw`, and an UNREGISTERED custom property computes to its own token
+     sequence rather than to a length, so `getPropertyValue("--frame-bar")` hands
+     back the string "3.4583cqw" and parseFloat turns that into 3.4583 pixels
+     without complaining. Used values from getBoundingClientRect and
+     borderTopLeftRadius have already been through the container. */
+  function metrics() {
+    var rect = bar.getBoundingClientRect();
+    return {
+      /* The bar is inset 0 on both sides of the Frame, so its width is the
+         Frame's — which is the width every #66 length is stated against. */
+      w: rect.width,
+      h: rect.height,
+      r: parseFloat(getComputedStyle(bar).borderTopLeftRadius) || 0
+    };
+  }
+  /* Colours are read the same way and for the same reason, and here the custom
+     property is a colour token rather than a length, so it does come back
+     usable. These two ARE the page behind the titlebar; see the backdrop
+     comment below. */
+  function cssColor(prop) {
+    return getComputedStyle(frame).getPropertyValue(prop).trim();
+  }
+
+  /* ---- shader sources ------------------------------------------------------
+     Verbatim from design/glass-tuner.html, which took them verbatim from
+     upstream. Do not "tidy" these: the odd-looking constants (the 1500.0
+     divisor, the pow(...,5.0), the 0.05 offset scale) are what the control
+     ranges — and therefore #66's settled values — were chosen around.
+     Two passes upstream has are not here. The debug ladder (STEP 0..8) is a
+     tuner affordance and nothing on a shipping page can reach it, so FRAG_MAIN
+     is upstream's STEP 9 branch alone; and the second metaball shape is gone
+     with it, since the subject is one bar. */
+  var VERT = [
+    "#version 300 es",
+    "in vec4 a_position;",
+    "out vec2 v_uv;",
+    "void main() {",
+    "  v_uv = (a_position.xy + 1.0) * 0.5;",
+    "  gl_Position = a_position;",
+    "}"
+  ].join("\n");
+
+  var SDF = [
+    "float superellipseCornerSDF(vec2 p, float r, float n) {",
+    "  p = abs(p);",
+    "  float v = pow(pow(p.x, n) + pow(p.y, n), 1.0 / n);",
+    "  return v - r;",
+    "}",
+    "float roundedRectSDF(vec2 p, vec2 center, float width, float height, float cornerRadius, float n) {",
+    "  p -= center;",
+    "  float cr = cornerRadius * u_dpr;",
+    "  vec2 d = abs(p) - vec2(width * u_dpr, height * u_dpr) * 0.5;",
+    "  float dist;",
+    "  if (d.x > -cr && d.y > -cr) {",
+    "    vec2 cornerCenter = sign(p) * (vec2(width * u_dpr, height * u_dpr) * 0.5 - vec2(cr));",
+    "    vec2 cornerP = p - cornerCenter;",
+    "    dist = superellipseCornerSDF(cornerP, cr, n);",
+    "  } else {",
+    "    dist = min(max(d.x, d.y), 0.0) + length(max(d, 0.0));",
+    "  }",
+    "  return dist;",
+    "}",
+    "float mainSDF(vec2 p2, vec2 p) {",
+    "  vec2 p2n = p2 + p / u_resolution.y;",
+    "  return roundedRectSDF(",
+    "    p2n,",
+    "    vec2(0.0),",
+    "    u_shapeWidth / u_resolution.y,",
+    "    u_shapeHeight / u_resolution.y,",
+    "    u_shapeRadius / u_resolution.y,",
+    "    u_shapeRoundness",
+    "  );",
+    "}"
+  ].join("\n");
+
+  var FRAG_BG = [
+    "#version 300 es",
+    "precision highp float;",
+    "in vec2 v_uv;",
+    "out vec4 fragColor;",
+    "uniform vec2 u_resolution;",
+    "uniform float u_dpr;",
+    "uniform vec2 u_shapeCentre;",
+    "uniform float u_shapeWidth;",
+    "uniform float u_shapeHeight;",
+    "uniform float u_shapeRadius;",
+    "uniform float u_shapeRoundness;",
+    "uniform float u_shadowExpand;",
+    "uniform float u_shadowFactor;",
+    "uniform vec2 u_shadowPosition;",
+    "uniform sampler2D u_bgTexture;",
+    SDF,
+    "void main() {",
+    "  vec2 u_resolution1x = u_resolution.xy / u_dpr;",
+    "  vec3 bgColor = texture(u_bgTexture, v_uv).rgb;",
+    "  vec2 p2 =",
+    "    (vec2(0, 0) - u_shapeCentre + vec2(u_shadowPosition.x * u_dpr, u_shadowPosition.y * u_dpr)) /",
+    "    u_resolution.y;",
+    "  float merged = mainSDF(p2, gl_FragCoord.xy);",
+    "  float shadow = exp(-1.0 / u_shadowExpand * abs(merged) * u_resolution1x.y) * 0.6 * u_shadowFactor;",
+    "  fragColor = vec4(bgColor - vec3(shadow), 1.0);",
+    "}"
+  ].join("\n");
+
+  /* Upstream names the two blur passes v/h and then blurs along x in the "v"
+     one; the names are back to front, the result is not. Kept as found so this
+     file and the tuner still line up with the originals. */
+  function blurFrag(axis) {
+    return [
+      "#version 300 es",
+      "precision highp float;",
+      "#define MAX_BLUR_RADIUS (200)",
+      "in vec2 v_uv;",
+      "uniform sampler2D u_prevPassTexture;",
+      "uniform vec2 u_resolution;",
+      "uniform int u_blurRadius;",
+      "uniform float u_blurWeights[MAX_BLUR_RADIUS + 1];",
+      "out vec4 fragColor;",
+      "void main() {",
+      "  vec2 texelSize = 1.0 / u_resolution;",
+      "  vec4 color = texture(u_prevPassTexture, v_uv) * u_blurWeights[0];",
+      "  for (int i = 1; i <= u_blurRadius; ++i) {",
+      "    float w = u_blurWeights[i];",
+      "    vec2 offset = vec2(float(i)) * texelSize;",
+      "    color += texture(u_prevPassTexture, v_uv + " + axis + ") * w;",
+      "    color += texture(u_prevPassTexture, v_uv - " + axis + ") * w;",
+      "  }",
+      "  fragColor = color;",
+      "}"
+    ].join("\n");
+  }
+
+  var FRAG_MAIN = [
+    "#version 300 es",
+    "precision highp float;",
+    "#define PI (3.14159265359)",
+    /* The three indices of refraction the dispersion is taken across: red bends
+       2% less than green and blue 2% more, which is what puts colour on the
+       bevel. */
+    "const float N_R = 1.0 - 0.02;",
+    "const float N_G = 1.0;",
+    "const float N_B = 1.0 + 0.02;",
+    "in vec2 v_uv;",
+    "uniform sampler2D u_blurredBg;",
+    "uniform sampler2D u_bg;",
+    "uniform vec2 u_resolution;",
+    "uniform float u_dpr;",
+    "uniform vec2 u_shapeCentre;",
+    "uniform float u_shapeWidth;",
+    "uniform float u_shapeHeight;",
+    "uniform float u_shapeRadius;",
+    "uniform float u_shapeRoundness;",
+    "uniform vec4 u_tint;",
+    "uniform float u_refThickness;",
+    "uniform float u_refFactor;",
+    "uniform float u_refDispersion;",
+    "uniform float u_refFresnelRange;",
+    "uniform float u_refFresnelFactor;",
+    "uniform float u_refFresnelHardness;",
+    "uniform float u_glareRange;",
+    "uniform float u_glareConvergence;",
+    "uniform float u_glareOppositeFactor;",
+    "uniform float u_glareFactor;",
+    "uniform float u_glareHardness;",
+    "uniform float u_glareAngle;",
+    "uniform int u_blurEdge;",
+    "uniform float u_rimReference;",
+    "out vec4 fragColor;",
+    SDF,
+    "float safeAsin(float x) { return asin(clamp(x, -1.0, 1.0)); }",
+    "vec2 getNormal(vec2 p2, vec2 p) {",
+    "  vec2 h = vec2(max(abs(dFdx(p.x)), 0.0001), max(abs(dFdy(p.y)), 0.0001));",
+    "  vec2 grad =",
+    "    vec2(",
+    "      mainSDF(p2, p + vec2(h.x, 0.0)) - mainSDF(p2, p - vec2(h.x, 0.0)),",
+    "      mainSDF(p2, p + vec2(0.0, h.y)) - mainSDF(p2, p - vec2(0.0, h.y))",
+    "    ) /",
+    "    (2.0 * h);",
+    "  return grad * 1.414213562 * 1000.0;",
+    "}",
+    /* sRGB to LCh and back. The rim and the glare are added as LIGHTNESS rather
+       than as white, which is why they keep the tint's hue instead of washing it
+       out — and why this whole block has to come across with the shader. */
+    "const vec3 D65_WHITE = vec3(0.95045592705, 1.0, 1.08905775076);",
+    "vec3 WHITE = D65_WHITE;",
+    "const mat3 RGB_TO_XYZ_M = mat3(",
+    "  0.4124, 0.3576, 0.1805,",
+    "  0.2126, 0.7152, 0.0722,",
+    "  0.0193, 0.1192, 0.9505",
+    ");",
+    "const mat3 XYZ_TO_RGB_M = mat3(",
+    "   3.2406255, -1.537208 , -0.4986286,",
+    "  -0.9689307,  1.8757561,  0.0415175,",
+    "   0.0557101, -0.2040211,  1.0569959",
+    ");",
+    "float UNCOMPAND_SRGB(float a) { return a > 0.04045 ? pow((a + 0.055) / 1.055, 2.4) : a / 12.92; }",
+    "float COMPAND_RGB(float a) { return a <= 0.0031308 ? 12.92 * a : 1.055 * pow(a, 0.41666666666) - 0.055; }",
+    "vec3 RGB_TO_XYZ(vec3 rgb) { return rgb * RGB_TO_XYZ_M; }",
+    "vec3 SRGB_TO_RGB(vec3 s) { return vec3(UNCOMPAND_SRGB(s.x), UNCOMPAND_SRGB(s.y), UNCOMPAND_SRGB(s.z)); }",
+    "vec3 RGB_TO_SRGB(vec3 c) { return vec3(COMPAND_RGB(c.x), COMPAND_RGB(c.y), COMPAND_RGB(c.z)); }",
+    "vec3 SRGB_TO_XYZ(vec3 s) { return RGB_TO_XYZ(SRGB_TO_RGB(s)); }",
+    "float XYZ_TO_LAB_F(float x) { return x > 0.00885645167 ? pow(x, 0.333333333) : 7.78703703704 * x + 0.13793103448; }",
+    "vec3 XYZ_TO_LAB(vec3 xyz) {",
+    "  vec3 s = xyz / WHITE;",
+    "  s = vec3(XYZ_TO_LAB_F(s.x), XYZ_TO_LAB_F(s.y), XYZ_TO_LAB_F(s.z));",
+    "  return vec3(116.0 * s.y - 16.0, 500.0 * (s.x - s.y), 200.0 * (s.y - s.z));",
+    "}",
+    "vec3 LAB_TO_LCH(vec3 Lab) {",
+    "  return vec3(Lab.x, sqrt(dot(Lab.yz, Lab.yz)), atan(Lab.z, Lab.y) * 57.2957795131);",
+    "}",
+    "vec3 SRGB_TO_LCH(vec3 srgb) { return LAB_TO_LCH(XYZ_TO_LAB(SRGB_TO_XYZ(srgb))); }",
+    "vec3 XYZ_TO_RGB(vec3 xyz) { return xyz * XYZ_TO_RGB_M; }",
+    "float LAB_TO_XYZ_F(float x) { return x > 0.206897 ? x * x * x : 0.12841854934 * (x - 0.137931034); }",
+    "vec3 LAB_TO_XYZ(vec3 Lab) {",
+    "  float w = (Lab.x + 16.0) / 116.0;",
+    "  return WHITE * vec3(LAB_TO_XYZ_F(w + Lab.y / 500.0), LAB_TO_XYZ_F(w), LAB_TO_XYZ_F(w - Lab.z / 200.0));",
+    "}",
+    "vec3 LAB_TO_SRGB(vec3 lab) { return RGB_TO_SRGB(XYZ_TO_RGB(LAB_TO_XYZ(lab))); }",
+    "vec3 LCH_TO_LAB(vec3 LCh) {",
+    "  return vec3(LCh.x, LCh.y * cos(LCh.z * 0.01745329251), LCh.y * sin(LCh.z * 0.01745329251));",
+    "}",
+    "vec3 LCH_TO_SRGB(vec3 lch) { return LAB_TO_SRGB(LCH_TO_LAB(lch)); }",
+    "float vec2ToAngle(vec2 v) {",
+    "  float angle = atan(v.y, v.x);",
+    "  if (angle < 0.0) angle += 2.0 * PI;",
+    "  return angle;",
+    "}",
+    "vec4 getTextureDispersion(sampler2D tex1, sampler2D tex2, float mixRate, vec2 offset, float factor) {",
+    "  vec4 pixel = vec4(1.0);",
+    "  float bgR = texture(tex1, v_uv + offset * (1.0 - (N_R - 1.0) * factor)).r;",
+    "  float bgG = texture(tex1, v_uv + offset * (1.0 - (N_G - 1.0) * factor)).g;",
+    "  float bgB = texture(tex1, v_uv + offset * (1.0 - (N_B - 1.0) * factor)).b;",
+    "  float blurR = texture(tex2, v_uv + offset * (1.0 - (N_R - 1.0) * factor)).r;",
+    "  float blurG = texture(tex2, v_uv + offset * (1.0 - (N_G - 1.0) * factor)).g;",
+    "  float blurB = texture(tex2, v_uv + offset * (1.0 - (N_B - 1.0) * factor)).b;",
+    "  pixel.r = mix(bgR, blurR, mixRate);",
+    "  pixel.g = mix(bgG, blurG, mixRate);",
+    "  pixel.b = mix(bgB, blurB, mixRate);",
+    "  return pixel;",
+    "}",
+    "void main() {",
+    "  vec2 u_resolution1x = u_resolution.xy / u_dpr;",
+    "  vec2 p2 = (vec2(0, 0) - u_shapeCentre) / u_resolution.y;",
+    "  float merged = mainSDF(p2, gl_FragCoord.xy);",
+    "  vec4 outColor;",
+    "  if (merged < 0.005) {",
+    "    float nmerged = -1.0 * (merged * u_resolution1x.y);",
+    /* Snell's law across the bevel band: the incidence angle is taken from how
+       far in from the edge this pixel is, refracted through u_refFactor, and the
+       tangent of the difference is how far the backdrop sample is dragged. */
+    "    float x_R_ratio = 1.0 - nmerged / u_refThickness;",
+    "    float thetaI = safeAsin(pow(x_R_ratio, 2.0));",
+    "    float thetaT = safeAsin(1.0 / u_refFactor * sin(thetaI));",
+    "    float edgeFactor = -1.0 * tan(thetaT - thetaI);",
+    "    if (nmerged >= u_refThickness) edgeFactor = 0.0;",
+    "    if (edgeFactor <= 0.0) {",
+    "      outColor = texture(u_blurredBg, v_uv);",
+    "      outColor = mix(outColor, vec4(u_tint.r, u_tint.g, u_tint.b, 1.0), u_tint.a * 0.8);",
+    "    } else {",
+    "      float edgeH = nmerged / u_refThickness;",
+    "      vec2 normal = getNormal(p2, gl_FragCoord.xy);",
+    /* THE ONE LINE OF THE GLASS THAT IS NOT UPSTREAM'S, and it is here because
+       this is the first canvas the shader has ever been asked to fill that is a
+       strip rather than a stage. getNormal returns the SDF's gradient, and the
+       SDF is normalised by u_resolution.y — so |normal| is 1414.2/u_resolution.y
+       and not 1, and upstream then uses it as the GAIN on the two edge terms
+       below. On the tuner's ~1035px stage that gain is 1.366, which is what #66
+       measured its rims at; on a titlebar 63px tall it is 22.4, sixteen times
+       too much, and mix() with a factor past 1 does not saturate, it
+       extrapolates — the rims come out pure white and the glare's LCh lands so
+       far out of gamut that the corners go black. That is what a verbatim port
+       renders here, and it is why this line exists rather than being tidied
+       away. Dividing the gain by the height it was settled at makes it the
+       constant it was always meant to be, at any canvas size.
+       The refraction offset needs no such correction: it multiplies normal by
+       u_resolution.y again further down, so the height cancels and the bend is
+       already the same at every size. Only the two mixes are affected. */
+    "      float rim = length(normal) * u_resolution.y / u_rimReference;",
+    "      vec4 blurredPixel = getTextureDispersion(",
+    "        u_bg,",
+    "        u_blurredBg,",
+    "        u_blurEdge > 0 ? 1.0 : edgeH,",
+    "        -normal * edgeFactor * 0.05 * u_dpr * vec2(u_resolution.y / (u_resolution1x.x * u_dpr), 1.0),",
+    "        u_refDispersion",
+    "      );",
+    "      outColor = mix(blurredPixel, vec4(u_tint.r, u_tint.g, u_tint.b, 1.0), u_tint.a * 0.8);",
+    "      float fresnelFactor = clamp(",
+    "        pow(",
+    "          1.0 +",
+    "            merged * u_resolution1x.y / 1500.0 * pow(500.0 / u_refFresnelRange, 2.0) +",
+    "            u_refFresnelHardness,",
+    "          5.0",
+    "        ),",
+    "        0.0,",
+    "        1.0",
+    "      );",
+    "      vec3 fresnelTintLCH = SRGB_TO_LCH(",
+    "        mix(vec3(1.0), vec3(u_tint.r, u_tint.g, u_tint.b), u_tint.a * 0.5)",
+    "      );",
+    "      fresnelTintLCH.x += 20.0 * fresnelFactor * u_refFresnelFactor;",
+    "      fresnelTintLCH.x = clamp(fresnelTintLCH.x, 0.0, 100.0);",
+    "      outColor = mix(",
+    "        outColor,",
+    "        vec4(LCH_TO_SRGB(fresnelTintLCH), 1.0),",
+    "        fresnelFactor * u_refFresnelFactor * 0.7 * rim",
+    "      );",
+    "      float glareGeoFactor = clamp(",
+    "        pow(",
+    "          1.0 +",
+    "            merged * u_resolution1x.y / 1500.0 * pow(500.0 / u_glareRange, 2.0) +",
+    "            u_glareHardness,",
+    "          5.0",
+    "        ),",
+    "        0.0,",
+    "        1.0",
+    "      );",
+    /* The shader DOUBLES the angle, which is why #66's 90 lights the two ends
+       rather than one side — the tuner's control says so where it is set. */
+    "      float glareAngle = (vec2ToAngle(normalize(normal)) - PI / 4.0 + u_glareAngle) * 2.0;",
+    "      int glareFarside = 0;",
+    "      if (",
+    "        glareAngle > PI * (2.0 - 0.5) && glareAngle < PI * (4.0 - 0.5) ||",
+    "        glareAngle < PI * (0.0 - 0.5)",
+    "      ) {",
+    "        glareFarside = 1;",
+    "      }",
+    "      float glareAngleFactor =",
+    "        (0.5 + sin(glareAngle) * 0.5) *",
+    "        (glareFarside == 1 ? 1.2 * u_glareOppositeFactor : 1.2) *",
+    "        u_glareFactor;",
+    "      glareAngleFactor = clamp(pow(glareAngleFactor, 0.1 + u_glareConvergence * 2.0), 0.0, 1.0);",
+    "      vec3 glareTintLCH = SRGB_TO_LCH(",
+    "        mix(blurredPixel.rgb, vec3(u_tint.r, u_tint.g, u_tint.b), u_tint.a * 0.5)",
+    "      );",
+    "      glareTintLCH.x += 150.0 * glareAngleFactor * glareGeoFactor;",
+    "      glareTintLCH.y += 30.0 * glareAngleFactor * glareGeoFactor;",
+    "      glareTintLCH.x = clamp(glareTintLCH.x, 0.0, 120.0);",
+    "      outColor = mix(",
+    "        outColor,",
+    "        vec4(LCH_TO_SRGB(glareTintLCH), 1.0),",
+    "        glareAngleFactor * glareGeoFactor * rim",
+    "      );",
+    "    }",
+    "  } else {",
+    "    outColor = texture(u_bg, v_uv);",
+    "  }",
+    "  outColor = mix(outColor, texture(u_bg, v_uv), smoothstep(-0.001, 0.001, merged));",
+    "  fragColor = outColor;",
+    "}"
+  ].join("\n");
+
+  /* ---- the tier ------------------------------------------------------------
+     Set from what the page actually resolved, never from what the browser says
+     it can do. `blur` is a computed `backdrop-filter` that is not `none`, which
+     is true only if the @supports block in styles.css really applied — so an
+     override that turns the declaration off (design/tools/render.mjs does
+     exactly that, to see the bottom rung) moves the reported tier with it.
+     The attribute has to come OFF before the computed style is read: the webgl
+     rule sets `backdrop-filter: none` itself, so leaving it on would read the
+     rung above's own suppression and call a blur-capable browser flat. */
+  function setTier(shaderDrew) {
+    if (shaderDrew) { bar.dataset.glass = "webgl"; return "webgl"; }
+    bar.removeAttribute("data-glass");
+    var cs = getComputedStyle(bar);
+    var bf = cs.backdropFilter || cs.webkitBackdropFilter || "none";
+    var tier = bf && bf !== "none" ? "blur" : "flat";
+    bar.dataset.glass = tier;
+    return tier;
+  }
+
+  /* ---- WebGL --------------------------------------------------------------- */
+  var canvas = document.createElement("canvas");
+  canvas.className = "frame-glass";
+  /* `alpha: false` because the canvas covers the whole bar and there is nothing
+     underneath it worth compositing — the rungs below are turned off by the
+     stylesheet the moment this one lands.
+     `preserveDrawingBuffer` IS LOAD-BEARING HERE and is not the usual debugging
+     flag. A drawing buffer's contents are undefined after it has been presented,
+     and this canvas is drawn once and then never again; without it the titlebar
+     is entitled to go blank the next time the compositor wants the memory back.
+     Everything that renders per frame can leave it off. Everything that renders
+     once cannot. */
+  var gl = null;
+  try {
+    gl = canvas.getContext("webgl2", {
+      antialias: false,
+      alpha: false,
+      preserveDrawingBuffer: true,
+      /* The bar is 3.5% of the Frame — a strip a laptop can draw four passes over
+         without waking a discrete GPU, and a page that renders once has nothing
+         to gain from one. */
+      powerPreference: "low-power"
+    });
+  } catch (e) {
+    gl = null;
+  }
+
+  if (!gl) { setTier(false); return; }
+
+  function compile(type, src) {
+    var s = gl.createShader(type);
+    gl.shaderSource(s, src);
+    gl.compileShader(s);
+    if (!gl.getShaderParameter(s, gl.COMPILE_STATUS)) throw new Error(gl.getShaderInfoLog(s));
+    return s;
+  }
+
+  function program(frag) {
+    var p = gl.createProgram();
+    gl.attachShader(p, compile(gl.VERTEX_SHADER, VERT));
+    gl.attachShader(p, compile(gl.FRAGMENT_SHADER, frag));
+    gl.bindAttribLocation(p, 0, "a_position");
+    gl.linkProgram(p);
+    if (!gl.getProgramParameter(p, gl.LINK_STATUS)) throw new Error(gl.getProgramInfoLog(p));
+    return { p: p, loc: {} };
+  }
+
+  var progBg, progV, progH, progMain, floatOK, IFMT, ITYPE;
+  try {
+    /* RGBA16F targets keep the blur from banding on a dark backdrop — and this
+       backdrop is as dark as backdrops get. Renderability is an extension even
+       in WebGL2, so fall back to 8-bit rather than fail: banding in the frosting
+       is a worse titlebar, not an absent one. */
+    floatOK = !!(gl.getExtension("EXT_color_buffer_float") || gl.getExtension("EXT_color_buffer_half_float"));
+    IFMT = floatOK ? gl.RGBA16F : gl.RGBA8;
+    ITYPE = floatOK ? gl.HALF_FLOAT : gl.UNSIGNED_BYTE;
+    progBg = program(FRAG_BG);
+    progV = program(blurFrag("vec2(offset.x, 0.0)"));
+    progH = program(blurFrag("vec2(0.0, offset.y)"));
+    progMain = program(FRAG_MAIN);
+  } catch (e) {
+    /* A context that exists and cannot compile is the same to a reader as no
+       context at all. */
+    setTier(false);
+    return;
+  }
+
+  function loc(prog, name) {
+    if (!(name in prog.loc)) prog.loc[name] = gl.getUniformLocation(prog.p, name);
+    return prog.loc[name];
+  }
+  function u1f(prog, n, v) { gl.uniform1f(loc(prog, n), v); }
+  function u1i(prog, n, v) { gl.uniform1i(loc(prog, n), v); }
+  function u2f(prog, n, a, b) { gl.uniform2f(loc(prog, n), a, b); }
+
+  var vao = gl.createVertexArray();
+  gl.bindVertexArray(vao);
+  var buf = gl.createBuffer();
+  gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+  /* One oversized triangle rather than two, which is the ordinary way to cover a
+     viewport without a seam down the diagonal. */
+  gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1, -1, 3, -1, -1, 3]), gl.STATIC_DRAW);
+  gl.enableVertexAttribArray(0);
+  gl.vertexAttribPointer(0, 2, gl.FLOAT, false, 0, 0);
+
+  function makeTarget() {
+    var tex = gl.createTexture();
+    gl.bindTexture(gl.TEXTURE_2D, tex);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    var fbo = gl.createFramebuffer();
+    gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
+    gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, tex, 0);
+    return { tex: tex, fbo: fbo, w: 0, h: 0 };
+  }
+
+  var tBg = makeTarget(), tV = makeTarget(), tH = makeTarget();
+
+  function sizeTarget(t, w, h) {
+    if (t.w === w && t.h === h) return;
+    gl.bindTexture(gl.TEXTURE_2D, t.tex);
+    gl.texImage2D(gl.TEXTURE_2D, 0, IFMT, w, h, 0, gl.RGBA, ITYPE, null);
+    t.w = w; t.h = h;
+  }
+
+  var sceneTex = gl.createTexture();
+  gl.bindTexture(gl.TEXTURE_2D, sceneTex);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+  gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+  gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
+
+  /* Upstream's computeGaussianKernelByRadius, padded to the array the shader
+     declares so the upload is one call whatever the radius is. */
+  var MAXR = 200;
+  var weights = new Float32Array(MAXR + 1);
+  function buildWeights(radius) {
+    weights.fill(0);
+    var sigma = radius / 3.0;
+    var sum = 0;
+    for (var i = 0; i <= radius; i++) {
+      var w = Math.exp(-0.5 * (i * i) / (sigma * sigma));
+      weights[i] = w;
+      sum += i === 0 ? w : w * 2;
+    }
+    for (var j = 0; j <= radius; j++) weights[j] /= sum;
+  }
+
+  /* ---- the backdrop --------------------------------------------------------
+     WHAT THE GLASS IS STANDING ON, painted in 2D and handed over as one texture.
+     It is the page: the Panel's own background outside the window's corners, and
+     the Frame's fill inside them. Nothing else is behind the titlebar — the
+     recording starts below it — so this is not a stand-in for the real backdrop,
+     it IS the real backdrop, which is what makes a single render honest.
+
+     The rounded rect drawn here has the shader's own top corners and runs off
+     the bottom of the canvas, so its two BOTTOM corners never exist. `roundRect`
+     with a four-value radius does that in one call; where it is missing the two
+     arcs are drawn by hand, because a browser without it would otherwise get a
+     square-cornered fill refracted through round-cornered glass — a bright
+     wedge in each corner rather than a missing rounding, which is much the more
+     obvious wrong. */
+  var scene = document.createElement("canvas");
+  var sctx = scene.getContext("2d");
+
+  function paintScene(w, h, radius) {
+    scene.width = w;
+    scene.height = h;
+    sctx.fillStyle = cssColor("--panel-bg");
+    sctx.fillRect(0, 0, w, h);
+    sctx.fillStyle = cssColor("--panel-frame-fill");
+    sctx.beginPath();
+    if (sctx.roundRect) {
+      sctx.roundRect(0, 0, w, h * 2, [radius, radius, 0, 0]);
+    } else {
+      sctx.moveTo(0, h * 2);
+      sctx.lineTo(0, radius);
+      sctx.arcTo(0, 0, radius, 0, radius);
+      sctx.lineTo(w - radius, 0);
+      sctx.arcTo(w, 0, w, radius, radius);
+      sctx.lineTo(w, h * 2);
+      sctx.closePath();
+    }
+    sctx.fill();
+  }
+
+  /* ---- render --------------------------------------------------------------- */
+  var W = 0, H = 0;
+
+  function render() {
+    var m = metrics();
+    if (!m.w || !m.h) return false;
+
+    /* Capped at 2 for the reason every renderer caps it: the fourth pass is
+       per-pixel and a 3x phone would pay 2.25x for a difference nobody can see
+       on a strip this thin. The shader is handed the SAME number — the
+       refraction offset is scaled by it, so a canvas rendered at one ratio and
+       told another bends by the wrong amount. */
+    var dpr = Math.min(window.devicePixelRatio || 1, 2);
+    var w = Math.max(1, Math.round(m.w * dpr));
+    var h = Math.max(1, Math.round(m.h * dpr));
+
+    /* THE EXPORT'S LENGTHS ARE PX AT A FRAME 1200 WIDE. This is the ratio that
+       makes them px at the Frame that is actually on screen. */
+    var k = m.w / REFERENCE_W;
+    var barH = m.h;
+    var radius = m.r;
+
+    W = w; H = h;
+    canvas.width = W;
+    canvas.height = H;
+    sizeTarget(tBg, W, H);
+    sizeTarget(tV, W, H);
+    sizeTarget(tH, W, H);
+
+    paintScene(W, H, radius * dpr);
+    gl.bindTexture(gl.TEXTURE_2D, sceneTex);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, scene);
+
+    /* THE SHAPE IS TWICE THE TITLEBAR AND HALF OF IT IS OFF THE CANVAS, which is
+       how a rounded rect grows a straight bottom edge. The SDF draws one rect
+       and a rect has four corners; a titlebar has two, at the top, and a cut
+       where the content starts. The tuner does this with a scissor pass because
+       its canvas is the whole stage. Here the canvas IS the strip, so the cut is
+       the canvas's own bottom edge and there is nothing to put back.
+       gl_FragCoord counts from the bottom, so a shape of height 2*barH whose
+       centre sits on y = 0 has its top edge at exactly barH — the canvas's top —
+       and its bottom edge a full strip below the bottom of the canvas. */
+    var shapeW = m.w;
+    var shapeH = barH * 2;
+    var centreX = (m.w / 2) * dpr;
+    var centreY = 0;
+    /* A LENGTH, NOT THE TUNER'S PERCENTAGE. Upstream's corner control is a share
+       of half the shape's short side and App.tsx multiplies it out on the way
+       into the uniform, which is why the tuner's 47.2 does not look like a
+       radius. Half the short side here IS barH, so that arithmetic resolves to
+       the window's own corner and the conversion has nowhere to go wrong. */
+    var shapeR = radius;
+
+    function shapeUniforms(prog) {
+      u2f(prog, "u_resolution", W, H);
+      u1f(prog, "u_dpr", dpr);
+      u2f(prog, "u_shapeCentre", centreX, centreY);
+      u1f(prog, "u_shapeWidth", shapeW);
+      u1f(prog, "u_shapeHeight", shapeH);
+      u1f(prog, "u_shapeRadius", shapeR);
+      u1f(prog, "u_shapeRoundness", ROUNDNESS);
+    }
+
+    gl.bindVertexArray(vao);
+    gl.viewport(0, 0, W, H);
+
+    /* pass 1 — the backdrop, with the shape's drop shadow subtracted from it.
+       Inert at the render's shadow of 0, and kept because removing it would put
+       this file and the tuner's port out of step over a uniform that costs one
+       exponential. */
+    gl.bindFramebuffer(gl.FRAMEBUFFER, tBg.fbo);
+    gl.useProgram(progBg.p);
+    shapeUniforms(progBg);
+    u1f(progBg, "u_shadowExpand", GLASS.shadowExpand);
+    u1f(progBg, "u_shadowFactor", GLASS.shadowFactor / 100);
+    /* Negated on the way in, as App.tsx does. */
+    u2f(progBg, "u_shadowPosition", -GLASS.shadowX, -GLASS.shadowY);
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, sceneTex);
+    u1i(progBg, "u_bgTexture", 0);
+    gl.drawArrays(gl.TRIANGLES, 0, 3);
+
+    /* passes 2 and 3 — the separable gaussian. Scaled with the Frame like every
+       other length, and floored at 1: a radius of 0 is a loop the shader never
+       enters, which is a titlebar with no frosting rather than a small one. */
+    var radiusPx = Math.max(1, Math.min(MAXR, Math.round(GLASS.blurRadius * k)));
+    buildWeights(radiusPx);
+    function blurPass(prog, srcTex, dstFbo) {
+      gl.bindFramebuffer(gl.FRAMEBUFFER, dstFbo);
+      gl.useProgram(prog.p);
+      u2f(prog, "u_resolution", W, H);
+      u1i(prog, "u_blurRadius", radiusPx);
+      gl.uniform1fv(loc(prog, "u_blurWeights[0]"), weights);
+      gl.activeTexture(gl.TEXTURE0);
+      gl.bindTexture(gl.TEXTURE_2D, srcTex);
+      u1i(prog, "u_prevPassTexture", 0);
+      gl.drawArrays(gl.TRIANGLES, 0, 3);
+    }
+    blurPass(progV, tBg.tex, tV.fbo);
+    blurPass(progH, tV.tex, tH.fbo);
+
+    /* pass 4 — the glass, to the canvas. The percentage controls are divided by
+       100 here exactly as App.tsx does on the way into the uniform; the three
+       that are lengths are multiplied by k instead. */
+    gl.bindFramebuffer(gl.FRAMEBUFFER, null);
+    gl.useProgram(progMain.p);
+    shapeUniforms(progMain);
+    gl.uniform4f(
+      loc(progMain, "u_tint"),
+      parseInt(GLASS.tintColor.slice(1, 3), 16) / 255,
+      parseInt(GLASS.tintColor.slice(3, 5), 16) / 255,
+      parseInt(GLASS.tintColor.slice(5, 7), 16) / 255,
+      GLASS.tintAlpha
+    );
+    u1f(progMain, "u_refThickness", GLASS.refThickness * k);
+    u1f(progMain, "u_refFactor", GLASS.refFactor);
+    u1f(progMain, "u_refDispersion", GLASS.refDispersion);
+    u1f(progMain, "u_refFresnelRange", GLASS.refFresnelRange);
+    u1f(progMain, "u_refFresnelHardness", GLASS.refFresnelHardness / 100);
+    u1f(progMain, "u_refFresnelFactor", GLASS.refFresnelFactor / 100);
+    u1f(progMain, "u_glareRange", GLASS.glareRange);
+    u1f(progMain, "u_glareHardness", GLASS.glareHardness / 100);
+    u1f(progMain, "u_glareConvergence", GLASS.glareConvergence / 100);
+    u1f(progMain, "u_glareOppositeFactor", GLASS.glareOppositeFactor / 100);
+    u1f(progMain, "u_glareFactor", GLASS.glareFactor / 100);
+    u1f(progMain, "u_glareAngle", GLASS.glareAngle * Math.PI / 180);
+    u1i(progMain, "u_blurEdge", GLASS.blurEdge ? 1 : 0);
+    u1f(progMain, "u_rimReference", REFERENCE_H);
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, tH.tex);
+    u1i(progMain, "u_blurredBg", 0);
+    gl.activeTexture(gl.TEXTURE1);
+    gl.bindTexture(gl.TEXTURE_2D, tBg.tex);
+    u1i(progMain, "u_bg", 1);
+    gl.drawArrays(gl.TRIANGLES, 0, 3);
+
+    /* A GL error means some part of the four passes did not happen, and a
+       half-drawn titlebar is exactly the "broken chrome" #57's user story 9 is
+       about. Better to hand the reader the rung below, which cannot fail. */
+    return gl.getError() === gl.NO_ERROR;
+  }
+
+  function attempt() {
+    var ok = false;
+    try { ok = render(); } catch (e) { ok = false; }
+    if (ok) {
+      /* First child, so the chrome is drawn over it — the controls sit ON the
+         glass, not under it. */
+      if (canvas.parentNode !== bar) bar.insertBefore(canvas, bar.firstChild);
+      setTier(true);
+    } else {
+      if (canvas.parentNode) canvas.parentNode.removeChild(canvas);
+      setTier(false);
+    }
+    return ok;
+  }
+
+  attempt();
+
+  /* Re-rendered when the box changes and at no other time. The Frame is nine of
+     twelve columns of a fluid composition, so this fires on window resize and on
+     the 900px reflow — and the canvas has to be repainted at the new size or the
+     bevel is a stretched copy of the old one. ResizeObserver rather than a
+     `resize` listener because the Frame's width is not the window's. */
+  if (window.ResizeObserver) {
+    var pending = 0;
+    new ResizeObserver(function () {
+      /* Coalesced to one frame: a drag across a desktop fires this per pixel,
+         and four passes per pixel of drag is the per-frame cost this whole file
+         is arranged to avoid. */
+      if (pending) return;
+      pending = requestAnimationFrame(function () { pending = 0; attempt(); });
+    }).observe(bar);
+  }
+
+  /* A context can be taken away — a laptop switching graphics adapters, a driver
+     reset, a tab backgrounded long enough for the browser to reclaim it — and
+     the default is that the canvas goes blank and stays blank, which is the one
+     outcome #57's user story 9 is written against.
+     IT GOES DOWN THE LADDER AND DOES NOT COME BACK UP, deliberately. Every
+     program, texture and buffer above is invalid after a loss, so restoring
+     means building all of it a second time — a path that would run on almost no
+     visit, could not be exercised from the harness, and whose failure mode is
+     the blank titlebar this handler exists to prevent. The rung below is a
+     titlebar that cannot fail, and a reader who never sees the change is better
+     served by it than by an untested rebuild. `preventDefault` is not called for
+     the same reason: without it the browser does not offer a restore, and there
+     is nothing here that wants one. */
+  canvas.addEventListener("webglcontextlost", function () {
+    if (canvas.parentNode) canvas.parentNode.removeChild(canvas);
+    setTier(false);
+  });
+})();

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -294,7 +294,7 @@
        two things that used to sit at this line, an @font-face at the foot of
        styles.css and a script that attached /fonts/friz-local.css on localhost
        only, are both gone. See the cut title block in styles.css. -->
-  <link rel="stylesheet" href="styles.css?v=31">
+  <link rel="stylesheet" href="styles.css?v=32">
 </head>
 <body>
   <!-- Only ever on screen while a corner picture is genuinely outstanding: it is
@@ -431,19 +431,20 @@
           <p>1,374,328 paths re-costed in 220 ms</p>
         </li>
       </ol>
-      <!-- The space the browser Frame stands in, holding the recording and
-           nothing else yet: no chrome, no titlebar, no glass. #66 builds the
-           material the titlebar is made of, #67 the Frame around this, and #68
-           stands the whole thing on the marble. It is a grid item in its own
-           right because the Frame is what occludes the subheading's second
-           line — see the .panel-frame block in styles.css, which is the whole
-           of that arithmetic — and #67 hangs its chrome inside this box rather
-           than around it, so none of it moves.
+      <!-- The browser Frame: a window with a glass titlebar, holding the
+           recording. It is a grid item in its own right because the Frame is
+           what occludes the subheading's second line — see the .panel-frame
+           block in styles.css, which is the whole of that arithmetic — and the
+           chrome hangs INSIDE this box rather than around it, so nothing in the
+           composition moved when it arrived. #68 stands the whole thing on the
+           marble.
 
            Decorative, so the box and everything in it is out of the
            accessibility tree. A silent looping recording of a scrolling grid is
-           not something a screen reader has any use for, and the paragraph
-           beside it says what the project is in the author's own words.
+           not something a screen reader has any use for, the paragraph beside it
+           says what the project is in the author's own words, and a window's
+           chrome is furniture — announcing three traffic lights and a back
+           button that go nowhere would be worse than silence.
 
            THE CLIP: the photo vault's grid, stacked, recorded by `record`
            against design/censor/capture-origin.mjs — which serves each of the
@@ -460,9 +461,110 @@
            `muted` is not decoration either: it is what lets `autoplay` run at
            all, and #57 asks for a page that never makes noise. -->
       <div class="panel-frame" aria-hidden="true">
-        <video class="panel-clip" poster="video/photos-grid.webp?v=21f8d5ea"
-               width="1440" height="900"
-               autoplay loop muted playsinline preload="none"></video>
+        <!-- The titlebar. EMPTY OF EVERYTHING BUT THE CONTROLS, because the
+             material it is made of is not markup: the flat and blurred rungs of
+             the ladder are this element's own background, and the shader rung is
+             a <canvas> frame-glass.js inserts here as the chrome's first sibling.
+             The three rungs and what picks between them are the .frame-bar block
+             in styles.css. -->
+        <div class="frame-bar">
+          <!-- NOT ONE OF THESE IS A CONTROL, and that is deliberate rather than
+               unfinished. Every one is a <span> or an <i> — no <button>, no <a>,
+               no `tabindex`, no handler — and .frame-chrome takes pointer events
+               out on top of that. The Frame is not a link because the photos site
+               binds to loopback and there is nowhere to send anyone; making any
+               of this live later is a change of element and of nothing else,
+               because every length is measured from the glyph's centre and no
+               rule here depends on what kind of element carries it.
+
+               The icons are drawn at the render's own scale: each viewBox is the
+               glyph's measured ink in the render's pixels, so a stroke-width of
+               1.5 lands within a hundredth of a pixel of 1 at a Frame 1200 wide,
+               and the aspect ratio in the file is the measured one — which is
+               what lets styles.css set a width and leave the height alone. -->
+          <div class="frame-chrome">
+            <span class="frame-lights"><i></i><i></i><i></i></span>
+            <!-- Sidebar toggle: a window with its left pane filled. -->
+            <span class="frame-icon frame-sidebar">
+              <svg viewBox="0 0 26 16" fill="none" stroke="currentColor" stroke-width="1.5">
+                <rect x="0.75" y="0.75" width="24.5" height="14.5" rx="2.5"/>
+                <path d="M9.5 0.75V15.25"/>
+                <rect x="3.4" y="3.6" width="3.2" height="8.8" rx="1" fill="currentColor" stroke="none"/>
+              </svg>
+            </span>
+            <!-- Back, and forward greyed out beside it: the render draws the
+                 second at a third of the first's ink, which is a browser saying
+                 there is nowhere forward to go. See --frame-ink-off. -->
+            <span class="frame-icon frame-back">
+              <svg viewBox="0 0 10 18" fill="none" stroke="currentColor"
+                   stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M8.5 1.5 1.5 9l7 7.5"/>
+              </svg>
+            </span>
+            <span class="frame-icon frame-fwd">
+              <svg viewBox="0 0 10 18" fill="none" stroke="currentColor"
+                   stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M1.5 1.5 8.5 9l-7 7.5"/>
+              </svg>
+            </span>
+            <!-- THE ADDRESS IS THE TRUTH AND NOT A DECORATION. The photos site
+                 binds to loopback on 8770 and is never deployed, so there is no
+                 hostname to put here that would not be an invention — #57's user
+                 story 20 asks for a pill a reader is not misled by, and the only
+                 honest reading of that is the address the thing in the recording
+                 was actually served from. design/censor/capture-origin.mjs is the
+                 origin `record` was pointed at, and it is this one.
+                 The render's pill is EMPTY — `record` was run with `mockup=none`,
+                 so it composited no chrome of its own and there is nothing here
+                 to have measured. The type size is chosen; styles.css says how. -->
+            <span class="frame-pill">
+              <span class="frame-url">127.0.0.1:8770</span>
+              <span class="frame-icon frame-reload">
+                <svg viewBox="0 0 16 18" fill="none" stroke="currentColor"
+                     stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M13.5 9a5.5 5.5 0 1 1-1.9-4.2"/>
+                  <path d="M13.9 1.4v3.6h-3.6"/>
+                </svg>
+              </span>
+            </span>
+            <!-- Share, new tab, tabs. -->
+            <span class="frame-icon frame-share">
+              <svg viewBox="0 0 22 21" fill="none" stroke="currentColor"
+                   stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M6 8.2H2.75v11.05h16.5V8.2H16"/>
+                <path d="M11 1v11.4M11 1 7.3 4.8M11 1l3.7 3.8"/>
+              </svg>
+            </span>
+            <span class="frame-icon frame-new">
+              <svg viewBox="0 0 20 20" fill="none" stroke="currentColor"
+                   stroke-width="1.5" stroke-linecap="round">
+                <path d="M10 1.5v17M1.5 10h17"/>
+              </svg>
+            </span>
+            <!-- Two tabs, the back one offset down and right by the same amount
+                 in both directions. Its path is the part of an identical rounded
+                 rect that the front one does not cover, so it begins and ends ON
+                 the front tab's outline — drawn as a bare corner instead it
+                 reads as a hook coming off the side rather than as a second
+                 rectangle behind the first. -->
+            <span class="frame-icon frame-tabs">
+              <svg viewBox="0 0 25 17" fill="none" stroke="currentColor" stroke-width="1.5">
+                <rect x="0.75" y="0.75" width="17" height="11.5" rx="2.5"/>
+                <path d="M17.75 4.75h3.5a2.5 2.5 0 0 1 2.5 2.5v6.5a2.5 2.5 0 0 1-2.5 2.5H9.25a2.5 2.5 0 0 1-2.5-2.5v-1.5"/>
+              </svg>
+            </span>
+          </div>
+        </div>
+        <!-- The window's content, and it is inset from the window's edge on
+             three sides — the render is explicit about it and the .frame-content
+             block has the measurement. The clip's crop happens here now rather
+             than on the Frame, because this box is the shape the recording has to
+             fill and it is not the Frame's shape. -->
+        <div class="frame-content">
+          <video class="panel-clip" poster="video/photos-grid.webp?v=21f8d5ea"
+                 width="1440" height="900"
+                 autoplay loop muted playsinline preload="none"></video>
+        </div>
       </div>
     </div>
   </section>
@@ -552,5 +654,15 @@
        browser that skips it keeps the poster that is already on screen — which
        is exactly what a reader asking for reduced motion is shown. -->
   <script src="panel-clip.js?v=1"></script>
+  <!-- The titlebar's glass, and last for the fourth time for the fourth version
+       of the same reason: the Frame is already drawn by the time this runs, and
+       a browser that skips it — blocked, errored, or without the WebGL2 the
+       whole thing is built on — keeps the titlebar the stylesheet has already
+       painted. That one is a fill and a pair of rings rather than a hole where a
+       titlebar should be, which is what #57's user story 9 asks for.
+       It does not depend on panel-clip.js and does not wait on the video: what
+       the glass refracts is the Frame's own fill, decided once. The file says
+       why that and not the recording. -->
+  <script src="frame-glass.js?v=1"></script>
 </body>
 </html>

--- a/portfolio/styles.css
+++ b/portfolio/styles.css
@@ -2104,11 +2104,17 @@ body::after {
   --panel-ink-soft: #dcdad5;
   --panel-muted:    #8b8983;
   --panel-rule:     rgba(242, 241, 238, 0.16);
-  /* The Frame's fill and edge. The fill is now what shows behind the recording
-     before it decodes, and in a browser that plays neither format; the edge goes
-     when #67 builds the real chrome. */
+  /* The Frame's fill and edge. The fill is the window's body: what shows behind
+     the recording before it decodes, what the titlebar's glass is standing on,
+     and the band between the recording and the window's own edge.
+     THE EDGE IS THE RIM ROUND THE WHOLE WINDOW, and it is measured rather than
+     chosen: the render's outer edge peaks at 84 of 255 against a page backdrop
+     of 8, so 0.32 of #f2f1ee. It was 0.1 while the Frame was a placeholder,
+     which is a third of what the render has. The rim along the TOP is not this —
+     that edge is inside the glass and the shader draws it, and .frame-bar paints
+     over this ring where the two meet. */
   --panel-frame-fill: #131518;
-  --panel-frame-edge: rgba(242, 241, 238, 0.1);
+  --panel-frame-edge: rgba(242, 241, 238, 0.32);
 
   /* ---- the type scale ---------------------------------------------------- */
   /* THE DESIGN RENDER IS NOT IN THIS REPOSITORY, so these are constants of the
@@ -2157,8 +2163,10 @@ body::after {
   /* Also off the render, and also a constant here for the reason above: the
      Frame including its titlebar measured 1430 x 735.
      THE RECORDING IS 1.6 AND THIS IS 1.945, and they do not reconcile — see the
-     .panel-clip block, which is where the crop is decided and why. #67 builds
-     the Frame and is where a decision to move this belongs. */
+     .panel-clip block, which is where the crop is decided and why. #67 built the
+     Frame and left this where it found it: the render's Frame is what the
+     composition is measured against, and cropping the recording into it is a
+     smaller lie than reshaping the window the whole design is drawn around. */
   --panel-frame-ratio: 1.945;
 
   position: relative;
@@ -2279,33 +2287,343 @@ body::after {
   z-index: 1;
   margin-top: var(--panel-frame-drop);
   aspect-ratio: var(--panel-frame-ratio);
-  border-radius: clamp(0.5rem, 0.9vw, 1rem);
+  position: relative;
   background: var(--panel-frame-fill);
-  border: 1px solid var(--panel-frame-edge);
-  /* The clip's corners are the Frame's, and the crop below has to happen
-     somewhere. Both are this. */
+  border-radius: var(--frame-radius);
+  /* The rim, as a ring rather than a `border`. A border would take a pixel off
+     the inside of every child's box and put the window's own edge INSIDE the
+     titlebar, one pixel in from where the glass draws its own — two rims a pixel
+     apart down each end. An inset ring paints over the fill instead and costs
+     the layout nothing. */
+  box-shadow: inset 0 0 0 1px var(--panel-frame-edge);
+  /* EVERY LENGTH IN THE CHROME IS A SHARE OF THIS BOX'S WIDTH, in cqw, so the
+     window holds its proportions at any size the composition gives it — the
+     same device .cut-title already uses to draw a word at an exact width. It is
+     also the form the #66 export is stated in: a CSS px there is a px at a Frame
+     1200 wide, so 41.5px of titlebar is 3.4583% and stays 3.4583% when the Frame
+     is 1600. `inline-size` and not `size`: the height comes from aspect-ratio
+     above, and size containment would take it away. */
+  container-type: inline-size;
+
+  /* The chrome's own constants, declared on the Frame because the rules that
+     read them are the Frame's children and the container they resolve against is
+     this box. Where each number comes from is the table over the chrome section
+     below — that is the only place any of them is explained. */
+  --frame-bar:    3.4583cqw;
+  --frame-radius: 1.6333cqw;
+  --frame-inset:  0.816cqw;
+  --frame-ink:      rgba(242, 241, 238, 0.55);
+  --frame-ink-off:  rgba(242, 241, 238, 0.22);
+  --frame-light:    rgba(242, 241, 238, 0.45);
+  --frame-pill-bg:  rgba(242, 241, 238, 0.12);
+  --frame-pill-ink: rgba(242, 241, 238, 0.72);
+}
+
+/* ---- the browser Frame's chrome --------------------------------------------
+   MEASURED OFF THE DESIGN RENDER, which is not in this repository, so these are
+   constants of the composition for the reason the .panel block already gives.
+   Read off its 2568px-wide pixels with the Frame spanning x 574–2411 (1837 wide)
+   and its top edge at y 534.5, then restated as shares of the Frame's width —
+   the only form of any of it that survives being scaled — and written in cqw
+   below, which is that share made a length again. The first three are on the
+   Frame itself, in the block above, because more than one rule reads them; the
+   rest are written into the rule that uses them, once each.
+
+   Every glyph's position is its measured CENTRE and every size its measured ink,
+   taken as the full width at half maximum of a brightness profile down the bar.
+   The render is a blurred perspective still, so a stroke's peak is a FLOOR on
+   its real value, not the value: that is why the ink alphas below are one number
+   for every enabled glyph rather than the seven slightly different numbers the
+   profile hands back. The one that is genuinely apart is the forward chevron,
+   which reads at a third of the back chevron in a render where every other pair
+   of neighbours matches — a browser greying out a direction it cannot go, and
+   the truth here too.
+
+     titlebar     3.4583%   (41.5px at a Frame 1200 — the #66 reference width)
+     corner       1.6333%   (19.6px, superellipse n≈2.2, drawn by the shader)
+     inset        0.816%    (15px, the band between the recording and the edge)
+     lights       0.95% across, 1.52% apart, first centred 2.04% in
+     sidebar      1.41% wide, centred  8.00%
+     back / fwd   0.54% wide, centred 10.66% / 12.95%
+     pill        39.45% wide, 2.07% tall, centred 50.19% — so centred on the Frame
+     reload       0.87% wide, centred 69.15% — inside the pill, at its right end
+     share        1.20% wide, centred 92.22%
+     new tab      1.03% wide, centred 94.91%
+     tabs         1.36% wide, centred 97.52%
+
+   THE PILL IS EMPTY IN THE RENDER. `record` was run with `mockup=none` and the
+   address is authored here, so there is nothing to measure and the type size is
+   chosen: 0.95cqw is 11.4px at 1200, which is a browser's address type against a
+   field 24.8px tall. What it says is not a choice — see the markup.
+
+   THE INK IS ONE ALPHA FOR EVERY ENABLED GLYPH — --frame-ink, 0.55, which is
+   what the back chevron measures and it is the one stroke thick enough that the
+   render's blur does not eat it. --frame-light is its own, 0.45, because a
+   filled disc is not a stroke and can be measured honestly; --frame-ink-off is
+   the forward chevron's 0.22. */
+
+/* ---- the titlebar, and the three materials it can be made of ----------------
+   THE LADDER IS THE CASCADE, not a chain of `if`s, and it is built so that each
+   rung is what a browser gets when the one above it is genuinely unavailable
+   rather than when a script decided it was:
+
+     flat   this block. A translucent fill and nothing else. It is also what a
+            browser that never runs frame-glass.js gets, which is the whole
+            point of putting it in the base rule.
+     blur   the @supports block. Adds the backdrop blur and the two rings.
+            No script involved, so a reader with JS off still gets it.
+     webgl  frame-glass.js sets data-glass="webgl" once the shader has actually
+            drawn, and that turns the two rules above off in favour of the
+            canvas it inserted.
+
+   THE FILL IS NOT A CHOSEN COLOUR. The render's chrome body is (44,38,49) and
+   the Frame's fill behind it is #131518 — and #fab2ff at 0.108 over that fill
+   solves all three channels to the integer. That is not a coincidence: 0.108 is
+   the #66 tint, 0.135, times the 0.8 the shader multiplies it by, and #fab2ff is
+   the tint colour. So the flat rung is the shader's own tint term with the
+   refraction, the rims and the blur removed — the same material with everything
+   that needs a GPU taken out, rather than an imitation of it.
+
+   Standing above the recording because the glass is a lens and a lens is in
+   front of what it bends. z-index and not source order alone, because the
+   canvas frame-glass.js inserts is a child of this and the video is a sibling
+   of it. */
+.frame-bar {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--frame-bar);
+  z-index: 1;
+  /* The window's own top corners, and the only two the Frame has. The shader
+     draws a superellipse of the same radius and paints the page's backdrop
+     outside it; this is what rounds the flat and blurred rungs, and what keeps
+     the fill off the corners underneath the canvas. */
+  border-radius: var(--frame-radius) var(--frame-radius) 0 0;
+  background: rgba(250, 178, 255, 0.108);
+  /* NO RIM OF ITS OWN, AND THAT IS THE POINT OF THE FILL BEING TRANSLUCENT.
+     .panel-frame's ring already runs round the whole window, the bar is painted
+     over it, and at 0.108 the ring shows through — so the outline stays
+     continuous across the titlebar without this rung drawing anything. Adding a
+     second ring here would put TWO on the same pixel: the Frame's, then the tint
+     over it, then this one, which measures 150 of 255 along the top edge against
+     the render's 66. One rim, once. */
+}
+
+/* The blurred rung. THE BLUR DOES NOTHING TODAY and is here anyway: what sits
+   behind the titlebar is the Frame's own flat fill, and a blur of a flat colour
+   is that colour. It is what #68 changes — the Panel stands on marble there, and
+   whatever of it shows through the window is the first thing this has to soften.
+   Writing it now means #68 moves a backdrop and not a ladder.
+
+   THE TWO RINGS ARE THE TWO THINGS THE SHADER'S EDGE DOES, and they replace the
+   window's rim rather than joining it, so between them they have to reach the
+   render's own numbers. The first is the Fresnel: a closed ring round the whole
+   shape, and the render's TOP rim peaks at 66 of 255 over a body of 44, so 0.104
+   of white. The second is the angular glare, which #66 settled at 90° — an angle
+   the shader doubles, so it lights the two ENDS and not the top — and the
+   render's side rims peak at 85 and 90.
+   THEY COMPOSITE, WHICH IS WHY THE SECOND IS NOT 0.20. Both are painted on the
+   left and right edges, so what has to equal the render there is the pair:
+   0.104 + a(1 − 0.104) = (90 − 43)/(255 − 43) = 0.222, which puts a at 0.132.
+   Giving the second ring the render's own 0.20 would put the ends at 103 — the
+   mistake of reading a measured total as one layer's share of it.
+   What this rung cannot do is the third thing, the refraction, and there is no
+   honest CSS for it: the route the photos project ships bends its backdrop with
+   `url()` inside `backdrop-filter`, which is Chromium's alone, and a fallback
+   that only falls back on one engine is not one. So the bevel is a rim here and
+   a bend one rung up. */
+@supports ((backdrop-filter: blur(1px)) or (-webkit-backdrop-filter: blur(1px))) {
+  .frame-bar {
+    -webkit-backdrop-filter: blur(0.5cqw);
+    backdrop-filter: blur(0.5cqw);
+    box-shadow:
+      inset  0    0 0 1px rgba(255, 255, 255, 0.104),
+      inset  1px  0 0 0   rgba(255, 255, 255, 0.132),
+      inset -1px  0 0 0   rgba(255, 255, 255, 0.132);
+  }
+}
+
+/* The shader rung. Everything the two below paint is turned off rather than
+   painted over: the canvas is opaque and would hide them, but a backdrop-filter
+   under an opaque child still costs a filter pass on every composite, which is
+   the per-frame cost this Frame exists without. */
+.frame-bar[data-glass="webgl"] {
+  background: none;
+  -webkit-backdrop-filter: none;
+  backdrop-filter: none;
+  box-shadow: none;
+}
+/* Sized in CSS and not by attribute, so a resize is a repaint of a canvas that
+   is already the right shape rather than a reflow waiting on script.
+   THE CLIP IS A CIRCLE AND THE SHADER'S CORNER IS NOT, which is a half-pixel
+   the change chooses to give up. The context is opaque — it has to be, there is
+   nothing worth compositing under it — so it paints the page's own backdrop
+   outside its superellipse, and against today's flat Panel that is invisible
+   whether it is clipped or not. It stops being invisible the moment something
+   else is behind the Frame, which is #68: without the clip the canvas would
+   paint --panel-bg over the marble in each top corner. `border-radius` cannot
+   describe a superellipse, so what it cuts instead is the ~3% the exponent 2.2
+   bulges past a circular arc at 45° — 0.48px at a Frame 1200 wide, and less
+   below that. The robust half-pixel is the better trade; #68 should extend the
+   backdrop rather than reach for this. */
+.frame-glass {
+  display: block;
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  /* Inert like everything else in the window. The canvas answers to nothing, but
+     it covers the whole bar, and a decorative element that is what the pointer
+     finds there is a small lie about what the Frame is. */
+  pointer-events: none;
+}
+
+/* ---- the controls -----------------------------------------------------------
+   INERT, AND SAID TWICE. `pointer-events: none` here, and nothing in the markup
+   below is a button or a link — see the comment there. The Frame is not a link
+   because the photos site binds to loopback and there is nowhere to send anyone;
+   this is the arrangement that lets #72 or a later ticket switch that on by
+   changing the elements, without moving a single length in this block.
+
+   A flex row, not ten absolutely-positioned percentages, and the measured
+   centres are still what places everything: each gap below is the distance
+   between two measured centres less the two half-widths between them, so moving
+   one glyph moves it by its own number and not by re-deriving nine others. The
+   pill is the exception and is centred on the Frame, which is where the render
+   has it to within a fifth of a percent. */
+.frame-chrome {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  /* 2.04% to the first light's centre, less half its 0.95% width. */
+  padding-left: 1.565cqw;
+  /* 97.52% to the tabs' centre, plus half its 1.36% width, from the right. */
+  padding-right: 1.80cqw;
+  pointer-events: none;
+  user-select: none;
+  -webkit-user-select: none;
+}
+.frame-lights {
+  display: flex;
+  /* 1.52% pitch less the 0.95% disc. */
+  gap: 0.57cqw;
+}
+.frame-lights i {
+  width: 0.95cqw;
+  height: 0.95cqw;
+  border-radius: 50%;
+  background: var(--frame-light);
+}
+/* Every glyph is drawn as SVG at its measured ink width, with the viewBox scaled
+   so the stroke lands on the box's edges — so the number in the rule is the
+   number in the table above, not a box with padding in it. */
+.frame-icon {
+  display: block;
+  flex: 0 0 auto;
+  color: var(--frame-ink);
+}
+.frame-icon svg { display: block; width: 100%; height: auto; }
+/* dot 3's right edge (5.505%) to the sidebar's left edge (7.295%) */
+.frame-sidebar { width: 1.41cqw; margin-left: 1.79cqw; }
+/* the sidebar's right edge (8.705%) to the back chevron's left (10.39%) */
+.frame-back    { width: 0.54cqw; margin-left: 1.685cqw; }
+/* 2.29% between the two chevrons' centres, less both half-widths */
+.frame-fwd     { width: 0.54cqw; margin-left: 1.75cqw; color: var(--frame-ink-off); }
+
+/* The address field. Absolutely placed rather than left to the flex row, because
+   it is centred on the FRAME and the row's two clusters are not the same width —
+   left to `auto` margins it would sit between them and drift with the longer
+   one. `left: 50%` is the render's 50.19% to a fifth of a percent, and the
+   difference is smaller than the edge of the pill it would move. */
+.frame-pill {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 39.45cqw;
+  height: 2.07cqw;
+  border-radius: 0.44cqw;
+  background: var(--frame-pill-bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.frame-url {
+  font-size: 0.95cqw;
+  line-height: 1;
+  letter-spacing: 0.01em;
+  color: var(--frame-pill-ink);
+  /* The one thing in the chrome set in figures, and the tabular set is what
+     stops the four groups of the address from shifting under each other if the
+     face is ever re-subsetted. */
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+/* Placed against the PILL'S right edge rather than at its own measured centre,
+   because it belongs to the field and travels with it: the render has the glyph
+   centred 69.15% across and the pill ending at 69.91%, so 0.325% of clearance
+   once its own half-width is taken off. Left as an absolute centre it would
+   disagree with the pill by the fifth of a percent the pill is already offset by
+   — see .frame-pill — and the reload would drift off the end of the field it
+   sits in rather than with it. */
+.frame-reload {
+  position: absolute;
+  right: 0.325cqw;
+  width: 0.87cqw;
+}
+/* The right-hand cluster. `auto` pushes it to the padding edge, which is where
+   the tabs glyph's measured centre puts it. */
+.frame-share { width: 1.20cqw; margin-left: auto; }
+/* 2.69% between share and new tab, less both half-widths */
+.frame-new   { width: 1.03cqw; margin-left: 1.575cqw; }
+/* 2.61% between new tab and tabs, less both half-widths */
+.frame-tabs  { width: 1.36cqw; margin-left: 1.415cqw; }
+
+/* ---- the window's content ---------------------------------------------------
+   THE RECORDING DOES NOT REACH THE WINDOW'S EDGE, and the render is explicit
+   about it: at every height sampled down the left side the outer rim is followed
+   by 15px of the Frame's own fill before the grid's white background starts, and
+   the right edge measures the same. Flush at the TOP, though — the grid begins
+   exactly where the titlebar ends, at y 598 — so the inset is three-sided and
+   the box is not concentric with the window.
+   Its corners are: 1.6333% of window radius less the 0.816% inset leaves 0.817%,
+   which is what a rounded rect inset inside another one gives, and it is why the
+   two top corners are rounded against a straight titlebar above them. The render
+   has that notch and it is not an artefact. */
+.frame-content {
+  position: absolute;
+  top: var(--frame-bar);
+  left: var(--frame-inset);
+  right: var(--frame-inset);
+  bottom: var(--frame-inset);
+  border-radius: var(--frame-inset);
+  /* The crop below has to happen somewhere, and the corners with it. */
   overflow: hidden;
 }
 
 /* ---- the recording ---------------------------------------------------------
-   THE CLIP AND THE FRAME ARE NOT THE SAME SHAPE, and this is where that is
+   THE CLIP AND THE CONTENT BOX ARE NOT THE SAME SHAPE, and this is where that is
    settled rather than hidden. The recording is 1440x900 — record's viewport, and
    the geometry design/censor/roll.json was assembled at, so it is not free to
-   move: change it and the clip passes over photographs nobody reviewed. The
-   Frame is --panel-frame-ratio, 1.945, measured off the design render.
+   move: change it and the clip passes over photographs nobody reviewed.
 
    They cannot be reconciled by choosing better numbers. The render's Frame is
    1430 wide by 735 including its titlebar, and 1430 of a 1.6 recording is 894
    tall before a titlebar is added at all — the picture alone is taller than the
-   whole window in the render. So something is cropped, and #65's job is to
-   supply the recording and its real ratio; #67 builds the Frame and is where a
-   decision to move --panel-frame-ratio belongs.
+   whole window in the render. So something is cropped.
 
-   `cover` from the TOP EDGE, not the middle. 1.6/1.945 of the recording's height
-   survives — 82%, so 18% is cropped, and taking all of it off the bottom keeps
-   the vault's own toolbar hard against the top of the Frame. That is the row
-   that says this is an application and not a wall of pictures, and it is where
-   a real window's content starts: directly under the chrome #67 puts above it.
+   IT IS CROPPED HARDER NOW THAN WHEN THE FRAME WAS A PLACEHOLDER, and by exactly
+   what the chrome takes: the box is the Frame less the titlebar's 3.4583%, less
+   the 0.816% inset on the two sides and the bottom, so 98.368 by 47.140 of the
+   Frame's width — a ratio of 2.087 against the 1.945 the whole box was. So
+   1.6/2.087 of the recording's height survives, 76.7%, and 23.3 is cut where it
+   was 18.
+
+   `cover` from the TOP EDGE, not the middle, and all of the cut comes off the
+   bottom. That keeps the vault's own toolbar hard against the top of the box,
+   which is the row that says this is an application and not a wall of pictures,
+   and it is where a real window's content starts: directly under the chrome.
    Cropping the bottom of the viewport can only ever REMOVE what the clip shows,
    which is the direction the censored list is safe in.
 

--- a/portfolio/styles.css
+++ b/portfolio/styles.css
@@ -2110,9 +2110,14 @@ body::after {
      THE EDGE IS THE RIM ROUND THE WHOLE WINDOW, and it is measured rather than
      chosen: the render's outer edge peaks at 84 of 255 against a page backdrop
      of 8, so 0.32 of #f2f1ee. It was 0.1 while the Frame was a placeholder,
-     which is a third of what the render has. The rim along the TOP is not this —
-     that edge is inside the glass and the shader draws it, and .frame-bar paints
-     over this ring where the two meet. */
+     which is a third of what the render has.
+     WHAT HAPPENS TO IT ALONG THE TITLEBAR DEPENDS ON THE RUNG, and .frame-bar
+     depends on that in turn, so it is worth being exact. Only the shader's
+     canvas is opaque, so only there is this ring covered — and covered by an
+     edge the shader draws itself, at the same place. On the other two rungs the
+     bar's fill is translucent and this ring shows THROUGH it, which is what
+     keeps the window's outline continuous without the bar drawing a rim of its
+     own. Adding one there would put two on the same pixel. */
   --panel-frame-fill: #131518;
   --panel-frame-edge: rgba(242, 241, 238, 0.32);
 


### PR DESCRIPTION
Closes #67 — by hand, because `Closes` never fires into `development`.

The Projects Panel's Frame was a dark rectangle with the recording stretched
across it. It is a browser window now, standing on a titlebar made of the
material #66 settled: traffic lights, sidebar toggle, back and forward, an
address pill, and share, new-tab and tabs on the right.

## The chrome

Measured off the design render — not in this repository, so these are constants
of the composition for the reason `.panel` already gives — and restated as shares
of the Frame's width, which is the only form of any of it that survives being
scaled. `.panel-frame` becomes a container and every length is `cqw`, the device
`.cut-title` already uses.

| | share of the Frame's width |
| --- | --- |
| titlebar | 3.4583% (41.5px at the #66 reference width of 1200) |
| corner | 1.6333%, superellipse n≈2.2, drawn by the shader |
| content inset | 0.816%, three-sided — flush under the bar |
| lights | 0.95% across, 1.52% apart, first centred 2.04% in |
| sidebar · back · fwd | centred 8.00% · 10.66% · 12.95% |
| pill | 39.45% wide, 2.07% tall, centred on the Frame |
| reload · share · new · tabs | 69.15% · 92.22% · 94.91% · 97.52% |

Each position is a measured centre and each size a measured ink width, taken as
the full width at half maximum of a brightness profile down the bar. The ink is
one alpha for every enabled glyph, because in a blurred render a thin stroke's
peak is a floor on its value rather than the value. The exception is the forward
chevron, which reads at a third of the back chevron where every other pair
matches — a browser greying out a direction it cannot go, and the truth here too.

**Nothing responds to clicks, and it is said twice.** Every control is a `<span>`
or an `<i>` — no `<button>`, no `<a>`, no `tabindex`, no handler — and
`.frame-chrome` takes pointer events out on top of that. Making any of it live
later is a change of element and of nothing else. The whole Frame stays
`aria-hidden`: a window's chrome is furniture, and announcing three traffic
lights and a back button that go nowhere would be worse than silence.

**The address is the truth.** `127.0.0.1:8770` is the origin `record` was pointed
at, and the photos site binds to loopback and is never deployed, so any hostname
would be an invention. The render's own pill is empty — `record` ran with
`mockup=none` — so the type size is chosen and says so.

## The ladder is the cascade

Not a chain of `if`s, so each rung is what a browser gets when the one above is
genuinely unavailable rather than when a script decided it was:

- **flat** — the base rule. A translucent fill, and nothing else. Also what a
  browser that never runs the script gets.
- **blur** — an `@supports` block: the backdrop blur and the two rings. No script
  involved, so a reader with JavaScript off still gets it.
- **webgl** — `frame-glass.js` puts a canvas over both once its four passes have
  actually drawn.

**The flat fill is not a chosen colour.** The render's chrome body is (44,38,49)
over the Frame's `#131518`, and `#fab2ff` at 0.108 solves all three channels to
the integer — 0.108 being #66's tint of 0.135 times the 0.8 the shader multiplies
it by. The bottom rung is the shader's own tint term with everything that needs a
GPU taken out.

**The two rings composite**, which is why the second is 0.132 and not the
render's 0.20: both are painted on the ends, so what has to equal the render
there is the pair. Reading a measured total as one layer's share of it put the
ends at 103 against the render's 90.

## `data-glass` cannot lie

The attribute is written from the computed `backdrop-filter` of the bar on
screen, not from what the browser claims to support — so an override that turns
the declaration off moves the reported tier with it. `render.mjs` reports it
beside every shot and can force the lower two with `--glass blur|flat`.

Chromium's `--disable-webgl2` is a real switch.
`--disable-blink-features=CSSBackdropFilter` is not — `CSS.supports()` still
answers true and the `@supports` block still applies, so a shot forced that way
would be captioned `flat` while showing a blur. The declarations are overridden
instead, before the page's own script runs. Forced shots carry the mode in the
filename, for the reason the page-key comment in that file already gives at
length.

## Found building it: the material was a function of the tuner's window size

`getNormal` returns the SDF's gradient, and the SDF is normalised by
`u_resolution.y` — so `|normal|` is `1414.2/u_resolution.y` rather than 1, and
upstream uses it as the **gain** on the Fresnel and glare mixes. That made the
same settings render differently at different stage sizes: 1.366 at 1552×1035,
2.16 at 656×655. An export judged in one window did not reproduce in another.

#67 is where it stopped being survivable, because the shipping canvas is the
titlebar itself — 63px tall, gain 22 — and `mix()` past 1 does not saturate, it
extrapolates. Verbatim, the titlebar renders with pure white rims and black
corners, the glare's LCh landing far out of gamut.

Fixed in **both** files by dividing the gain by the height the material was
settled at, which is measured rather than chosen: at 1920×1080 with one device
pixel per CSS pixel the tuner's stage is 1552×1035, and reading its canvas back
there gives body (43,37,47), top rim 68, side rims 87 — #92's recorded table to
the integer. So the tuner renders at 1552×1035 exactly what it rendered before,
and at every other size it now renders that too.

## Verified

Served from the worktree, not `preview_start` — that serves the main checkout.

**Each tier seen, not assumed.** All three engage and report themselves through
`render.mjs`: `glass → webgl`, `glass → blur`, `glass → flat`. Script blocked
entirely: no canvas, the translucent fill on screen, no attribute, reported as
`no script` rather than guessed at.

**Read back off the rendered page**, against the render's own pixels:

| | render | shipped |
| --- | --- | --- |
| body | (44,38,49) | (44,38,49) |
| top rim, peak | 66 | 68 |
| side rims, peak | 88 and 91 | 93 |
| ends, blurred rung | 88 and 91 | 90 |

Geometry lands on the measured shares: titlebar 3.457%, pill 39.45 × 2.07
centred at 50.0%, content inset 0.814% at a ratio of 2.087, and every glyph
centre within 0.05% of its target.

Desktop 1440 and 1920, tablet, mobile, dark theme, and reduced motion all hold
the Frame's proportions and the top rung. Reduced motion still fetches **zero**
video: 0 sources, 0 requests. A resize re-renders the canvas at the new size,
including across the 900px reflow.

**#62's check passes** — 592 / 852 / 80 / 80 on all four gutters, both themes,
luminance 188.4 light and 46.1 dark.

## Found on review, and fixed in this branch

- **The four passes ran twice on every visit.** `ResizeObserver` delivers a
  callback for the element's initial size the moment `observe()` is called, so it
  redrew the box `attempt()` had just drawn — producing an identical picture,
  which is why it would never have been noticed. Guarded on the device size
  actually having moved; measured back down to one.
- **The observer went on driving dead GL after a context loss**, once per resize
  for the rest of the session, to reach a conclusion that cannot change.
- **`--panel-frame-edge`'s comment contradicted `.frame-bar`'s.** Only the shader
  rung covers the window's ring, because only its canvas is opaque; on the other
  two it shows through the translucent fill, which is what keeps the outline
  continuous without the bar drawing a rim of its own.

## Deliberate, and worth disagreeing with

- **The backdrop is static.** #66 measured that the render cannot tell the
  Frame's fill from the page showing through it, and that only the recording
  under the chrome is visibly not the render — and the recording is the only one
  of the three that costs anything, four passes a frame forever. #57's decision
  is a static backdrop and that is what ships. #68 is where the first half stops
  being true.
- **Context loss goes down the ladder and does not come back up.** Restoring
  means rebuilding every program, texture and buffer — a path that would run on
  almost no visit, could not be exercised from the harness, and whose failure
  mode is the blank titlebar the handler exists to prevent.
- **The canvas is clipped by a circular `border-radius` and the shader's corner
  is not.** It costs ~3% of the radius at 45°, 0.48px at a Frame 1200 wide. The
  context has to be opaque, so without the clip it would paint `--panel-bg` over
  whatever #68 puts behind the Frame's top corners.
- **`--panel-frame-ratio` did not move**, though the clip is now cropped 23.3%
  rather than 18% because the chrome takes its share. The render's Frame is what
  the composition is measured against, and cropping the recording into it is a
  smaller lie than reshaping the window the design is drawn around.
- **Phone is proportional, not designed.** At 390px the Frame is a small browser
  window rather than a broken one; #70 owns the real reflow.

Three tier shots and the contact sheet are reproducible in one command and are
not committed — `design/shots/` would take 3.8MB of screenshots that go stale.
