### PR TITLE
Add a stone to the plinth by handing it a photograph

### DIFF
--- a/design/plinth/add-stone.py
+++ b/design/plinth/add-stone.py
@@ -1,0 +1,367 @@
+#!/usr/bin/env python3
+"""Put a photograph of your own on the plinth, and in the tuner's picker.
+
+    python design/plinth/add-stone.py --src <photo> --name <name> [options]
+
+Three steps, and the only one that needs Blender is the last:
+
+    1. design/plinth/maps/<name>/   the photograph taken apart into the four maps
+                                    a PBR surface wants, by build-portoro-maps.py
+    2. design/plinth/stones/<name>-<style>.json   one entry per style, which
+                                    build-slab.py merges into PHOTO_CANDIDATES
+    3. portfolio/img/tex/plinth-<name>-<style>.webp   the Cycles plates, plus a
+                                    rewritten design/plinth/slab.json, which is
+                                    what design/plinth/plinth-tuner.html reads
+
+After it, reload the tuner and the stones are in the strip with their plates
+under them. They are listed as `photograph, plate only` like every other
+photo-backed stone: the
+previz is a GLSL twin of the PROCEDURAL material and there is no honest way for
+it to draw a photograph it does not have, so what you see there is the real
+render rather than an approximation of one.
+
+WHAT MAKES A GOOD SOURCE, in the order the mistakes actually happen:
+
+  SQUARE. build-slab.py projects the maps with a BOX projection and a uniform
+  mapping scale, so one tile of the image covers a square of model space whatever
+  the image's own aspect is - a 3:2 photograph is squashed to two thirds of its
+  height on the stone. So this crops the centre square out by default, and what
+  you see in the picture is what lands on the plinth. `--keep-aspect` turns that
+  off if the stretch is what you want.
+
+  BIG. The front face is 0.07 model units of texture stretched over 177 rows of a
+  3000px plate, so it MAGNIFIES the source about twice over. Under ~2000px on the
+  cropped square the hairlines go soft; ~3000px is where more stops helping.
+
+  FLAT-LIT AND SQUARE-ON. What this pipeline knows how to remove is a constant
+  veiling (`degloss`) - not a gradient, not a vignette, and not the shape of a
+  softbox. Any of those is baked into the base colour and then lit a second time
+  by Cycles, which is how a slab ends up with a bright patch that does not move
+  when the light does. Same for perspective: a slab shot at an angle arrives with
+  a foreshortening the block then foreshortens again.
+
+  ALL STONE. No edges, no hands, no background, no watermark. The maps are made
+  seamless across U by cross-fading the left tenth into the right tenth, so those
+  two strips should look like each other.
+
+  DARK GROUND, LIGHT VEINS. The mineral split is a threshold on luma and on r-b:
+  dark is the ground, light is calcite, light and warm is the gold. Feed it a
+  white Carrara and nearly every pixel classifies as calcite, at which point the
+  `deep` grade - which crushes the ground and lifts the calcite - has almost
+  nothing to crush. This says so when it sees it, and `--grade asis` is the
+  honest setting for a light stone.
+
+WHAT IT WRITES IS FOUR STONES, NOT ONE, and they are the four gemini-* recipes
+worth having: `<name>-noir`, `<name>-noir-fine`, `<name>-screen` and
+`<name>-screen-fine`. Deep grade, every map wired, no coat, dark room - the shape
+docs/agents/plinth-marble.md says to use - crossed with the two questions a new
+photograph actually raises:
+
+    the room    `noir` is the dark room. `screen` is the same room with the
+                Frame standing in it as a real emitter, which is the brightest
+                object in the composition and had never been allowed to light
+                the stone. Which one wins is not predictable from the photograph.
+    the figure  plain lays one slab across the block, `-fine` lays two, so the
+                veining halves in size and reads finer and more jewel-like.
+                `scale` is the strongest control there is and it is not a quality
+                setting - it is how big the rock is, and a photograph with big
+                figure in it and one with small figure in it want opposite
+                answers.
+
+Four stones is four bakes in one Blender run, about a minute. `--styles noir` if
+you only want the one. Every field has a flag as well, and they override whatever
+the style said - all of them are documented in PHOTO_CANDIDATES in build-slab.py.
+
+WHAT IS COMMITTED AND WHAT IS NOT. The entry and the plate are; the maps and your
+photograph are not, the same way the gemini-* stones' are not (see .gitignore).
+So the stone survives in a fresh checkout and can be looked at there, and can
+only be RE-BAKED from a tree that still has the photograph. Keep it somewhere.
+"""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import importlib
+
+# The maps builder is `build-portoro-maps`, which is not an identifier, so it
+# cannot be reached by `import`. Nothing is wrong with the name - every build
+# script in this repository is hyphenated because they are run rather than
+# imported - and this is the one place that has to say so out loud.
+maps_mod = importlib.import_module("build-portoro-maps")
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(os.path.dirname(HERE))
+MAPS_DIR = os.path.join(HERE, "maps")
+STONES_DIR = os.path.join(HERE, "stones")
+SIDECAR = os.path.join(HERE, "slab.json")
+PLATES = os.path.join(ROOT, "portfolio", "img", "tex")
+BUILD_SLAB = os.path.join(HERE, "build-slab.py")
+
+NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+
+# ---------------------------------------------------------------------------
+# the styles
+# ---------------------------------------------------------------------------
+# Each is an existing PHOTO_CANDIDATES entry with the gemini taken out of it, so
+# a stone added here is comparable with one already in the strip rather than
+# being a fifth thing tuned differently. `screen-fine` is the one cross that
+# build-slab.py does not carry - there is no `gemini-screen-fine` - and it is
+# here because the two questions are independent: which room is better lit and
+# which figure size suits the photograph have nothing to say to each other.
+#
+# The suffix is the key, and `<name>-noir` rather than a bare `<name>` for the
+# same reason the built-ins are named that way: the room is not the default state
+# of the stone, it is a choice, and a name that does not say which room it was
+# rendered in is a name that stops meaning anything the moment a second room
+# exists.
+STYLES = {
+    "noir": {
+        "note": "one slab across the block, dark room",
+        "scale": 0.84, "offset": 0.40, "bump": (0.22, 0.00035), "sss": 0.65,
+        "coat": (0.0, 0.0), "rough": 1.0, "room": "noir",
+    },
+    "noir-fine": {
+        "note": "two slabs across - fine figure, dark room",
+        "scale": 1.75, "offset": 0.30, "bump": (0.22, 0.00022), "sss": 0.60,
+        "coat": (0.0, 0.0), "rough": 1.0, "room": "noir",
+    },
+    "screen": {
+        "note": "one slab across, dark room with the Frame lighting it",
+        "scale": 0.84, "offset": 0.40, "bump": (0.22, 0.00035), "sss": 0.65,
+        "coat": (0.0, 0.0), "rough": 1.0, "room": "screen",
+    },
+    "screen-fine": {
+        "note": "fine figure, dark room with the Frame lighting it",
+        "scale": 1.75, "offset": 0.30, "bump": (0.22, 0.00022), "sss": 0.60,
+        "coat": (0.0, 0.0), "rough": 1.0, "room": "screen",
+    },
+}
+
+# Under this, on the cropped square, the front face is interpolating rather than
+# resolving - see WHAT MAKES A GOOD SOURCE. A warning and not an error: a soft
+# stone is a look, and it is not this script's business to refuse one.
+SOFT_PX = 2000
+# ...and over this there is nothing left to resolve, so the pixels are only cost:
+# one tile of the source lands on 3000px of plate at the scale these stones use,
+# and the maps are written uncompressed. A 5300px square photograph writes 168MB
+# of PNG for a plate that cannot show any of it. Downscale only - `--size 0`
+# keeps whatever the source is, and nothing here ever upscales.
+CAP_PX = 3000
+# The mineral split this pipeline is built around is mostly ground. Far off that
+# and the grades are being asked to do something they were not fitted for.
+THIN_GROUND = 0.55
+
+
+def find_blender(explicit):
+    """The Blender to bake with: --blender, then $BLENDER, then PATH, then the
+    newest one Windows installed. Returns None rather than guessing wrong, and
+    the caller then prints the command instead of running it."""
+    for c in (explicit, os.environ.get("BLENDER"), shutil.which("blender")):
+        if c and os.path.isfile(c):
+            return os.path.normpath(c)
+    found = glob.glob("C:/Program Files/Blender Foundation/Blender */blender.exe")
+    return os.path.normpath(sorted(found)[-1]) if found else None
+
+
+def pick_val(override, styled):
+    """The override if one was given, the style's own value otherwise. `is None`
+    and not truthiness: --rough 0 and --sss 0 are meaningful settings, and 0 or
+    styled would silently discard both."""
+    return styled if override is None else override
+
+
+def taken_names():
+    """Every stone name already in use, from slab.json - which build-slab.py
+    wrote and so knows about all three families - plus anything in stones/ that a
+    bake has not caught up with yet. Read rather than imported because importing
+    build-slab.py means importing bpy, and this script deliberately runs without
+    Blender until the last step."""
+    names = set()
+    if os.path.isfile(SIDECAR):
+        doc = json.load(open(SIDECAR, encoding="utf-8"))
+        for f in ("candidates", "photo_candidates", "relit_candidates"):
+            names |= set(doc.get(f) or {})
+    names |= {os.path.basename(p)[:-5]
+              for p in glob.glob(os.path.join(STONES_DIR, "*.json"))}
+    return names
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__.splitlines()[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="The overrides default to whatever the style says. See\n"
+               "PHOTO_CANDIDATES in design/plinth/build-slab.py for what each one\n"
+               "does and which of them are worth moving.")
+    ap.add_argument("--src", required=True, help="the photograph")
+    ap.add_argument("--name", required=True,
+                    help="the stem the styles are named off: lowercase, digits "
+                         "and dashes")
+    ap.add_argument("--styles", default=",".join(STYLES),
+                    help="which of %s to write (default: all four)"
+                         % ", ".join(STYLES))
+    ap.add_argument("--title", default=None,
+                    help="the one-line description the tuner shows; the style's "
+                         "own note is appended to it")
+    ap.add_argument("--grade", default="deep", choices=sorted(maps_mod.GRADES),
+                    help="which basecolor-*.png (default: deep)")
+    ap.add_argument("--scale", type=float, default=None,
+                    help="tiles per model unit; 0.84 lays one slab across the "
+                         "plinth, 0.42 doubles the figure, 1.75 halves it")
+    ap.add_argument("--offset", type=float, default=None,
+                    help="where in the slab the block was cut from")
+    ap.add_argument("--bump", type=float, nargs=2, default=None,
+                    metavar=("STRENGTH", "DISTANCE"),
+                    help="the height map's strength and distance; the distance "
+                         "is tiny and has to be")
+    ap.add_argument("--sss", type=float, default=None,
+                    help="Subsurface Weight through the calcite mask")
+    ap.add_argument("--coat", type=float, nargs=2, default=None,
+                    metavar=("WEIGHT", "ROUGHNESS"),
+                    help="a second specular lobe; off in the dark rooms, where "
+                         "it lifts the black")
+    ap.add_argument("--rough", type=float, default=None,
+                    help="multiplies the roughness map; 0 pins it flat")
+    ap.add_argument("--crack", action="store_true",
+                    help="lay the procedural hairline network over the photo too")
+    ap.add_argument("--room", default=None,
+                    choices=("noir", "screen", "flat", "gallery"),
+                    help="override the style's surround")
+    ap.add_argument("--size", type=int, default=CAP_PX,
+                    help="cap the longest edge at this (default: %d); 0 keeps "
+                         "the source. Never upscales." % CAP_PX)
+    ap.add_argument("--keep-aspect", action="store_true",
+                    help="do not crop to a square first - see the header")
+    ap.add_argument("--replace", action="store_true",
+                    help="rebuild a stone this script added before")
+    ap.add_argument("--no-bake", action="store_true",
+                    help="stop after the maps and the entry, and print the "
+                         "Blender command instead of running it")
+    ap.add_argument("--blender", default=None, help="path to blender.exe")
+    args = ap.parse_args()
+
+    name = args.name
+    if not NAME_RE.match(name):
+        sys.exit("`%s` is not a stone name - lowercase letters, digits and "
+                 "dashes, starting with a letter or digit. It becomes a "
+                 "filename, a JSON key and a URL." % name)
+    styles = [s.strip() for s in args.styles.split(",") if s.strip()]
+    unknown = [s for s in styles if s not in STYLES]
+    if not styles or unknown:
+        sys.exit("--styles takes any of %s%s"
+                 % (", ".join(STYLES),
+                    (" - not %s" % ", ".join(unknown)) if unknown else ""))
+    keys = [name + "-" + s for s in styles]
+    taken = taken_names()
+    clash = [k for k in keys
+             if k in taken and not (args.replace
+                                    and os.path.isfile(os.path.join(STONES_DIR,
+                                                                    k + ".json")))]
+    if clash:
+        sys.exit("already a stone: %s\n\nPick another --name, or pass --replace "
+                 "to rebuild ones this script added before. Built-in stones "
+                 "cannot be replaced this way: they are the table in "
+                 "build-slab.py, and a JSON file that shadowed one would render "
+                 "as something other than what that file documents."
+                 % ", ".join(clash))
+    if not os.path.isfile(args.src):
+        sys.exit("missing %s" % args.src)
+
+    # ---- 1. the maps -------------------------------------------------------
+    # build_maps() resamples to whatever `size` it is handed, up or down; the cap
+    # is applied here, against the CROPPED edge, so that a square cut out of a
+    # long photograph is measured as what it will be rather than as what it was.
+    from PIL import Image
+    with Image.open(args.src) as probe:
+        edge = min(probe.size) if not args.keep_aspect else max(probe.size)
+    size = min(args.size, edge) if args.size else 0
+    out = os.path.join(MAPS_DIR, name)
+    print("== maps ==")
+    st = maps_mod.build_maps(args.src, out, size, not args.keep_aspect)
+
+    short = min(st["w"], st["h"])
+    if short < SOFT_PX:
+        print("\n! %dpx across, and the front face magnifies about 2x - the fine "
+              "structure\n  will be soft. Not fatal, and not fixable by "
+              "resampling: it is not in the file." % short)
+    if st["ground"] < THIN_GROUND:
+        print("\n! ground %.0f%% / calcite %.0f%% / gold %.0f%%. This pipeline "
+              "splits minerals by\n  luma, so a light stone classifies as almost "
+              "all calcite and `deep` - which\n  crushes the ground to lift the "
+              "veins - has little left to crush. Try\n  --grade asis."
+              % (st["ground"] * 100, st["calcite"] * 100, st["gold"] * 100))
+
+    # ---- 2. the entries ----------------------------------------------------
+    # One JSON file per style, all four pointing at the one maps directory: the
+    # maps are the photograph and the style is what is done with it, so building
+    # them four times would be four identical copies of 50MB.
+    #
+    # `src` is the basename only. The absolute path is this machine's and would
+    # be committed; the basename is what MISSING_ADDED_MAPS needs to be able to
+    # name the photograph in a checkout that does not have it.
+    base = args.title or os.path.splitext(os.path.basename(args.src))[0]
+    os.makedirs(STONES_DIR, exist_ok=True)
+    print("\n== entries ==")
+    for style, key in zip(styles, keys):
+        st_spec = STYLES[style]
+        spec = {
+            "title": "%s - %s" % (base, st_spec["note"]),
+            "grade": args.grade,
+            "scale": pick_val(args.scale, st_spec["scale"]),
+            "offset": pick_val(args.offset, st_spec["offset"]),
+            "bump": list(args.bump or st_spec["bump"]),
+            "sss": pick_val(args.sss, st_spec["sss"]),
+            "coat": list(args.coat or st_spec["coat"]),
+            "rough": pick_val(args.rough, st_spec["rough"]),
+            "crack": bool(args.crack),
+            "room": args.room or st_spec["room"],
+            # The maps are shared, so this is the stem and not the key.
+            "maps": name,
+            "src": os.path.basename(args.src),
+        }
+        path = os.path.join(STONES_DIR, key + ".json")
+        with open(path, "w", encoding="utf-8", newline="\n") as fh:
+            json.dump(spec, fh, indent=2)
+            fh.write("\n")
+        print("wrote %s" % os.path.relpath(path, ROOT))
+
+    # ---- 3. the plates -----------------------------------------------------
+    blender = find_blender(args.blender)
+    cmd = [blender or "blender", "-b", "-P",
+           os.path.relpath(BUILD_SLAB, ROOT), "--"] + keys
+    shown = " ".join(('"%s"' % c if " " in c else c) for c in cmd)
+    if args.no_bake or blender is None:
+        if blender is None and not args.no_bake:
+            print("\n! no blender found - pass --blender, or set $BLENDER.")
+        print("\nbake them with:\n\n    %s\n" % shown)
+        return
+    print("\n== plates ==")
+    r = subprocess.run(cmd, cwd=ROOT)
+    if r.returncode != 0:
+        sys.exit("blender exited %d - the maps and the entries are written, so "
+                 "re-run this once it is fixed:\n\n    %s" % (r.returncode, shown))
+
+    print("")
+    for key in keys:
+        plate = os.path.join(PLATES, "plinth-%s.webp" % key)
+        if os.path.isfile(plate):
+            print("%s  %.1f KB" % (os.path.relpath(plate, ROOT),
+                                   os.path.getsize(plate) / 1024.0))
+        else:
+            print("! blender reported success and there is no plate at %s" % plate)
+    print("\nreload the tuner - %s are in the strip, with their plates under them."
+          % ", ".join("`%s`" % k for k in keys))
+
+
+if __name__ == "__main__":
+    main()

--- a/design/plinth/build-portoro-maps.py
+++ b/design/plinth/build-portoro-maps.py
@@ -2,6 +2,12 @@
 """Take a photograph of Nero Portoro apart into the maps a PBR surface wants.
 
     python design/plinth/build-portoro-maps.py [--src PATH] [--size N]
+                                               [--out DIR] [--square]
+
+To put a DIFFERENT photograph on the plinth, do not run this by hand - run
+design/plinth/add-stone.py, which calls build_maps() below into a maps directory
+of its own, writes the stone's entry and bakes its plate. Running this one points
+every gemini-* stone at your photograph, because they all read `maps/`.
 
 WHY THIS EXISTS AT ALL. design/plinth/build-slab.py grows its stone out of noise
 nodes, and the note at the top of it is honest about what that buys and what it
@@ -272,27 +278,43 @@ HEIGHT_GAIN = 2.2
 CALCITE_PROUD = 0.16
 
 
-def main():
-    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
-    ap.add_argument("--src", default=DEFAULT_SRC)
-    ap.add_argument("--size", type=int, default=0,
-                    help="longest edge; 0 keeps the source resolution")
-    args = ap.parse_args()
+def build_maps(src, out_dir=OUT_DIR, size=0, square=False):
+    """One photograph -> the four maps, in `out_dir`. Returns the mineral split.
 
-    if not os.path.isfile(args.src):
+    Split out of main() so design/plinth/add-stone.py can build a stone of its
+    own without shelling out, and - the part that actually matters - without one
+    stone's maps landing on top of another's. `out_dir` is maps/ for the stone
+    this file was written for and maps/<name>/ for every stone added since.
+
+    WHY `square` EXISTS AND WHY IT IS OFF HERE. build-slab.py projects these with
+    a BOX projection and a UNIFORM mapping scale, so one tile of the image covers
+    a 1/scale by 1/scale SQUARE of model space whatever the image's own aspect
+    is. A 2:1 photograph is therefore squeezed to half its height on the block.
+    The stone this file was written for is 2814x1536 and every number in its
+    PHOTO_CANDIDATES entry was fitted with that squeeze in place, so turning it
+    on here would silently change all six gemini-* stones. A NEW photograph has
+    nothing fitted to it yet, so add-stone.py crops it square by default and what
+    you see in the picture is what lands on the plinth.
+    """
+    if not os.path.isfile(src):
         raise SystemExit(
             "missing %s\n\nThe source photograph is not in the repository - see\n"
             "the note at the top of this file. Drop it at the repo root, or pass\n"
-            "--src." % args.src)
+            "--src." % src)
 
-    im = Image.open(args.src).convert("RGB")
-    if args.size and max(im.size) != args.size:
-        s = args.size / float(max(im.size))
+    im = Image.open(src).convert("RGB")
+    if square and im.width != im.height:
+        e = min(im.size)
+        l, t = (im.width - e) // 2, (im.height - e) // 2
+        im = im.crop((l, t, l + e, t + e))
+        print("square  centre %dx%d cut from the source" % (e, e))
+    if size and max(im.size) != size:
+        s = size / float(max(im.size))
         im = im.resize((round(im.width * s), round(im.height * s)),
                        Image.LANCZOS)
     srgb = np.asarray(im, np.float32) / 255.0
     h, w = srgb.shape[:2]
-    print("source  %s  %dx%d" % (os.path.basename(args.src), w, h))
+    print("source  %s  %dx%d" % (os.path.basename(src), w, h))
 
     # ---- seamless across U, and only across U -----------------------------
     # The block is 1.19 units wide and at every scale worth using that is more
@@ -315,10 +337,10 @@ def main():
     print("split   ground %.1f%%  gold %.1f%%  calcite %.1f%%"
           % (ground.mean() * 100, gold.mean() * 100, calcite.mean() * 100))
 
-    os.makedirs(OUT_DIR, exist_ok=True)
+    os.makedirs(out_dir, exist_ok=True)
 
     def write(name, a, bits=8):
-        path = os.path.join(OUT_DIR, name)
+        path = os.path.join(out_dir, name)
         if a.ndim == 2:
             a = a[..., None]
         if bits == 16:
@@ -352,7 +374,22 @@ def main():
     # ---- and the mask that makes the stone translucent ---------------------
     write("calcite.png", calcite)
 
-    print("\nwrote %s" % os.path.relpath(OUT_DIR, ROOT))
+    print("\nwrote %s" % os.path.relpath(out_dir, ROOT))
+    return {"w": w, "h": h, "ground": float(ground.mean()),
+            "gold": float(gold.mean()), "calcite": float(calcite.mean())}
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--src", default=DEFAULT_SRC)
+    ap.add_argument("--size", type=int, default=0,
+                    help="longest edge; 0 keeps the source resolution")
+    ap.add_argument("--out", default=OUT_DIR,
+                    help="where to write the maps; defaults to design/plinth/maps")
+    ap.add_argument("--square", action="store_true",
+                    help="centre-crop to a square first - see build_maps()")
+    args = ap.parse_args()
+    build_maps(args.src, args.out, args.size, args.square)
     print("now:  blender -b -P design/plinth/build-slab.py -- gemini")
 
 

--- a/design/plinth/build-slab.py
+++ b/design/plinth/build-slab.py
@@ -2,13 +2,23 @@
 """Render the Projects Panel's marble plinth as an actual block of stone.
 
     "C:/Program Files/Blender Foundation/Blender 5.2/blender.exe" -b \
-        -P design/plinth/build-slab.py -- [<stone> | proc | photo | all]
+        -P design/plinth/build-slab.py -- [<stone> | proc | photo | added | all]...
+
+Several may be named at once, and are rendered in the order given.
 
 There are two families of stone here and they are generated in completely
 different ways. `proc` is nero/portoro/marquina/grey, grown out of noise nodes.
 `photo` is the gemini-* set, read off a photograph by
 design/plinth/build-portoro-maps.py — run that first, it needs no GPU. See `the
 stone, photographed` for why both exist and what each one cannot do.
+
+TO ADD A STONE OF YOUR OWN, do not edit the table here — run
+
+    python design/plinth/add-stone.py --src <photo> --name <name>
+
+which builds that photograph's maps into a directory of its own, writes
+design/plinth/stones/<name>.json and calls this script to bake the plate. `added`
+is the group of stones that arrived that way.
 
 WHY THIS REPLACES design/plinth/build-marble.py. That file painted a plinth: a
 photograph of a slab, warped, dropped onto a luminance ramp measured off the
@@ -742,6 +752,17 @@ the .gitignore note about /Texturelabs_*.jpg, which these follow. Run:
 DOES NOT: git only puts tracked files in one, so an ignored source sitting in
 the main checkout is simply absent here. Copy it across first."""
 
+MISSING_ADDED_MAPS = """\
+missing %s
+
+`%s` was added from a photograph by design/plinth/add-stone.py, and the maps it
+built are not in the repository - design/plinth/maps/ is gitignored, so they
+exist only in the tree they were built in and a fresh checkout or a fresh
+worktree has none of them. What ships is the plate and the entry. Rebuild them
+from the same photograph%s:
+
+    python design/plinth/add-stone.py --src <photo> --name %s --replace"""
+
 # A photo stone is a grade, a scale, a window and a surface model.
 #
 #   grade    which basecolor-*.png, so which of build-portoro-maps.py's GRADES
@@ -903,6 +924,67 @@ PHOTO_CANDIDATES = {
 }
 
 # ---------------------------------------------------------------------------
+# ...AND THE STONES ADDED FROM A PHOTOGRAPH OF YOUR OWN
+# ---------------------------------------------------------------------------
+# design/plinth/add-stone.py takes a photograph, builds a set of maps for it in
+# maps/<name>/, and writes design/plinth/stones/<name>.json. Everything above
+# reads `maps/`; a stone here reads its own directory, which is the whole of what
+# `maps` adds to the table and the reason a second photograph does not overwrite
+# the first one's maps.
+#
+# ONE FILE PER STONE rather than one table, and the reason is what a table costs
+# in a repository whose rule is one change per branch: two stones added in two
+# worktrees are two new files that merge, where two entries in one JSON object
+# are a conflict every time. It also makes deleting a stone `rm` on two paths.
+#
+# THEY ARE COMMITTED AND THEIR MAPS ARE NOT, which looks lopsided and is the same
+# split the gemini-* stones already live under — design/plinth/maps/ is gitignored
+# and so is the photograph, and what ships is the plate. So a fresh checkout can
+# LIST an added stone and show its plate, and can only RE-BAKE it from the tree
+# that has the photograph. See MISSING_ADDED_MAPS.
+STONES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "stones")
+
+_REQUIRED = ("title", "grade", "scale", "offset", "bump", "sss", "coat",
+             "rough", "crack")
+
+
+def load_added_stones():
+    """Every design/plinth/stones/*.json, merged into PHOTO_CANDIDATES.
+
+    A built-in name is never shadowed. Overwriting `gemini` from a JSON file
+    would be a stone that renders as one thing and is documented as another,
+    found only by noticing the plate had changed, so the clash is reported and
+    the file ignored.
+    """
+    import json
+    added = {}
+    for name in sorted(os.listdir(STONES_DIR) if os.path.isdir(STONES_DIR) else []):
+        if not name.endswith(".json"):
+            continue
+        key = name[:-5]
+        path = os.path.join(STONES_DIR, name)
+        if key in PHOTO_CANDIDATES or key in CANDIDATES or key in PROC_ROOMS:
+            print("! %s names a stone this file already defines - ignored"
+                  % os.path.relpath(path, ROOT))
+            continue
+        with open(path, encoding="utf-8") as fh:
+            spec = json.load(fh)
+        missing = [f for f in _REQUIRED if f not in spec]
+        if missing:
+            sys.exit("%s is missing %s\n\nRebuild it with design/plinth/add-stone.py."
+                     % (os.path.relpath(path, ROOT), ", ".join(missing)))
+        # JSON has no tuples and the material unpacks these as pairs; lists work
+        # for that, but write_sidecar() decides what to list() by isinstance, so
+        # keeping the shape identical to a built-in entry keeps the sidecar - and
+        # the tuner's copy-out, which renders Python - identical too.
+        for f in ("bump", "coat"):
+            spec[f] = tuple(spec[f])
+        spec.setdefault("maps", key)
+        added[key] = spec
+    return added
+
+
+# ---------------------------------------------------------------------------
 # ...AND THE PROCEDURAL STONES, RE-LIT
 # ---------------------------------------------------------------------------
 # If a surround fitted to a light stone is what flattened the black, then the
@@ -919,6 +1001,10 @@ PHOTO_CANDIDATES = {
 # wrong" are different diagnoses with different consequences, and only one of
 # them has been demonstrated.
 PROC_ROOMS = {k + "-noir": k for k in CANDIDATES}
+
+# Last, so that load_added_stones() can see every built-in name it must not take.
+ADDED = load_added_stones()
+PHOTO_CANDIDATES.update(ADDED)
 
 
 # ---------------------------------------------------------------------------
@@ -1315,7 +1401,7 @@ def build_material(key):
     return mat
 
 
-def photo_map(tree, co, name, colorspace, x, y):
+def photo_map(tree, co, name, colorspace, x, y, spec):
     """One of build-portoro-maps.py's maps, box-projected onto the block.
 
     BOX AND NOT FLAT, and this is the whole trick rather than a default worth
@@ -1332,8 +1418,15 @@ def photo_map(tree, co, name, colorspace, x, y):
     usual consequence of forgetting: a roughness map read as sRGB is silently
     de-gamma'd, so 0.055 arrives as 0.004 and the stone becomes a mirror.
     """
-    path = os.path.join(MAPS_DIR, name)
+    # maps/ for the stones this file was written for, maps/<name>/ for one added
+    # from a photograph of your own - see load_added_stones().
+    sub = spec.get("maps")
+    path = os.path.join(MAPS_DIR, sub, name) if sub else os.path.join(MAPS_DIR, name)
     if not os.path.isfile(path):
+        if sub:
+            src = spec.get("src")
+            sys.exit(MISSING_ADDED_MAPS
+                     % (path, sub, (" (%s)" % src) if src else "", sub))
         sys.exit(MISSING_MAPS % path)
     img = bpy.data.images.load(path, check_existing=True)
     img.colorspace_settings.name = colorspace
@@ -1383,7 +1476,7 @@ def build_photo_material(key):
     co = (m, "Vector")
 
     base = photo_map(tree, co, "basecolor-%s.png" % spec["grade"], "sRGB",
-                     -1300, 400)
+                     -1300, 400, spec)
     colour = (base, "Color")
 
     # ---- the crack overlay, only on the hybrid -----------------------------
@@ -1405,7 +1498,7 @@ def build_photo_material(key):
 
     # ---- roughness ---------------------------------------------------------
     if spec["rough"] > 0.0:
-        rmap = photo_map(tree, co, "roughness.png", "Non-Color", -1300, 100)
+        rmap = photo_map(tree, co, "roughness.png", "Non-Color", -1300, 100, spec)
         rm = tree.nodes.new("ShaderNodeMath")
         rm.location = (-900, 100)
         rm.operation = 'MULTIPLY'
@@ -1418,7 +1511,7 @@ def build_photo_material(key):
     # ---- relief ------------------------------------------------------------
     bstr, bdist = spec["bump"]
     if bstr > 0.0:
-        hmap = photo_map(tree, co, "height.png", "Non-Color", -1300, -200)
+        hmap = photo_map(tree, co, "height.png", "Non-Color", -1300, -200, spec)
         bump = tree.nodes.new("ShaderNodeBump")
         bump.location = (-700, -200)
         bump.inputs["Strength"].default_value = bstr
@@ -1435,7 +1528,7 @@ def build_photo_material(key):
 
     # ---- and the reason marble does not look like painted card -------------
     if spec["sss"] > 0.0:
-        cmap = photo_map(tree, co, "calcite.png", "Non-Color", -1300, -500)
+        cmap = photo_map(tree, co, "calcite.png", "Non-Color", -1300, -500, spec)
         sw = tree.nodes.new("ShaderNodeMath")
         sw.location = (-900, -500)
         sw.operation = 'MULTIPLY'
@@ -1821,6 +1914,16 @@ def write_sidecar():
                    for f in PHOTO_FIELDS}}
             for k, v in PHOTO_CANDIDATES.items()
         },
+        # Which of those came from design/plinth/stones/*.json rather than from
+        # the table in this file, so the tuner can name the file to edit. Getting
+        # that wrong sends you to change a value in build-slab.py that build-slab.py
+        # does not hold, and the re-bake then looks like it did nothing. `src` is
+        # the photograph's basename, which is all the tuner needs to write the
+        # add-stone.py line for a variant of it, and `stem` is the name the
+        # styles were built off - the maps are shared between them and are named
+        # for it, so it is the one part of the key that is not the style.
+        "added_stones": {k: {"src": v.get("src"), "stem": v.get("maps")}
+                         for k, v in ADDED.items()},
         # What the ?v= in portfolio/styles.css should read, so the tuner can say
         # whether the plates on disk are the ones the stylesheet is asking for.
         "version": digest() if os.path.isdir(OUT_DIR) else None,
@@ -1833,20 +1936,34 @@ def write_sidecar():
 
 
 def main():
-    which = (ARGV[0] if ARGV else "all").lower()
+    # Several arguments, each a stone or a group, because the scene is built once
+    # and a stone is fifteen seconds - so four stones in one invocation is four
+    # renders, and four invocations is four renders plus four Blender starts.
+    # design/plinth/add-stone.py writes a set of stones from one photograph and
+    # asks for all of them at once.
+    which = [a.lower() for a in ARGV] or ["all"]
     # `all` is both families, `proc` and `photo` are one each — because during a
     # bake-off you re-render one family at a time and the other four plates are
     # forty seconds you do not need to spend.
     groups = {"all": list(CANDIDATES) + list(PHOTO_CANDIDATES) + list(PROC_ROOMS),
               "proc": list(CANDIDATES),
               "photo": list(PHOTO_CANDIDATES),
-              "relit": list(PROC_ROOMS)}
-    if which in groups:
-        keys = groups[which]
-    elif which in CANDIDATES or which in PHOTO_CANDIDATES or which in PROC_ROOMS:
-        keys = [which]
-    else:
-        sys.exit(__doc__)
+              "relit": list(PROC_ROOMS),
+              # ...and the ones added from a photograph of your own, which is the
+              # group you want after re-running add-stone.py on a tree that had
+              # to rebuild their maps.
+              "added": list(ADDED)}
+    keys = []
+    for a in which:
+        if a in groups:
+            keys += groups[a]
+        elif a in CANDIDATES or a in PHOTO_CANDIDATES or a in PROC_ROOMS:
+            keys.append(a)
+        else:
+            sys.exit(__doc__)
+    # Order preserved, duplicates dropped: `photo gemini` is a plausible thing to
+    # type and rendering gemini twice is fifteen seconds of rendering it twice.
+    keys = list(dict.fromkeys(keys))
     os.makedirs(OUT_DIR, exist_ok=True)
     print("plate %dx%d   camera d=%.5f h=%.5f   block %.5f x %.2f x %.5f"
           % (PLATE_W, PLATE_H, CAM_D, CAM_H, PLINTH_W, DEPTH, HEIGHT))

--- a/design/plinth/plinth-tuner.html
+++ b/design/plinth/plinth-tuner.html
@@ -420,7 +420,13 @@
       b.appendChild(ti);
       if (s.baked) {
         var img = document.createElement("img");
-        img.src = plateURL(k, "../../");
+        /* `../../portfolio/` and not `../../`: this page is at /design/plinth/,
+           so two levels up is the repository root and the plates are a further
+           directory in. It read `../../` and every thumbnail in the strip 404'd
+           — silently, because a broken <img> in a dark row looks like a stone
+           that has not been baked yet, which is a thing the strip is expected to
+           contain. */
+        img.src = plateURL(k, "../../portfolio/");
         img.alt = "";
         img.loading = "lazy";
         b.appendChild(img);
@@ -455,6 +461,12 @@
     return '"' + v + '"';
   }
 
+  /* Stones that arrived through design/plinth/add-stone.py rather than out of
+     the table in build-slab.py. Their values live in design/plinth/stones/, and
+     everything this page says about where to go and change them has to say so —
+     see photoControls() and writeExport(). */
+  function addedStone(k) { return (slab.added_stones || {})[k] || null; }
+
   var PHOTO_ROWS = [
     ["grade", "which basecolor-*.png, so which of build-portoro-maps.py's GRADES"],
     ["scale", "tiles per model unit, and a unit is a Frame width. 0.84 lays one slab across the plinth; 0.42 crops in and the figure doubles; 1.75 goes fine and jewel-like. The strongest control here, and not a quality setting."],
@@ -475,7 +487,14 @@
           + "so drawing it live would show this stone in the light it was made to get away from. "
         : "cut from a photograph, not grown from noise. There is no previz for it. ")
       + "The picture above is the real Cycles plate. "
-      + "These are read-only — change them in PHOTO_CANDIDATES in build-slab.py and re-bake:"
+      /* An added stone's values are NOT in build-slab.py — it merges them from
+         design/plinth/stones/<name>.json, which design/plinth/add-stone.py
+         wrote. Sending you to the table in build-slab.py to change a number it
+         does not hold costs a re-bake that appears to do nothing. */
+      + (addedStone(pick)
+          ? "These are read-only — change them in design/plinth/stones/" + pick
+            + ".json and re-bake:"
+          : "These are read-only — change them in PHOTO_CANDIDATES in build-slab.py and re-bake:")
       + "\n\n    blender -b -P design/plinth/build-slab.py -- " + pick;
     n.style.whiteSpace = "pre-wrap";
     controlsEl.appendChild(n);
@@ -510,7 +529,7 @@
   }
 
   /* Where a stone's baked plate lives, from two different places.
-     The strip is at /design/plinth/ and needs `../../`; the frame is a document
+     The strip is at /design/plinth/ and needs `../../portfolio/`; the frame is a document
      at /portfolio/ whose own stylesheet writes `img/tex/...` relative to itself,
      so it needs an absolute path instead. One function so the two can never
      drift onto different files — and the same ?v= the stylesheet asks for, so
@@ -1239,6 +1258,34 @@
     var name = pick;
     var ind = "        ";
     var lines = [];
+    var add = live.photo ? addedStone(name) : null;
+    if (add) {
+      /* An added stone exports as the COMMAND that would make another one,
+         because that is the only form of it that works. Pasting its entry into
+         PHOTO_CANDIDATES under a new name would give a stone pointing at
+         design/plinth/maps/, which is the gemini photograph's maps and not this
+         one's — a copy that bakes cleanly and comes out as a different rock. */
+      lines.push("# design/plinth/stones/" + name + ".json, added by add-stone.py.");
+      lines.push("# Nothing on this stone is tunable from here. For a variant, run");
+      lines.push("# this against the same photograph and change what you want:");
+      /* --name takes the STEM, not the key: add-stone.py appends the style to
+         it, so passing the key back in would ask for `<name>-screen-fine-noir`
+         and three others nobody wanted. */
+      var stem = add.stem || name;
+      var style = name.indexOf(stem + "-") === 0 ? name.slice(stem.length + 1) : null;
+      lines.push("python design/plinth/add-stone.py \\");
+      lines.push("    --src " + (add.src || "<photo>") + " --name " + stem + "-2"
+                 + (style ? " --styles " + style : "") + " \\");
+      lines.push("    --grade " + live.photo.grade + " --scale " + live.photo.scale
+                 + " --offset " + live.photo.offset + " \\");
+      lines.push("    --bump " + live.photo.bump.join(" ")
+                 + " --sss " + live.photo.sss + " --coat " + live.photo.coat.join(" ") + " \\");
+      lines.push("    --rough " + live.photo.rough + " --room " + (live.photo.room || "flat")
+                 + (live.photo.crack ? " --crack" : ""));
+      outPy.value = lines.join("\n") + "\n";
+      writeCss(name);
+      return;
+    }
     if (live.photo) {
       /* The PHOTO_CANDIDATES entry as it stands, not as edited — nothing here
          is editable. It is exported anyway because the useful thing to copy off

--- a/docs/agents/plinth-marble.md
+++ b/docs/agents/plinth-marble.md
@@ -141,6 +141,37 @@ Then:
 
 `proc` | `photo` | `relit` | `all` | a single stone name. ~5 s each.
 
+### Putting a different photograph on the plinth
+
+`design/plinth/add-stone.py`, and **not** by running `build-portoro-maps.py` by
+hand — that writes `maps/`, which every `gemini-*` stone reads, so it silently
+repoints all fourteen of them at your photograph.
+
+```bash
+python design/plinth/add-stone.py --src <photo> --name <name>
+```
+
+Builds `maps/<name>/`, writes four entries into `design/plinth/stones/`, and
+bakes their plates in one Blender run — `<name>-noir`, `<name>-noir-fine`,
+`<name>-screen`, `<name>-screen-fine`, which are the `gemini-*` recipes worth
+having crossed with the two questions a new photograph raises: which room lights
+it better, and whether its figure wants to be laid one slab across the block or
+two. Reload the tuner and they are in the strip. `--styles noir` for just the one;
+every field in the table has a flag as well.
+
+**The entries are committed and their maps are not**, which is the split the
+`gemini-*` stones already live under. So a fresh checkout lists an added stone and
+shows its plate, and can only re-bake it from a tree that still has the
+photograph. `build-slab.py` says so by name when the maps are missing.
+
+**What the source has to be** is in the script's header at length; the two that
+are not guessable are that it is cropped **square** by default, because a BOX
+projection with a uniform mapping scale lays one tile over a square of model
+space whatever the image's aspect is (the Gemini source is 1.83:1 and is squashed
+to half its height on the block — every number fitted to it assumes that), and
+that the mineral split is a luma threshold, so a **light** stone classifies as
+almost all calcite and wants `--grade asis` rather than `deep`.
+
 ### Three things in the maps worth not undoing
 
 - **Grade each mineral separately, then recombine through the masks.** A curve


### PR DESCRIPTION
design/plinth/add-stone.py takes a photograph and puts four stones in the
tuner's picker: it builds that photograph's maps into a directory of its
own, writes an entry per style into design/plinth/stones/, and bakes all
four plates in one Blender run.

The styles are the gemini-* recipes rather than new ones - noir,
noir-fine, screen and screen-fine - so an added stone is comparable with
what is already in the strip. screen-fine is the one cross build-slab.py
does not carry, and it is here because which room lights a photograph
better and which figure size suits it are independent questions.

Three things this needed underneath:

  - a maps directory per stone. Every photo stone read design/plinth/maps/,
    so a second photograph could only be added by overwriting the first
    one's maps and repointing all fourteen gemini-* stones at it.
  - stones as one JSON file each, merged into PHOTO_CANDIDATES. One table
    would be a merge conflict every time two stones are added in two
    worktrees; one file each is two paths to delete and nothing to merge.
    The entries are committed and their maps are not, which is the split
    the gemini-* stones already live under.
  - build-slab.py taking several stones per invocation, so four plates
    cost four renders rather than four renders and four Blender starts.

And one bug found on the way: the contact strip asked for its plates at
../../img/tex/, which is the repository root and not portfolio/, so every
thumbnail in it 404'd. Silently - a broken img in a dark row looks like a
stone that has not been baked yet, which the strip is expected to contain.

The tuner also now sends you to design/plinth/stones/<name>.json rather
than to a table in build-slab.py that does not hold an added stone's
values, and exports it as the add-stone.py line that would make a variant
of it, because pasting its entry into PHOTO_CANDIDATES under a new name
would give a stone pointing at the gemini photograph's maps.
