### PR TITLE
Cut the plinth from gemini-noir, and unstick the digest that went with it

### DIFF
--- a/docs/agents/plinth-marble.md
+++ b/docs/agents/plinth-marble.md
@@ -365,9 +365,15 @@ colour. It stays a gate for any change that points the stylesheet at a new stone
 
 ## Still open
 
-- **Nothing ships yet.** `--panel-plinth-src` in `portfolio/styles.css` still
-  points at `plinth-nero.webp`, deliberately — the stone is the user's pick, and
-  switching it needs the `?v=` digest re-pasted and the capture contract re-run.
+- ~~**Nothing ships yet.**~~ **`gemini-noir` ships.** `--panel-plinth-src` in
+  `portfolio/styles.css` points at `plinth-gemini-noir.webp?v=912aa827` — the
+  user's pick, made in the tuner. The `?v=` had drifted while nothing shipped:
+  the stylesheet still carried `de287c12` from #106 while two further bakes (#108
+  and #114) had moved `slab.json`'s `version` to `912aa827`, so every plate URL
+  on the deployment was a day-stale name for a file that had changed twice. All
+  five are now stamped with the digest `slab.json` actually holds. The capture
+  contract passes at the new stone; `nero` is kept as a `data-marble` candidate
+  because every proportion in the `.panel` block was measured against it.
 - **`plinth-tuner.html` is stale and now more so.** It reimplements the
   procedural material in GLSL and cannot preview a photo-backed stone at all.
   `slab.json` carries `photo_candidates` so the tuner can list them and say it

--- a/portfolio/img/tex/README.md
+++ b/portfolio/img/tex/README.md
@@ -8,10 +8,12 @@ lives and why it has the value it has.
 | --- | --- | --- | --- |
 | `film-1600.webp`, `film-2600.webp` | Texturelabs Film 185XL | [`build-textures.py`](../../../design/effects/build-textures.py) | one frame over the whole band, `cover`, never tiled |
 | `paper-512.webp`, `paper-1024.webp` | Texturelabs Paper 349XL | [`build-textures.py`](../../../design/effects/build-textures.py) | a square that wraps in both axes, tiled edge to edge |
-| `plinth-nero.webp` | rendered — no source | [`build-slab.py`](../../../design/plinth/build-slab.py) | the Projects Panel's plinth, with its silhouette in the alpha |
+| `plinth-gemini-noir.webp` | a photograph, cut by [`add-stone.py`](../../../design/plinth/add-stone.py) | [`build-slab.py`](../../../design/plinth/build-slab.py) | the Projects Panel's plinth, with its silhouette in the alpha |
+| `plinth-nero.webp` | rendered — no source | [`build-slab.py`](../../../design/plinth/build-slab.py) | ...the stone drawn before it, kept as a candidate |
 | `plinth-portoro.webp` | rendered — no source | [`build-slab.py`](../../../design/plinth/build-slab.py) | ...one candidate for the same plinth |
 | `plinth-marquina.webp` | rendered — no source | [`build-slab.py`](../../../design/plinth/build-slab.py) | ...and another |
 | `plinth-grey.webp` | rendered — no source | [`build-slab.py`](../../../design/plinth/build-slab.py) | ...and the third |
+| `plinth-gemini*.webp`, `plinth-*-noir.webp` | as above | [`build-slab.py`](../../../design/plinth/build-slab.py) | the rest of the bake — reachable from the tuner, not named in the stylesheet |
 
 ## The two effect plates
 
@@ -53,9 +55,11 @@ a seam is rougher than the ground it sits in and catches the light differently.
 3000 px wide is one rung and not the first of a ladder: the slab is ~1800 CSS px
 on a 2560 display, so this is 1:1 at a 2× device ratio and 2:1 at 1×.
 
-**Which one is drawn** is `data-marble` on the `.panel` section — `nero` is the
-default and the other three are named in the stylesheet beside it. #69's tuner is
-the place they get chosen between by eye; only one is ever fetched.
+**Which one is drawn** is `data-marble` on the `.panel` section — `gemini-noir` is
+the default and four others are named in the stylesheet beside it. #69's tuner is
+the place they get chosen between by eye, and it reaches the rest of the bake by
+writing `--panel-plinth-src` straight at a plate rather than through a rule here;
+only one is ever fetched.
 
 ## Rebuilding
 

--- a/portfolio/styles.css
+++ b/portfolio/styles.css
@@ -2466,14 +2466,21 @@ body::after {
   --panel-plinth-depth: calc((var(--panel-plinth-top) + var(--panel-plinth-front))
                              * var(--panel-frame-w));
 
-  /* WHICH STONE. Four renders, one drawn, and the switch is here rather than in
+  /* WHICH STONE. Many renders, one drawn, and the switch is here rather than in
      a script so #69's tuner is a `dataset.marble =` and nothing else. The
      candidates are below the .panel-plinth block; the ?v= is the digest
      design/plinth/build-slab.py prints, and it is load-bearing for the same
      reason the textures' is — vercel.json caches /portfolio/img/ for a day, so a
      re-rendered plate under an unchanged URL is served stale for up to 24 hours
-     while being right on localhost. */
-  --panel-plinth-src: url("img/tex/plinth-nero.webp?v=de287c12");
+     while being right on localhost.
+
+     `gemini-noir` is the stone: cut from a photograph by design/plinth/add-stone.py
+     and lit in the dark room, which is the pair docs/agents/plinth-marble.md
+     measures as the one that keeps the black black. It replaces `nero`, the
+     procedural stone the earlier fitted room lit as flat grey smoke — kept below
+     as a candidate rather than dropped, because it is what every proportion in
+     this block was measured against. */
+  --panel-plinth-src: url("img/tex/plinth-gemini-noir.webp?v=912aa827");
 
   position: relative;
   display: grid;
@@ -2778,15 +2785,22 @@ body::after {
   background-size: 100% 100%;
   background-repeat: no-repeat;
 }
-/* The candidates. All four are the same block under the same camera and the same
-   two lights, and differ only in the material — which stone, not which
-   photograph; the CANDIDATES table in design/plinth/build-slab.py is what each
-   one is. Switched by an attribute on the section so #69's tuner needs no
+/* The candidates. All of them are the same block under the same camera, and they
+   differ in the material and in the ROOM — which stone, and what is lighting it;
+   the CANDIDATES table in design/plinth/build-slab.py is what each one is, and
+   docs/agents/plinth-marble.md is why the dark-room ones are the ones to compare
+   against. Switched by an attribute on the section so #69's tuner needs no
    stylesheet of its own, and so that a plate not in the repository yet fails as a
-   missing image rather than as a missing rule. */
-.panel[data-marble="portoro"]  { --panel-plinth-src: url("img/tex/plinth-portoro.webp?v=de287c12"); }
-.panel[data-marble="marquina"] { --panel-plinth-src: url("img/tex/plinth-marquina.webp?v=de287c12"); }
-.panel[data-marble="grey"]     { --panel-plinth-src: url("img/tex/plinth-grey.webp?v=de287c12"); }
+   missing image rather than as a missing rule.
+
+   These are the four the tuner shipped with plus the stone that was drawn before
+   `gemini-noir`; the tuner lists every plate in design/plinth/slab.json, which is
+   many more than this, and reaches them by pointing the property straight at the
+   plate rather than through a rule here. */
+.panel[data-marble="nero"]     { --panel-plinth-src: url("img/tex/plinth-nero.webp?v=912aa827"); }
+.panel[data-marble="portoro"]  { --panel-plinth-src: url("img/tex/plinth-portoro.webp?v=912aa827"); }
+.panel[data-marble="marquina"] { --panel-plinth-src: url("img/tex/plinth-marquina.webp?v=912aa827"); }
+.panel[data-marble="grey"]     { --panel-plinth-src: url("img/tex/plinth-grey.webp?v=912aa827"); }
 
 /* ---- the reflection ---------------------------------------------------------
    THE FRAME AGAIN, UPSIDE DOWN AND LYING IN THE STONE. Not a picture of it: the


### PR DESCRIPTION
The tuner's pick. `--panel-plinth-src` has pointed at `plinth-nero.webp` since
#103 and docs/agents/plinth-marble.md has carried "Nothing ships yet" beside it
for as long -- deliberately, because which stone stands under the Frame is the
user's call and not a thing to be inferred from a measurement. It has been made:
gemini-noir, the photographed stone lit in the dark room, which is the pair the
marble doc measures as the only one that keeps the black black. `nero` was the
procedural stone under the fitted room, whose ground sat pinned at a flat 24
whatever the texture said, and no grade turns that down because it is light added
on top rather than albedo.

The `?v=` had drifted the whole time, and shipping is what makes it matter. The
stylesheet still carried `de287c12`, pasted in #106; slab.json's `version` is
`912aa827`, moved by the two bakes since (#108, #114). Both plates changed under
both unchanged names. vercel.json caches /portfolio/img/ for a day, so the
deployment has been serving a stale plate under a name that says it is current
while localhost was right -- exactly the failure the comment above the property
describes, sitting on the property it describes. All five URLs are now stamped
with the digest slab.json actually holds.

`nero` is kept, as a `data-marble` candidate beside the other three rather than
dropped, because every proportion in the .panel block -- behind, top, front, and
the fit constant that counts them -- was measured against its render. It is the
reference for the box, not a preference.

design/tools/check-capture-contract.py passes: 592, 852, four 80s, and 188.4 /
46.1 unchanged to the tenth. Unchanged because the profile README's crop stops
above the Panel and never sees the plinth, so the contract is a guard on this
change rather than a measurement of it -- what was verified directly is that the
property resolves to plinth-gemini-noir.webp?v=912aa827 and that the plate loads
at its 3000x269, served out of this worktree rather than out of development.
