### PR TITLE
Set the Projects Panel's backdrop to pure black

### DIFF
--- a/design/glass-tuner.html
+++ b/design/glass-tuner.html
@@ -814,7 +814,7 @@ var GROUPS = [
     { k: "shadowExpand", type: "num", min: 2, max: 100, step: 0.01, def: 25, label: "expand",
       tip: "How far the drop shadow spreads from the shape. It is drawn into the backdrop before\nthe blur, so the glass refracts its own shadow — which is why it reads as thickness.\nInert while intensity is 0, which is where the render puts it." },
     { k: "shadowFactor", type: "num", min: 0, max: 100, step: 0.01, def: 0, studio: 15, label: "intensity",
-      tip: "How dark the shadow is. 0 removes it.\nThe render has none: the backdrop three pixels above the titlebar is the same near-black as\nthe backdrop anywhere else. Left at 0, which also stops the shadow eating the panel's own\n#08090a — at the studio's 15 it subtracts more than that colour has." },
+      tip: "How dark the shadow is. 0 removes it.\nThe render has none: the backdrop three pixels above the titlebar is the same near-black as\nthe backdrop anywhere else. Left at 0, which also stops the shadow eating the panel's own\nblack — at the studio's 15 it subtracts from a colour that has nothing to give." },
     { k: "shadowX", type: "num", min: -20, max: 20, step: 0.1, def: 0, label: "offset x",
       tip: "Shadow offset, CSS px." },
     { k: "shadowY", type: "num", min: -20, max: 20, step: 0.1, def: -10, label: "offset y",
@@ -1001,7 +1001,7 @@ if (drift.length) {
 }
 
 /* --panel-bg and --panel-frame-fill, copied for the same reason. */
-var PANEL_BG = "#08090a";
+var PANEL_BG = "#000000";
 var FRAME_FILL = "#131518";
 
 var PANEL_MODES = { dark: 1, marble: 1, clip: 1 };

--- a/portfolio/styles.css
+++ b/portfolio/styles.css
@@ -2099,7 +2099,12 @@ body::after {
    panel is the one part of the document that is not a print. */
 .panel {
   /* ---- the palette, and it answers to nothing above ---------------------- */
-  --panel-bg:       #08090a;
+  /* PURE BLACK, AND NOT THE RENDER'S NEAR-BLACK. The design render's backdrop
+     is #08090a, which is what this was; the panel is set to #000 by choice, so
+     the composition ends at the same black the screen's own bezel does. The one
+     number measured against the old value is --panel-frame-edge below, and the
+     note there says what the two pixels of difference do to it. */
+  --panel-bg:       #000000;
   --panel-ink:      #f2f1ee;
   --panel-ink-soft: #dcdad5;
   --panel-muted:    #8b8983;
@@ -2111,6 +2116,12 @@ body::after {
      chosen: the render's outer edge peaks at 84 of 255 against a page backdrop
      of 8, so 0.32 of #f2f1ee. It was 0.1 while the Frame was a placeholder,
      which is a third of what the render has.
+     THE BACKDROP IS NOW 0 AND THIS ALPHA WAS LEFT WHERE IT WAS, deliberately.
+     Composited on #000 the rim peaks at 77 rather than the render's 84 — seven
+     of 255 on a hairline — and holding the measured 84 would mean 0.347. Not
+     done here because re-deriving the Frame's rim is a change to the Frame, and
+     this one is a change to the backdrop; if the rim ever looks thin against
+     pure black, 0.347 is the number and this is why.
      WHAT HAPPENS TO IT ALONG THE TITLEBAR DEPENDS ON THE RUNG, and .frame-bar
      depends on that in turn, so it is worth being exact. Only the shader's
      canvas is opaque, so only there is this ring covered — and covered by an


### PR DESCRIPTION
--panel-bg was #08090a, the design render's near-black. The page's own dark
theme is already #000, so the panel sat two levels above the sheet it stands
on; it is now the same black in both.

--panel-frame-edge is the one number measured against the old backdrop: 0.32
of #f2f1ee peaked at 84 of 255 over 8, and over 0 it peaks at 77. Left where
it is — seven of 255 on a hairline — with the note saying 0.347 is the number
if the rim ever reads thin.

design/glass-tuner.html carries its own copy of the panel palette so its
preview stands on the same backdrop as the page; updated with it.

check-capture-contract.py passes: 592 / 852 / 80 / 80 unmoved, both mean
luminances unchanged. The panel is a screen below the crop.
