### PR TITLE
Make a plinth out of any photograph without leaving the browser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,14 @@ portfolio/img/tex/paper-seam-proof.png
 /Gemini_Generated_Image_*.jpg
 design/plinth/maps/
 
+# ...and where design/plinth/plinth-studio.py keeps the photographs dropped on
+# it. Same rule again, and worth saying out loud because this is the one that
+# arrives by drag-and-drop rather than by being put somewhere deliberately: a
+# stone's ENTRY and PLATE are committed and the image it was cut from is not, so
+# a stone can be looked at in a fresh checkout and can only be RE-BAKED in a tree
+# that still has this directory. Keep anything you care about elsewhere too.
+design/plinth/sources/
+
 # per-candidate plinth shots from ender.mjs --stones. 1.4MB each and
 # regenerable in a minute; what is committed is the contact sheet built from
 # them, design/shots/plinth-stones.jpg.

--- a/design/README.md
+++ b/design/README.md
@@ -68,6 +68,12 @@ design/
                          every value on a slider, for asking what a change would
                          do without paying a minute of Cycles for the answer;
                          it exports a CANDIDATES entry to paste back.
+    plinth-studio.py     interactive, and the only tool in design/ that is a
+    plinth-studio.html   SERVER rather than a page: photograph in, stone on the
+                         site out, with no command in between. Drop an image,
+                         move every parameter a stone has, bake it in Cycles,
+                         see it under the real Frame, write it into styles.css.
+                           python design/plinth/plinth-studio.py
   tools/
     render.mjs       Playwright: serves the repo, walks the matrix, writes shots/
     package.json     dev dependency (playwright) — not the site's
@@ -615,6 +621,57 @@ that comes out on line 3.02 is telling you it wants to be on the line.
 It also carries a `state:` comment at the foot of the export, so pasting an
 earlier one back into the box and pressing `import` restores the whole
 arrangement — the same device the type tuner's `tuner-state` is.
+
+## Plinth studio
+
+The odd one out in a different direction from the layout tuner: every other tool
+here is a page served by a static server, and this one **is** the server, because
+what it does cannot be done from a page. Making a plinth means resampling a
+photograph into four PBR maps and then path-tracing them in Blender, and a
+browser can do neither.
+
+```bash
+python design/plinth/plinth-studio.py
+```
+
+It prints a URL and opens it. Do not serve it with `run.bat` — the page is inert
+without its own server behind it, and it needs no other one: it serves the
+repository as well, so `/portfolio` in its iframe and the plates in its strip
+come off the same origin.
+
+**What it is for** is that the four steps between a photograph and a stone on the
+site were four commands in a fixed order — `build-portoro-maps.py`,
+`build-slab.py` in Blender, `add-stone.py` over the top of both, and then
+`portfolio/styles.css` edited by hand with a digest in it that goes stale
+silently. Now: drop an image, move the sliders, bake, apply.
+
+Three things it knows that those commands do not:
+
+- **Maps are per-image, not per-stone.** They are cached under a digest of the
+  image bytes and the two flags that change what they contain, so a second bake
+  at a different `scale` is fifteen seconds of Cycles rather than another fifty
+  megabytes of PNG. Content-addressed and not name-addressed on purpose — a
+  directory keyed by a name is a directory the next `photo.jpg` overwrites.
+- **The `?v=` is a digest of every plate**, so it moves when any stone is baked,
+  including one only being tried. Apply restamps every plinth `url()` in the
+  stylesheet, and the page shows a warning whenever they have drifted apart —
+  which is exactly the drift that survived two bakes unnoticed before it shipped.
+- **It refuses to shadow a built-in.** A stone it writes is
+  `design/plinth/stones/<key>.json`, the same door `add-stone.py` uses, and a
+  name the tables in `build-slab.py` already define is rejected rather than
+  merged.
+
+**The one thing it draws rather than renders** is the window: the block's
+footprint laid over your photograph, from the same arithmetic
+`build_photo_material()` projects with, so `scale` and `offset` — the two
+strongest controls — are answered before a bake is paid for. Everything else that
+claims to show a stone is a real Cycles render. There is no GLSL previz of a
+photographic material and there is not going to be one; the plinth tuner has one
+for the *procedural* stones and says out loud that it cannot draw these.
+
+What is committed and what is not follows `add-stone.py` exactly: the entry and
+the plate ship, the maps and your photograph do not. `design/plinth/sources/` is
+gitignored, so keep anything you care about somewhere else as well.
 
 ## Regenerating the shots
 

--- a/design/plinth/build-slab.py
+++ b/design/plinth/build-slab.py
@@ -4,7 +4,9 @@
     "C:/Program Files/Blender Foundation/Blender 5.2/blender.exe" -b \
         -P design/plinth/build-slab.py -- [<stone> | proc | photo | added | all]...
 
-Several may be named at once, and are rendered in the order given.
+Several may be named at once, and are rendered in the order given. `none`
+renders nothing and rewrites design/plinth/slab.json alone, which is what a
+deleted stone needs — see the group table in main().
 
 There are two families of stone here and they are generated in completely
 different ways. `proc` is nero/portoro/marquina/grey, grown out of noise nodes.
@@ -2006,7 +2008,15 @@ def main():
               # ...and the ones added from a photograph of your own, which is the
               # group you want after re-running add-stone.py on a tree that had
               # to rebuild their maps.
-              "added": list(ADDED)}
+              "added": list(ADDED),
+              # NOTHING, which is not a no-op: main() writes slab.json whatever
+              # it rendered, so this is "rewrite the sidecar" on its own. What
+              # needs it is a stone being DELETED — the tables are read at import
+              # and the picker in design/plinth/plinth-studio.html reads the
+              # sidecar, so until this runs it goes on listing an entry whose
+              # file is gone. Three seconds of starting Blender against a minute
+              # of re-rendering something to make it notice.
+              "none": []}
     keys = []
     for a in which:
         if a in groups:

--- a/design/plinth/plinth-studio.html
+++ b/design/plinth/plinth-studio.html
@@ -1,0 +1,957 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Plinth studio — photograph in, stone on the site out</title>
+  <!--
+    THE PAGE HALF OF design/plinth/plinth-studio.py. It does nothing on its own:
+    every button here is an endpoint on that server, which is also what serves
+    this file, /portfolio/ in the iframe below and the plates in the strip. Open
+    it off the filesystem and every fetch fails.
+
+    WHAT IS DRAWN BEFORE A BAKE, and what is not. The window guide is the
+    block's footprint laid on the photograph, from the same numbers
+    build_photo_material() projects with — that is `scale` and `offset`
+    answered exactly, without Cycles. Everything else on this page that claims
+    to show a stone is a real render. There is deliberately no GLSL previz of a
+    photographic material: plinth-tuner.html has one for the PROCEDURAL stones
+    and says out loud that it cannot draw these, and a plausible-looking
+    approximation of a path-traced mirror is worse than no approximation.
+  -->
+  <style>
+    :root { color-scheme: light dark; --ui: #1a1917; --ui-bg: #fcfbf8; --ui-panel: #f5f2ea; --ui-line: #d6d0c4; --ui-mut: #6f6a5d; --ui-hit: #8a5a2b; --ui-bad: #a8322a; --ui-ok: #2f6b3d; }
+    @media (prefers-color-scheme: dark) {
+      :root { --ui: #eaeaea; --ui-bg: #161616; --ui-panel: #1e1e1e; --ui-line: #3a3a3a; --ui-mut: #9a9a9a; --ui-hit: #d8a76a; --ui-bad: #e0796e; --ui-ok: #7fc08e; }
+    }
+    * { box-sizing: border-box; }
+    html, body { height: 100%; }
+    body { margin: 0; display: flex; flex-direction: column; background: var(--ui-bg); color: var(--ui);
+           font: 13px/1.45 "Segoe UI", system-ui, sans-serif; }
+
+    .top { flex: 0 0 auto; display: flex; flex-wrap: wrap; align-items: center; gap: 0.4rem;
+           padding: 0.5rem 0.8rem; border-bottom: 1px solid var(--ui-line); }
+    .top strong { font-size: 11px; letter-spacing: 0.09em; text-transform: uppercase; color: var(--ui-mut); }
+    .grow { flex: 1 1 auto; }
+
+    button, select, input[type="text"], input[type="number"], textarea {
+      font: inherit; color: var(--ui); background: transparent; border: 1px solid var(--ui-line); border-radius: 5px; }
+    select, input[type="text"], input[type="number"], textarea { background: var(--ui-bg); color-scheme: light dark; }
+    input[type="number"] { width: 5.6rem; padding: 0.18rem 0.3rem; }
+    input[type="text"] { padding: 0.18rem 0.35rem; }
+    button { padding: 0.24rem 0.6rem; cursor: pointer; }
+    button:hover:not(:disabled) { border-color: var(--ui-mut); }
+    button:disabled { opacity: 0.45; cursor: default; }
+    button.go { background: var(--ui); color: var(--ui-bg); border-color: var(--ui); font-weight: 600; }
+    button.go:disabled { background: transparent; color: var(--ui); }
+    .chip { padding: 0.12rem 0.45rem; border-radius: 99px; border: 1px solid var(--ui-line); font-size: 11.5px; color: var(--ui-mut); }
+    .chip b { color: var(--ui); font-weight: 600; }
+    .chip.bad { border-color: var(--ui-bad); color: var(--ui-bad); }
+    .chip.ok { border-color: var(--ui-ok); color: var(--ui-ok); }
+
+    .wrap { flex: 1 1 auto; display: flex; min-height: 0; }
+    .side { flex: 0 0 25rem; display: flex; flex-direction: column; min-height: 0;
+            border-right: 1px solid var(--ui-line); background: var(--ui-panel); overflow: auto; }
+    .stage { flex: 1 1 auto; min-width: 0; display: flex; flex-direction: column; overflow: auto; padding: 0.7rem; gap: 0.7rem; }
+
+    section.box { border-bottom: 1px solid var(--ui-line); padding: 0.6rem 0.75rem 0.75rem; }
+    section.box > h2 { margin: 0 0 0.5rem; font-size: 11px; letter-spacing: 0.09em; text-transform: uppercase; color: var(--ui-mut); }
+    .row { display: flex; align-items: center; gap: 0.4rem; margin-bottom: 0.35rem; flex-wrap: wrap; }
+    .row > label { flex: 0 0 7.4rem; color: var(--ui-mut); }
+    .row > input[type="range"] { flex: 1 1 6rem; min-width: 4rem; accent-color: var(--ui-hit); }
+    .row > input[type="text"] { flex: 1 1 8rem; }
+    .row > select { flex: 1 1 8rem; padding: 0.18rem 0.3rem; }
+    .hint { margin: -0.1rem 0 0.5rem 7.8rem; font-size: 11px; color: var(--ui-mut); }
+    .note { margin: 0.4rem 0 0; font-size: 11.5px; color: var(--ui-mut); }
+    .note.bad { color: var(--ui-bad); }
+    .note.ok { color: var(--ui-ok); }
+
+    .drop { border: 1px dashed var(--ui-line); border-radius: 6px; padding: 0.9rem; text-align: center;
+            color: var(--ui-mut); cursor: pointer; }
+    .drop.over { border-color: var(--ui-hit); color: var(--ui-hit); }
+
+    .presets { display: flex; flex-wrap: wrap; gap: 0.3rem; }
+    .presets button { font-size: 11.5px; }
+
+    canvas { display: block; max-width: 100%; border: 1px solid var(--ui-line); border-radius: 4px;
+             background: repeating-conic-gradient(#8883 0% 25%, transparent 0% 50%) 50% / 16px 16px; }
+    iframe { border: 1px solid var(--ui-line); background: #fff; width: 100%; flex: 0 0 auto; }
+
+    .strip { display: flex; flex-direction: column; gap: 0.35rem; max-height: 34rem; overflow: auto;
+             border: 1px solid var(--ui-line); border-radius: 4px; padding: 0.4rem; }
+    .stone { display: flex; flex-direction: column; gap: 0.2rem; }
+    .stone .bar { display: flex; align-items: center; gap: 0.4rem; font-size: 11.5px; }
+    .stone .bar .k { font: 12px/1 ui-monospace, Consolas, monospace; }
+    .stone .bar .t { color: var(--ui-mut); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .stone img { display: block; width: 100%; border-radius: 3px;
+                 background: repeating-conic-gradient(#8883 0% 25%, transparent 0% 50%) 50% / 12px 12px; }
+    .stone[data-live="true"] .k { color: var(--ui-hit); font-weight: 700; }
+
+    pre.log { margin: 0; padding: 0.5rem 0.6rem; border: 1px solid var(--ui-line); border-radius: 4px;
+              background: var(--ui-panel); font: 11.5px/1.5 ui-monospace, Consolas, monospace;
+              max-height: 18rem; overflow: auto; white-space: pre-wrap; word-break: break-word; }
+    pre.log:empty { display: none; }
+
+    .stagehead { display: flex; align-items: baseline; gap: 0.5rem; font-size: 11px; letter-spacing: 0.09em;
+                 text-transform: uppercase; color: var(--ui-mut); }
+    .stagehead span { text-transform: none; letter-spacing: 0; font-size: 11.5px; }
+    .cols { display: flex; gap: 0.7rem; align-items: flex-start; flex-wrap: wrap; }
+    .cols > div { flex: 1 1 20rem; min-width: 16rem; }
+    table.maps { border-collapse: collapse; font-size: 11.5px; width: 100%; }
+    table.maps td { padding: 0.12rem 0.3rem 0.12rem 0; color: var(--ui-mut); }
+    table.maps td.k { font: 11px/1.4 ui-monospace, Consolas, monospace; color: var(--ui); }
+  </style>
+</head>
+<body>
+
+<div class="top">
+  <strong>Plinth studio</strong>
+  <span class="chip" id="chipSite">site: —</span>
+  <span class="chip" id="chipVer">?v= —</span>
+  <span class="chip" id="chipBlender">blender: —</span>
+  <span class="grow"></span>
+  <span class="chip" id="chipBusy" hidden></span>
+  <button id="btnContract" title="Replay the GitHub profile README's hourly screenshot of /portfolio against this tree">capture contract</button>
+  <button id="btnReload">reload state</button>
+</div>
+
+<div class="wrap">
+  <aside class="side">
+
+    <section class="box">
+      <h2>1 &middot; the photograph</h2>
+      <div class="drop" id="drop">drop an image here, or click to choose<br>
+        <span style="font-size:11px">jpg &middot; png &middot; webp &middot; tif &middot; bmp</span></div>
+      <input type="file" id="file" accept="image/*" hidden>
+      <div class="row" style="margin-top:0.5rem">
+        <label for="src">source</label>
+        <select id="src"></select>
+      </div>
+      <div class="row">
+        <label for="size">size cap</label>
+        <input type="number" id="size" min="0" max="8000" step="100">
+        <label style="flex:0 0 auto"><input type="checkbox" id="square"> square crop</label>
+      </div>
+      <p class="hint" style="margin-left:0">Longest edge the maps are built at; 0 keeps the source, and
+        nothing is ever upscaled. Both of these change what the maps <em>are</em>, so moving either
+        costs one map build (a minute) on the next bake. Every other control below is Cycles only.</p>
+      <p class="note" id="srcNote"></p>
+    </section>
+
+    <section class="box">
+      <h2>2 &middot; the stone</h2>
+      <div class="row">
+        <label for="key">name</label>
+        <input type="text" id="key" spellcheck="false" placeholder="my-stone-noir">
+      </div>
+      <div class="row">
+        <label for="title">title</label>
+        <input type="text" id="title" placeholder="what the picker will call it">
+      </div>
+      <div class="row">
+        <label>start from</label>
+        <div class="presets" id="presets"></div>
+      </div>
+      <div class="row">
+        <label for="copy">copy a stone</label>
+        <select id="copy"></select>
+      </div>
+
+      <div class="row" style="margin-top:0.6rem">
+        <label for="grade">grade</label>
+        <select id="grade"></select>
+      </div>
+      <p class="hint" id="gradeHint"></p>
+      <div class="row">
+        <label for="room">room</label>
+        <select id="room"></select>
+      </div>
+      <p class="hint">Which surround Cycles lights it in. <code>noir</code> is the dark room that keeps a
+        black ground black; <code>screen</code> is the same room with the Frame standing in it as a real
+        emitter. The rooms themselves are in build-slab.py and are not per-stone.</p>
+
+      <div id="sliders"></div>
+
+      <div class="row" style="margin-top:0.5rem">
+        <label style="flex:0 0 auto"><input type="checkbox" id="crack"> procedural hairline cracks over the photo</label>
+      </div>
+
+      <div class="row" style="margin-top:0.7rem">
+        <button class="go" id="btnBake">bake this stone</button>
+        <button id="btnRevert" title="Back to the values this stone was last baked with">revert</button>
+      </div>
+      <p class="note" id="bakeNote"></p>
+    </section>
+
+    <section class="box">
+      <h2>3 &middot; the site</h2>
+      <p class="note" id="siteNote"></p>
+      <div class="row" style="margin-top:0.5rem">
+        <button class="go" id="btnApply">apply the shown stone</button>
+        <button id="btnForget" title="Delete this stone's entry and plate">delete stone</button>
+      </div>
+      <p class="hint" style="margin-left:0">Apply rewrites the default <code>--panel-plinth-src</code> in
+        portfolio/styles.css and restamps the <code>?v=</code> on every plinth url() in it. Nothing else in
+        the repository is touched, and nothing is committed — that is still yours.</p>
+    </section>
+
+    <section class="box">
+      <h2>maps on disk</h2>
+      <table class="maps" id="mapTable"></table>
+      <div class="row" style="margin-top:0.5rem">
+        <button id="btnSweep">sweep unused</button>
+        <button id="btnRefresh" title="Rewrite slab.json without rendering">refresh slab.json</button>
+      </div>
+    </section>
+
+  </aside>
+
+  <main class="stage">
+    <div>
+      <div class="stagehead">the window <span id="winNote"></span></div>
+      <canvas id="guide" width="900" height="300"></canvas>
+    </div>
+    <div>
+      <div class="stagehead">the front face, albedo only <span>— what lands on the 7% of the block you
+        actually look at. No light, no relief, no translucency: this is the photograph, cropped.</span></div>
+      <canvas id="face" width="900" height="66"></canvas>
+    </div>
+    <div>
+      <div class="stagehead">the page <span id="frameNote"></span></div>
+      <iframe id="frame" src="/portfolio/" title="/portfolio" height="620"></iframe>
+    </div>
+    <div class="cols">
+      <div>
+        <div class="stagehead">the plates <span>— every bake, same width, newest of yours first</span></div>
+        <div class="strip" id="strip"></div>
+      </div>
+      <div>
+        <div class="stagehead">log</div>
+        <pre class="log" id="log"></pre>
+      </div>
+    </div>
+  </main>
+</div>
+
+<script>
+(function () {
+  "use strict";
+
+  /* ---- what a stone is, on this page ------------------------------------
+     One object, the same shape as a design/plinth/stones/*.json entry minus the
+     two fields the server fills in (`maps`, `src`). Everything the form does is
+     read or write a field of P, and the bake posts P. There is no second copy
+     of the defaults anywhere: `presets` and the values of existing stones both
+     arrive from the server, which reads them from add-stone.py's STYLES table
+     and from slab.json. */
+  var P = null, PBAKED = null;
+
+  /* The sliders, in the order build-slab.py's PHOTO_FIELDS comment explains
+     them. `path` is where the value lives in P — the two pair-valued fields are
+     lists in the entry and two rows here, because a pair on one slider is a
+     pair nobody moves. */
+  var FIELDS = [
+    { path: ["scale"], label: "scale", min: 0.08, max: 4, step: 0.01,
+      hint: "Tiles across per model unit, and a model unit is a Frame width. 0.84 lays exactly one slab " +
+            "across the block; 0.42 crops into half a slab and the figure doubles; 1.75 lays two down and " +
+            "the veining goes fine. The strongest control here, and not a quality setting — it is how big " +
+            "the rock is." },
+    { path: ["offset"], label: "offset", min: 0, max: 1, step: 0.005,
+      hint: "Where in the slab the block was cut from, in tiles, applied after the scale — so the arris " +
+            "sits at exactly this fraction down the image whatever the scale is. Only a sliver of the slab " +
+            "is ever seen, so this decides which veins land on the plinth at all." },
+    { path: ["bump", 0], label: "bump strength", min: 0, max: 1, step: 0.01 },
+    { path: ["bump", 1], label: "bump distance", min: 0, max: 0.0018, step: 0.00001, fixed: 5,
+      hint: "The most delicate number in the table. The top face is seen at 7.8° where Fresnel is about " +
+            "0.5, so it is essentially a mirror and bump is not adding texture up there — it is adding " +
+            "distortion to a reflection, and the amplification at grazing incidence is severe. At 0.0016 " +
+            "the plinth reads honed rather than polished." },
+    { path: ["sss"], label: "subsurface", min: 0, max: 1, step: 0.01,
+      hint: "Subsurface Weight through the calcite mask. The most per unit of effort: calcite is " +
+            "translucent, and that is most of why real marble looks deep and wet where a flat albedo looks " +
+            "like painted card." },
+    { path: ["coat", 0], label: "coat weight", min: 0, max: 1, step: 0.01,
+      hint: "A second specular lobe — what \"polished\" looks like as opposed to \"shiny\". Off in the dark " +
+            "rooms on purpose: on a black ground it is a second thing lifting the floor." },
+    { path: ["coat", 1], label: "coat roughness", min: 0, max: 0.2, step: 0.001 },
+    { path: ["rough"], label: "roughness ×", min: 0, max: 2, step: 0.01,
+      hint: "Multiplies the roughness map. 0 pins it flat at BASE_ROUGH instead, which is the deliberately " +
+            "crippled control — see gemini-plain." }
+  ];
+
+  var S = null;                 /* the last /api/state */
+  var img = null;               /* the source, decoded, for the two canvases */
+  var squareCanvas = null;      /* ...centre-cropped, when `square` is on */
+  var doc = null, panel = null; /* the iframe's document and its .panel */
+  var shown = null;             /* which stone the frame and the strip are showing */
+  var poll = null, watching = null;
+
+  var $ = function (id) { return document.getElementById(id); };
+  var el = function (tag, cls, text) {
+    var n = document.createElement(tag);
+    if (cls) n.className = cls;
+    if (text != null) n.textContent = text;
+    return n;
+  };
+
+  function get(P0, path) { return path.length > 1 ? P0[path[0]][path[1]] : P0[path[0]]; }
+  function set(P0, path, v) { if (path.length > 1) { P0[path[0]][path[1]] = v; } else { P0[path[0]] = v; } }
+
+  /* ---- talking to the server --------------------------------------------- */
+
+  function api(path, body) {
+    var opt = body === undefined ? {} : {
+      method: "POST", headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body)
+    };
+    return fetch(path, opt).then(function (r) {
+      return r.json().then(function (j) {
+        if (!r.ok) { throw new Error(j && j.error ? j.error : r.status + " " + r.statusText); }
+        return j;
+      });
+    });
+  }
+
+  function logClear() { $("log").textContent = ""; }
+  function logLine(t) {
+    var pre = $("log");
+    var atEnd = pre.scrollTop + pre.clientHeight >= pre.scrollHeight - 8;
+    pre.textContent += t + "\n";
+    if (atEnd) pre.scrollTop = pre.scrollHeight;
+  }
+
+  /* A job is started by a POST and watched by polling, rather than streamed.
+     Blender writes its progress as carriage returns on one line and a bake is
+     forty lines in a minute; a poll is simpler than an event stream and cannot
+     leave a half-open response behind when this page is reloaded mid-bake. */
+  function watch(id, then) {
+    var from = 0;
+    busy(true, "running");
+    clearInterval(poll);
+    watching = id;
+    var stop = function () { clearInterval(poll); watching = null; busy(false); };
+    poll = setInterval(function () {
+      fetch("/api/job?id=" + id + "&from=" + from).then(function (r) { return r.json(); })
+        .then(function (j) {
+          (j.lines || []).forEach(logLine);
+          from = j.total;
+          if (!j.done) { busy(true, j.label); return; }
+          stop();
+          then(j);
+        }).catch(function (e) { stop(); logLine("! " + e.message); });
+    }, 400);
+  }
+
+  function busy(on, label) {
+    var chip = $("chipBusy");
+    chip.hidden = !on;
+    chip.textContent = label || "";
+    ["btnBake", "btnApply", "btnForget", "btnContract", "btnSweep", "btnRefresh"]
+      .forEach(function (b) { $(b).disabled = !!on; });
+  }
+
+  /* ---- state -------------------------------------------------------------- */
+
+  function refresh() {
+    return api("/api/state").then(function (s) {
+      S = s;
+      $("chipBlender").innerHTML = s.blender
+        ? "blender: <b>found</b>" : "blender: <b>not found</b>";
+      $("chipBlender").className = "chip" + (s.blender ? "" : " bad");
+      $("chipBlender").title = s.blender || "Set $BLENDER, put it on PATH, or start the server with --blender.";
+      $("chipSite").innerHTML = "site: <b>" + (s.site.stone || "?") + "</b>";
+      $("chipVer").innerHTML = "?v= <b>" + (s.site.version || "—") + "</b>";
+      $("chipVer").className = "chip" + (s.stale ? " bad" : "");
+      $("chipVer").title = s.stale
+        ? "The stylesheet asks for ?v=" + s.site.version + " and the plates on disk digest to "
+          + s.version + ". vercel.json caches /portfolio/img/ for a day, so the deployment would serve "
+          + "a stale plate under an unchanged URL. Apply restamps it."
+        : "matches the plates on disk";
+      fillSources();
+      fillPresets();
+      fillGrades();
+      fillRooms();
+      fillCopy();
+      fillStrip();
+      fillMaps();
+      siteNote();
+      /* A bake is a minute, and reloading this page during one used to lose the
+         log and leave every button live while Blender was still writing. The
+         job outlives the page, so pick it back up where it is. */
+      if (s.busy && watching !== s.busy) watch(s.busy, function () { refresh(); });
+      return s;
+    }).catch(function (e) {
+      logLine("! could not read the server state: " + e.message);
+    });
+  }
+
+  function siteNote() {
+    var n = $("siteNote");
+    var bits = ["portfolio/styles.css draws <code>" + (S.site.stone || "?") + "</code> at <code>?v="
+                + (S.site.version || "—") + "</code>."];
+    if (S.stale) {
+      bits.push("<b>The plates on disk digest to <code>" + S.version + "</code></b> — every plinth url() "
+                + "in the stylesheet is a stale name. Apply to restamp.");
+    }
+    n.className = "note" + (S.stale ? " bad" : "");
+    n.innerHTML = bits.join(" ");
+  }
+
+  /* ---- the form ----------------------------------------------------------- */
+
+  function fillSources() {
+    var sel = $("src"), was = sel.value;
+    sel.textContent = "";
+    if (!S.sources.length) {
+      sel.appendChild(el("option", null, "— nothing in design/plinth/sources/ yet —"));
+      sel.value = "";
+    }
+    S.sources.forEach(function (s) {
+      var o = el("option", null, s.name + (s.w ? "   " + s.w + "×" + s.h : "   unreadable"));
+      o.value = s.name;
+      sel.appendChild(o);
+    });
+    if (was && S.sources.some(function (s) { return s.name === was; })) sel.value = was;
+    else if (S.sources.length) sel.value = S.sources[S.sources.length - 1].name;
+    loadSource();
+  }
+
+  function currentSource() {
+    var name = $("src").value;
+    return S.sources.filter(function (s) { return s.name === name; })[0] || null;
+  }
+
+  function loadSource() {
+    var s = currentSource();
+    var note = $("srcNote");
+    if (!s) { note.textContent = "Drop a photograph above to begin."; img = null; draw(); return; }
+    if (s.error) { note.className = "note bad"; note.textContent = s.error; img = null; draw(); return; }
+    var bits = [s.w + "×" + s.h + " px, aspect " + s.aspect.toFixed(3) + ", "
+                + (s.bytes / 1e6).toFixed(1) + " MB."];
+    var cls = "note";
+    if (s.w < S.soft_px) {
+      cls = "note bad";
+      bits.push("Under " + S.soft_px + "px of width the fine structure will be soft on the front face, and "
+                + "resampling cannot put back what is not in the file. Not fatal — a soft stone is a look.");
+    }
+    note.className = cls;
+    note.textContent = bits.join(" ");
+    var probe = new Image();
+    probe.onload = function () { img = probe; squareCanvas = null; draw(); };
+    probe.onerror = function () { img = null; draw(); };
+    probe.src = s.url + "?t=" + Date.now();
+  }
+
+  function fillPresets() {
+    var box = $("presets");
+    box.textContent = "";
+    Object.keys(S.presets).forEach(function (name) {
+      var p = S.presets[name];
+      var b = el("button", null, name);
+      b.title = p.note;
+      b.addEventListener("click", function () { adopt(preset(name), name); });
+      box.appendChild(b);
+    });
+  }
+
+  /* A preset is one of add-stone.py's four STYLES, arriving from the server so
+     this page cannot hold a second, drifting copy of them. */
+  function preset(name) {
+    var p = S.presets[name];
+    return {
+      title: "", grade: "deep",
+      scale: p.scale, offset: p.offset,
+      bump: [p.bump[0], p.bump[1]], sss: p.sss,
+      coat: [p.coat[0], p.coat[1]], rough: p.rough,
+      crack: false, room: p.room, note: p.note
+    };
+  }
+
+  function fillGrades() {
+    var sel = $("grade");
+    sel.textContent = "";
+    Object.keys(S.grades).forEach(function (g) {
+      var o = el("option", null, g);
+      o.value = g;
+      o.title = S.grades[g];
+      sel.appendChild(o);
+    });
+  }
+
+  function fillRooms() {
+    var sel = $("room");
+    sel.textContent = "";
+    S.rooms.forEach(function (r) {
+      var o = el("option", null, r);
+      o.value = r;
+      sel.appendChild(o);
+    });
+  }
+
+  function fillCopy() {
+    var sel = $("copy");
+    sel.textContent = "";
+    sel.appendChild(el("option", null, "— pick a stone to load its numbers —"));
+    S.stones.filter(function (s) { return s.photo; }).forEach(function (s) {
+      var o = el("option", null, s.key + "  ·  " + s.title);
+      o.value = s.key;
+      sel.appendChild(o);
+    });
+    sel.value = "";
+  }
+
+  function stoneByKey(k) {
+    return S.stones.filter(function (s) { return s.key === k; })[0] || null;
+  }
+
+  function buildSliders() {
+    var box = $("sliders");
+    box.textContent = "";
+    FIELDS.forEach(function (f, i) {
+      var row = el("div", "row");
+      var lab = el("label", null, f.label);
+      lab.setAttribute("for", "f" + i);
+      var rng = el("input");
+      rng.type = "range"; rng.id = "f" + i;
+      rng.min = f.min; rng.max = f.max; rng.step = f.step;
+      var num = el("input");
+      num.type = "number";
+      num.min = f.min; num.max = f.max; num.step = f.step;
+      function push(v) {
+        if (!isFinite(v)) return;
+        set(P, f.path, v);
+        rng.value = v; num.value = fmt(f, v);
+        noteClear();
+        draw();
+      }
+      rng.addEventListener("input", function () { push(parseFloat(rng.value)); });
+      num.addEventListener("change", function () { push(parseFloat(num.value)); });
+      row.appendChild(lab); row.appendChild(rng); row.appendChild(num);
+      box.appendChild(row);
+      if (f.hint) box.appendChild(el("p", "hint", f.hint));
+      f._rng = rng; f._num = num;
+    });
+  }
+
+  function fmt(f, v) { return f.fixed ? Number(v).toFixed(f.fixed) : String(Number(v.toFixed(6))); }
+
+  function adopt(p, presetName) {
+    P = p;
+    if (presetName && !$("key").value.trim()) {
+      var s = currentSource();
+      var stem = s ? s.name.replace(/\.[^.]+$/, "").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") : "stone";
+      $("key").value = stem + "-" + presetName;
+    }
+    if (presetName && !$("title").value.trim() && p.note) {
+      var s2 = currentSource();
+      $("title").value = (s2 ? s2.name.replace(/\.[^.]+$/, "") : "stone") + " — " + p.note;
+    }
+    toForm();
+    noteClear();
+    draw();
+  }
+
+  function toForm() {
+    $("grade").value = P.grade;
+    $("room").value = P.room;
+    $("crack").checked = !!P.crack;
+    FIELDS.forEach(function (f) {
+      var v = get(P, f.path);
+      f._rng.value = v; f._num.value = fmt(f, v);
+    });
+    $("gradeHint").textContent = S.grades[P.grade] || "";
+  }
+
+  function fromForm() {
+    P.grade = $("grade").value;
+    P.room = $("room").value;
+    P.crack = $("crack").checked;
+    $("gradeHint").textContent = S.grades[P.grade] || "";
+    noteClear();
+  }
+
+  /* ---- the window guide ---------------------------------------------------
+     THE ONLY THING ON THIS PAGE DRAWN RATHER THAN RENDERED, and it is drawn
+     from build_photo_material()'s own arithmetic rather than from an eyeball:
+
+       U = scale·x + 0.5              across the block
+       V = (scale·aspect)·y + offset  into the top face
+       V = (scale·aspect)·z + offset  down the front face
+
+     Both V axes carry the aspect, which is what makes a tile of the texture the
+     same shape on the stone as the photograph is on screen — so the window is
+     simply the block's plan view laid on the picture, and no correction of its
+     own is needed here. The arris is where the two V expressions meet, at
+     V = offset exactly, which is why the pattern runs over the edge.
+
+     x, y, z come from slab.json's `block`, written by build-slab.py. Nothing
+     here is a literal. */
+
+  function sourceBitmap() {
+    if (!img) return null;
+    if (!$("square").checked) return img;
+    if (squareCanvas) return squareCanvas;
+    var e = Math.min(img.naturalWidth, img.naturalHeight);
+    var c = document.createElement("canvas");
+    c.width = c.height = e;
+    c.getContext("2d").drawImage(img, (img.naturalWidth - e) / 2, (img.naturalHeight - e) / 2,
+                                 e, e, 0, 0, e, e);
+    squareCanvas = c;
+    return c;
+  }
+
+  function bitmapAspect(bm) { return (bm.width || bm.naturalWidth) / (bm.height || bm.naturalHeight); }
+
+  /* One tiled blit, used twice: the guide wants it isotropic and the face strip
+     wants it stretched to the plate's proportions, and the difference is only
+     which w/h it is handed. */
+  function tiled(ctx, bm, u0, u1, v0, v1, w, h) {
+    var tw = w / (u1 - u0), th = h / (v1 - v0);
+    for (var i = Math.floor(u0); i < u1; i++) {
+      for (var j = Math.floor(v0); j < v1; j++) {
+        ctx.drawImage(bm, (i - u0) * tw, (v1 - j - 1) * th, tw + 0.5, th + 0.5);
+      }
+    }
+  }
+
+  function draw() {
+    drawGuide();
+    drawFace();
+  }
+
+  /* The note under the bake button is about the LAST bake, so it is cleared by
+     moving something rather than by redrawing — draw() runs on every reload of
+     the state, which is the first thing a finished bake does, and clearing it
+     there wiped the "baked" message a tenth of a second after writing it. */
+  function noteClear() { $("bakeNote").className = "note"; $("bakeNote").textContent = ""; }
+
+  function drawGuide() {
+    var c = $("guide"), ctx = c.getContext("2d");
+    var bm = sourceBitmap();
+    var W = Math.max(320, Math.min(1100, (c.parentNode.clientWidth || 900)));
+    if (!bm || !P || !S || !S.block) {
+      c.width = W; c.height = 120;
+      ctx.clearRect(0, 0, W, 120);
+      ctx.fillStyle = getComputedStyle(document.body).color;
+      ctx.globalAlpha = 0.5;
+      ctx.font = "13px system-ui";
+      ctx.fillText(bm ? "waiting for design/plinth/slab.json" : "no source photograph", 12, 30);
+      ctx.globalAlpha = 1;
+      $("winNote").textContent = "";
+      return;
+    }
+    var B = S.block, A = bitmapAspect(bm);
+    var s = P.scale, v = s * A, off = P.offset;
+    var u0 = 0.5 - B.near_half * s, u1 = 0.5 + B.near_half * s;
+    var vFront = off - B.height * v, vArris = off, vTop = off + B.depth * v;
+
+    /* Half a block of margin all round, so the window is seen in the picture
+       rather than filling it. */
+    var padU = (u1 - u0) * 0.35, padV = (vTop - vFront) * 0.35;
+    var U0 = u0 - padU, U1 = u1 + padU, V0 = vFront - padV, V1 = vTop + padV;
+    var k = W / (U1 - U0);                  /* px per U tile */
+    var kv = k / A;                         /* ...and per V tile, so a tile is the photo's own shape */
+    var H = Math.max(60, Math.round((V1 - V0) * kv));
+    c.width = W; c.height = H;
+    ctx.clearRect(0, 0, W, H);
+    tiled(ctx, bm, U0, U1, V0, V1, W, H);
+
+    var X = function (u) { return (u - U0) * k; };
+    var Y = function (vv) { return (V1 - vv) * kv; };
+
+    /* Everything outside the block, dimmed — the window is what is left. */
+    ctx.fillStyle = "rgba(0,0,0,0.55)";
+    ctx.fillRect(0, 0, W, Y(vTop));
+    ctx.fillRect(0, Y(vFront), W, H - Y(vFront));
+    ctx.fillRect(0, Y(vTop), X(u0), Y(vFront) - Y(vTop));
+    ctx.fillRect(X(u1), Y(vTop), W - X(u1), Y(vFront) - Y(vTop));
+
+    ctx.lineWidth = 1.5;
+    ctx.strokeStyle = "rgba(255,255,255,0.9)";
+    ctx.strokeRect(X(u0), Y(vTop), X(u1) - X(u0), Y(vFront) - Y(vTop));
+    /* The arris, which is the single most looked-at line in the picture. */
+    ctx.strokeStyle = "#d8a76a";
+    ctx.setLineDash([6, 4]);
+    ctx.beginPath();
+    ctx.moveTo(X(u0), Y(vArris)); ctx.lineTo(X(u1), Y(vArris));
+    ctx.stroke();
+    ctx.setLineDash([]);
+    ctx.fillStyle = "#d8a76a";
+    ctx.font = "11px ui-monospace, Consolas, monospace";
+    ctx.fillText("arris", X(u0) + 4, Y(vArris) - 4);
+    ctx.fillStyle = "rgba(255,255,255,0.85)";
+    ctx.fillText("top face", X(u0) + 4, Y(vTop) + 13);
+    ctx.fillText("front face", X(u0) + 4, Y(vFront) - 4);
+
+    var tiles = (B.depth + B.height) * v;
+    $("winNote").innerHTML = "— " + tiles.toFixed(2) + " tiles of the photograph tall"
+      + (tiles > 1
+         ? ", <b style='color:var(--ui-bad)'>over one, so the unblended vertical wrap will cross the "
+           + "block</b> (build-portoro-maps.py cross-fades U and only U)"
+         : "")
+      + ". " + ((u1 - u0)).toFixed(2) + " tiles wide.";
+  }
+
+  function drawFace() {
+    var c = $("face"), ctx = c.getContext("2d");
+    var bm = sourceBitmap();
+    var W = Math.max(320, Math.min(1100, (c.parentNode.clientWidth || 900)));
+    if (!bm || !P || !S || !S.block) { c.width = W; c.height = 40; ctx.clearRect(0, 0, W, 40); return; }
+    var B = S.block, A = bitmapAspect(bm);
+    var s = P.scale, v = s * A, off = P.offset;
+    /* The plate's own proportions for the strip's height, so this sits at the
+       same shape as the front face does on the page. */
+    var H = Math.max(28, Math.round(W * B.height / (2 * B.near_half)));
+    c.width = W; c.height = H;
+    ctx.clearRect(0, 0, W, H);
+    tiled(ctx, bm, 0.5 - B.near_half * s, 0.5 + B.near_half * s,
+          off - B.height * v, off, W, H);
+  }
+
+  /* ---- the strip and the frame -------------------------------------------- */
+
+  /* The same ?v= the stylesheet asks for, so the strip and the frame can never
+     be showing two different renders of one stone. Always a query, even when
+     slab.json has no version yet, because every caller appends `&t=` to it. */
+  function plateURL(k, base) {
+    return (base || "/portfolio/") + "img/tex/plinth-" + k + ".webp"
+      + "?v=" + ((S && S.version) || "0");
+  }
+
+  function fillStrip() {
+    var box = $("strip");
+    box.textContent = "";
+    S.stones.forEach(function (s) {
+      if (!s.plate) return;
+      var wrap = el("div", "stone");
+      wrap.dataset.live = String(s.key === shown);
+      var bar = el("div", "bar");
+      bar.appendChild(el("span", "k", s.key));
+      bar.appendChild(el("span", "t", s.title || ""));
+      var grow = el("span", "grow"); grow.style.flex = "1 1 auto";
+      bar.appendChild(grow);
+      var b1 = el("button", null, "show");
+      b1.addEventListener("click", function () { show(s.key); });
+      bar.appendChild(b1);
+      if (s.photo) {
+        var b2 = el("button", null, "load");
+        b2.title = "Load this stone's numbers into the form";
+        b2.addEventListener("click", function () { loadStone(s.key); });
+        bar.appendChild(b2);
+      }
+      wrap.appendChild(bar);
+      var im = el("img");
+      im.loading = "lazy";
+      im.alt = s.key;
+      im.src = plateURL(s.key, "/portfolio/") + "&t=" + Date.now();
+      wrap.appendChild(im);
+      box.appendChild(wrap);
+    });
+    if (!box.childNodes.length) box.appendChild(el("p", "note", "No plates on disk yet."));
+  }
+
+  function loadStone(k) {
+    var s = stoneByKey(k);
+    if (!s) return;
+    adopt({
+      title: s.title, grade: s.grade, scale: s.scale, offset: s.offset,
+      bump: s.bump.slice(), sss: s.sss, coat: s.coat.slice(), rough: s.rough,
+      crack: !!s.crack, room: s.room || "flat"
+    });
+    $("title").value = s.title || "";
+    /* A stone that came from a file can be re-baked in place; a built-in cannot
+       be shadowed, so its numbers arrive as a starting point under a new name
+       and the field is cleared rather than pre-filled with a name that will be
+       refused. */
+    $("key").value = s.mine ? k : "";
+    if (s.src) {
+      var match = S.sources.filter(function (x) { return x.name === s.src; })[0];
+      if (match) { $("src").value = s.src; loadSource(); }
+    }
+    PBAKED = JSON.parse(JSON.stringify(P));
+    show(k);
+  }
+
+  function show(k) {
+    shown = k;
+    if (panel) {
+      panel.dataset.marble = k;
+      /* SET the property, do not clear it: the stylesheet only carries
+         `.panel[data-marble="…"]` rules for a handful of stones, so anything
+         else would silently fall through to the default and the frame would
+         show the shipped stone while the strip highlighted this one. */
+      panel.style.setProperty("--panel-plinth-src",
+        'url("' + plateURL(k) + "&t=" + Date.now() + '")');
+    }
+    $("frameNote").textContent = "— showing " + k
+      + (S && S.site.stone === k ? " (which is what the site draws)" : "");
+    Array.prototype.forEach.call($("strip").querySelectorAll(".stone"), function (n) {
+      n.dataset.live = String(n.querySelector(".k").textContent === k);
+    });
+  }
+
+  function fillMaps() {
+    var t = $("mapTable");
+    t.textContent = "";
+    if (!S.maps.length) {
+      t.appendChild(el("tr")).appendChild(el("td", null, "none yet"));
+      return;
+    }
+    S.maps.forEach(function (m) {
+      var tr = el("tr");
+      tr.appendChild(el("td", "k", m.stem));
+      tr.appendChild(el("td", null, (m.bytes / 1e6).toFixed(0) + " MB"));
+      tr.appendChild(el("td", null, m.used_by.length
+        ? m.used_by.join(", ") : (m.complete ? "unused" : "incomplete, unused")));
+      t.appendChild(tr);
+    });
+  }
+
+  /* ---- the buttons -------------------------------------------------------- */
+
+  function bake() {
+    fromForm();
+    var key = $("key").value.trim().toLowerCase();
+    var src = $("src").value;
+    var note = $("bakeNote");
+    if (!src) { note.className = "note bad"; note.textContent = "Pick a source photograph first."; return; }
+    if (!key) { note.className = "note bad"; note.textContent = "Give the stone a name."; return; }
+    var body = {
+      key: key, src: src, size: parseInt($("size").value, 10) || 0,
+      square: $("square").checked,
+      title: $("title").value.trim() || key,
+      grade: P.grade, scale: P.scale, offset: P.offset, bump: P.bump,
+      sss: P.sss, coat: P.coat, rough: P.rough, crack: P.crack, room: P.room
+    };
+    note.className = "note";
+    note.textContent = "";
+    logClear();
+    api("/api/bake", body).then(function (j) {
+      watch(j.job, function (res) {
+        if (!res.ok) {
+          note.className = "note bad";
+          note.textContent = "The bake failed — see the log. Nothing was written to the stylesheet.";
+          return;
+        }
+        PBAKED = JSON.parse(JSON.stringify(P));
+        /* After the reload, not before: refresh() redraws the whole left column
+           from the new state and the message has to outlive that. */
+        refresh().then(function () {
+          show(key);
+          note.className = "note ok";
+          note.textContent = "Baked. It is in the strip and standing under the Frame below. "
+            + "“apply” writes it into portfolio/styles.css.";
+        });
+      });
+    }).catch(function (e) { note.className = "note bad"; note.textContent = e.message; });
+  }
+
+  function applyStone() {
+    if (!shown) return;
+    api("/api/apply", { key: shown }).then(function (r) {
+      logLine("portfolio/styles.css: " + (r.was_stone === r.stone
+        ? "still " + r.stone : r.was_stone + " → " + r.stone)
+        + ", ?v=" + (r.was_version || "—") + " → " + r.version
+        + " on " + r.stamped + " url()s.");
+      logLine("Not committed — that is still yours. A change to the stone the Panel draws is a "
+              + "change to /portfolio's colour, so run the capture contract before merging it.");
+      refresh();
+    }).catch(function (e) { logLine("! " + e.message); });
+  }
+
+  function forget() {
+    if (!shown) return;
+    var s = stoneByKey(shown);
+    if (!s || !s.mine) { logLine("! `" + shown + "` is a built-in — it is a table in build-slab.py, not a file."); return; }
+    if (!window.confirm("Delete " + shown + "?\n\nIts design/plinth/stones/ entry and its plate go; the "
+                        + "maps stay (other stones may share them) and are collected by `sweep unused`.")) return;
+    api("/api/forget", { key: shown }).then(function (r) {
+      r.removed.forEach(function (p) { logLine("removed " + p); });
+      shown = null;
+      return api("/api/refresh", {});
+    }).then(function (j) {
+      watch(j.job, function () { refresh(); });
+    }).catch(function (e) { logLine("! " + e.message); });
+  }
+
+  /* ---- wiring ------------------------------------------------------------- */
+
+  function upload(fileObj) {
+    if (!fileObj) return;
+    logLine("uploading " + fileObj.name + " (" + (fileObj.size / 1e6).toFixed(1) + " MB)…");
+    fetch("/api/upload", { method: "POST", headers: { "X-Filename": fileObj.name }, body: fileObj })
+      .then(function (r) { return r.json().then(function (j) { if (!r.ok) throw new Error(j.error); return j; }); })
+      .then(function (info) {
+        logLine("design/plinth/sources/" + info.name + "  " + info.w + "×" + info.h);
+        return refresh().then(function () { $("src").value = info.name; loadSource(); });
+      })
+      .catch(function (e) { logLine("! " + e.message); });
+  }
+
+  $("drop").addEventListener("click", function () { $("file").click(); });
+  $("file").addEventListener("change", function () { upload($("file").files[0]); $("file").value = ""; });
+  ["dragenter", "dragover"].forEach(function (t) {
+    $("drop").addEventListener(t, function (e) { e.preventDefault(); $("drop").classList.add("over"); });
+  });
+  ["dragleave", "drop"].forEach(function (t) {
+    $("drop").addEventListener(t, function (e) { e.preventDefault(); $("drop").classList.remove("over"); });
+  });
+  $("drop").addEventListener("drop", function (e) { upload(e.dataTransfer.files[0]); });
+
+  $("src").addEventListener("change", loadSource);
+  $("square").addEventListener("change", function () { squareCanvas = null; draw(); });
+  $("size").addEventListener("change", draw);
+  $("grade").addEventListener("change", fromForm);
+  $("room").addEventListener("change", fromForm);
+  $("crack").addEventListener("change", fromForm);
+  $("copy").addEventListener("change", function () { if ($("copy").value) loadStone($("copy").value); });
+  $("btnBake").addEventListener("click", bake);
+  $("btnRevert").addEventListener("click", function () {
+    if (PBAKED) { P = JSON.parse(JSON.stringify(PBAKED)); toForm(); draw(); }
+  });
+  $("btnApply").addEventListener("click", applyStone);
+  $("btnForget").addEventListener("click", forget);
+  $("btnReload").addEventListener("click", function () { refresh(); });
+  $("btnSweep").addEventListener("click", function () {
+    api("/api/sweep", {}).then(function (r) {
+      logLine(r.removed.length
+        ? "swept " + r.removed.length + " map set(s), " + (r.bytes / 1e6).toFixed(0) + " MB"
+        : "nothing to sweep.");
+      refresh();
+    }).catch(function (e) { logLine("! " + e.message); });
+  });
+  $("btnRefresh").addEventListener("click", function () {
+    logClear();
+    api("/api/refresh", {}).then(function (j) { watch(j.job, function () { refresh(); }); })
+      .catch(function (e) { logLine("! " + e.message); });
+  });
+  $("btnContract").addEventListener("click", function () {
+    logClear();
+    logLine("Replaying the profile README's capture against this tree. It fetches the capture script "
+            + "from the profile repository at run time, so this needs the network.");
+    api("/api/contract", {}).then(function (j) { watch(j.job, function () {}); })
+      .catch(function (e) { logLine("! " + e.message); });
+  });
+
+  $("frame").addEventListener("load", function () {
+    doc = $("frame").contentDocument;
+    panel = doc.getElementById("projects");
+    if (!panel) { $("frameNote").textContent = "— no #projects in /portfolio, so there is no Panel to stand a plinth under."; return; }
+    /* The plinth is at the foot of a page several screens long. Instantly, not
+       smoothly: a glide on every reload is time spent not looking at the stone. */
+    panel.scrollIntoView({ block: "end", behavior: "instant" });
+    if (shown) show(shown);
+  });
+
+  window.addEventListener("resize", function () { draw(); });
+
+  buildSliders();
+  refresh().then(function () {
+    $("size").value = S.cap_px;
+    adopt(preset("noir"), "noir");
+    if (S.site.stone) show(S.site.stone);
+  });
+})();
+</script>
+</body>
+</html>

--- a/design/plinth/plinth-studio.py
+++ b/design/plinth/plinth-studio.py
@@ -1,0 +1,822 @@
+#!/usr/bin/env python3
+"""The plinth, end to end, in a browser: photograph in, stone on the site out.
+
+    python design/plinth/plinth-studio.py
+
+...then open what it prints. It serves the repository, so the studio page, the
+plates and the real /portfolio all come off one origin and the preview is the
+actual page rather than a mock of it.
+
+WHAT IT IS FOR. Everything under design/plinth/ already exists as a command:
+build-portoro-maps.py takes a photograph apart, build-slab.py lights the result
+in Cycles, add-stone.py runs the two together for four fixed presets, and
+portfolio/styles.css is hand-edited afterwards to point at the winner. That is
+four steps, three of which have to be got right in the correct order, and the
+last of which has a digest in it that goes stale silently. This is those four
+steps behind one page: drop an image, move every slider the stone has, bake,
+look at it standing under the real Frame, and write it into the stylesheet.
+
+WHAT IT IS NOT. It is not a preview of an unbaked stone. A photo-backed stone
+is a path-traced render of four maps and there is no honest way to draw one
+without Cycles - see plinth-tuner.html, which reimplements the PROCEDURAL
+material in GLSL and says out loud that it cannot draw the photographic ones.
+What this page gives you before a bake is the WINDOW: which rectangle of your
+photograph lands on the block, drawn from the same numbers build_photo_material()
+projects with. That answers `scale` and `offset`, which are the two strongest
+controls, and it is honest about answering nothing else.
+
+THE THREE THINGS IT KNOWS THAT THE COMMANDS DO NOT:
+
+  MAPS ARE PER-IMAGE, NOT PER-STONE, so a second bake of the same photograph at
+  a different `scale` is fifteen seconds of Cycles and not fifty megabytes of
+  PNG. add-stone.py rebuilds the maps every run because it is a one-shot; this
+  keeps them, keyed by the CONTENT of the image and the two options that change
+  what the maps are (`size`, `square`). Content-addressed and not name-addressed
+  on purpose: a directory keyed by a name is a directory a second photograph
+  called photo.jpg silently overwrites, which is the exact failure
+  docs/agents/plinth-marble.md warns about for maps/ itself.
+
+  THE ?v= IS THE DIGEST OF EVERY PLATE, so it moves whenever ANY stone is baked
+  - including one you are only trying out. portfolio/styles.css then asks for a
+  filename that no longer describes what is on disk, and vercel.json caches
+  /portfolio/img/ for a day, so the deployment serves the stale plate for up to
+  24 hours while localhost looks right. "Apply" restamps every plinth url() in
+  the stylesheet, and the page shows a warning whenever they have drifted apart.
+
+  A STONE THIS WRITES IS A FILE, NOT A TABLE ENTRY. design/plinth/stones/<key>.json,
+  which build-slab.py's load_added_stones() merges into PHOTO_CANDIDATES - the
+  same door add-stone.py uses. Built-in names are refused rather than shadowed.
+
+WHAT IS COMMITTED AND WHAT IS NOT, unchanged from add-stone.py: the entry and
+the plate ship, the maps and your photograph do not. So a stone survives a fresh
+checkout and can be looked at there, and can only be RE-BAKED from a tree that
+still has the image. design/plinth/sources/ is where this keeps them and it is
+gitignored - keep anything you care about somewhere else as well.
+
+IT WRITES TO portfolio/styles.css when you press Apply, and to nothing else
+outside design/plinth/ and portfolio/img/tex/. It binds to 127.0.0.1 only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import http.server
+import importlib
+import io
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import threading
+import time
+import urllib.parse
+import webbrowser
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(os.path.dirname(HERE))
+sys.path.insert(0, HERE)
+
+# Both are hyphenated, so neither is reachable by `import` - see the same note
+# in add-stone.py, which is where the two helpers taken from it are documented.
+maps_mod = importlib.import_module("build-portoro-maps")
+add_stone = importlib.import_module("add-stone")
+
+SOURCES = os.path.join(HERE, "sources")
+MAPS_DIR = os.path.join(HERE, "maps")
+STONES_DIR = os.path.join(HERE, "stones")
+SIDECAR = os.path.join(HERE, "slab.json")
+BUILD_SLAB = os.path.join(HERE, "build-slab.py")
+PLATES = os.path.join(ROOT, "portfolio", "img", "tex")
+STYLESHEET = os.path.join(ROOT, "portfolio", "styles.css")
+CONTRACT = os.path.join(ROOT, "design", "tools", "check-capture-contract.py")
+STUDIO_PAGE = "/design/plinth/plinth-studio.html"
+
+# The surrounds build-slab.py's ROOMS defines. Stated here because ROOMS lives
+# behind `import bpy` and cannot be read without Blender; a name that is not one
+# of these reaches set_lights() as a KeyError inside a headless render, so it is
+# refused at the form instead.
+ROOMS = ("noir", "screen", "flat", "gallery")
+
+# What build_maps() writes, all of it, for one photograph. Used to decide
+# whether a maps directory is complete rather than merely present - a bake
+# interrupted halfway leaves a directory that exists and is missing a map, and
+# build-slab.py would then stop with MISSING_ADDED_MAPS forty seconds in.
+MAP_FILES = tuple(["basecolor-%s.png" % g for g in sorted(maps_mod.GRADES)]
+                  + ["roughness.png", "height.png", "calcite.png"])
+
+# What may be dropped on the page. Checked by extension AND by asking Pillow to
+# open it, because the extension is the uploader's claim and the decode is the
+# only thing that makes it true.
+IMAGE_EXT = (".jpg", ".jpeg", ".png", ".webp", ".tif", ".tiff", ".bmp")
+MAX_UPLOAD = 96 * 1024 * 1024
+
+NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+# The default declaration in the .panel block, which is the stone the site
+# draws. Anchored at the start of a line with nothing but indent before it, so
+# it cannot match the `.panel[data-marble="…"] { --panel-plinth-src: … }`
+# candidate rules further down - those carry a selector on the same line.
+SITE_SRC_RE = re.compile(
+    r'^(?P<lead>[ \t]*--panel-plinth-src:[ \t]*url\(")'
+    r'img/tex/plinth-(?P<key>[a-z0-9-]+)\.webp(?:\?v=(?P<ver>[0-9a-f]+))?'
+    r'(?P<tail>"\);)', re.M)
+# ...and every plinth plate url() in the file, candidates included, for the
+# restamp. One digest covers all of them: digest() hashes the whole directory.
+ANY_SRC_RE = re.compile(
+    r'(?P<head>url\("img/tex/plinth-[a-z0-9-]+\.webp)(?:\?v=[0-9a-f]+)?(?P<tail>"\))')
+
+
+def slug(text):
+    return SLUG_RE.sub("-", text.lower()).strip("-") or "image"
+
+
+def sha256_file(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def maps_stem(src_path, size, square):
+    """Which maps directory a (photograph, size, square) triple belongs in.
+
+    The digest covers all three because all three change what the maps ARE, and
+    a directory shared by two different sets of maps is a stone that silently
+    re-renders as another stone's rock the next time anything is baked. The slug
+    is only there so the directory is recognisable in a file listing.
+    """
+    h = hashlib.sha256()
+    h.update(sha256_file(src_path).encode())
+    h.update(b"|%d|%d" % (int(size), 1 if square else 0))
+    return "%s-%s" % (slug(os.path.splitext(os.path.basename(src_path))[0]),
+                      h.hexdigest()[:8])
+
+
+def maps_complete(stem):
+    d = os.path.join(MAPS_DIR, stem)
+    return all(os.path.isfile(os.path.join(d, f)) for f in MAP_FILES)
+
+
+def sidecar():
+    if not os.path.isfile(SIDECAR):
+        return {}
+    with open(SIDECAR, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def added_keys():
+    """The stones that are files - design/plinth/stones/*.json - as against the
+    ones that are the tables in build-slab.py. Only these can be rewritten."""
+    names = os.listdir(STONES_DIR) if os.path.isdir(STONES_DIR) else []
+    return {n[:-5] for n in names if n.endswith(".json")}
+
+
+def taken_names(doc):
+    """Every stone name build-slab.py would recognise, so a new one can be
+    refused before a minute of Cycles is spent discovering the clash. Read out
+    of the sidecar for the same reason add-stone.py reads it: knowing the
+    built-in tables means importing build-slab.py, which means importing bpy."""
+    names = set()
+    for field in ("candidates", "photo_candidates", "relit_candidates"):
+        names |= set(doc.get(field) or {})
+    return names | added_keys()
+
+
+def probe(path):
+    from PIL import Image
+    with Image.open(path) as im:
+        w, h = im.size
+        fmt = im.format
+    return {"w": w, "h": h, "aspect": (w / float(h)) if h else 1.0,
+            "format": fmt, "bytes": os.path.getsize(path)}
+
+
+def list_sources():
+    out = []
+    for name in sorted(os.listdir(SOURCES) if os.path.isdir(SOURCES) else []):
+        path = os.path.join(SOURCES, name)
+        if not os.path.isfile(path) or not name.lower().endswith(IMAGE_EXT):
+            continue
+        try:
+            info = probe(path)
+        except Exception as exc:                      # a file that is not one
+            info = {"error": str(exc)}
+        info["name"] = name
+        info["url"] = "/design/plinth/sources/" + urllib.parse.quote(name)
+        out.append(info)
+    return out
+
+
+def read_site():
+    """Which stone portfolio/styles.css draws, and at which digest."""
+    with open(STYLESHEET, encoding="utf-8") as fh:
+        css = fh.read()
+    hits = SITE_SRC_RE.findall(css)
+    m = SITE_SRC_RE.search(css)
+    return {"stone": m.group("key") if m else None,
+            "version": m.group("ver") if m else None,
+            "declarations": len(hits),
+            "stamped": len(ANY_SRC_RE.findall(css))}
+
+
+def plate_path(key):
+    return os.path.join(PLATES, "plinth-%s.webp" % key)
+
+
+def stones_state(doc):
+    """Every stone the picker offers: what it is, whether its plate is on disk,
+    and whether this studio can rewrite or delete it."""
+    added = doc.get("added_stones") or {}
+    out = []
+    for key, spec in (doc.get("photo_candidates") or {}).items():
+        p = plate_path(key)
+        entry = dict(spec)
+        entry["key"] = key
+        entry["photo"] = True
+        entry["mine"] = key in added
+        entry["src"] = (added.get(key) or {}).get("src")
+        entry["stem"] = (added.get(key) or {}).get("stem")
+        entry["plate"] = os.path.isfile(p)
+        entry["plate_bytes"] = os.path.getsize(p) if entry["plate"] else 0
+        out.append(entry)
+    # The procedural stones and their re-lit twins. Listed because they have
+    # plates and a picker that hides a plate on disk reads as a bake that
+    # failed; not editable here, because their material is a table in
+    # build-slab.py and there is no file to write.
+    for field in ("candidates", "relit_candidates"):
+        for key, spec in (doc.get(field) or {}).items():
+            p = plate_path(key)
+            out.append({"key": key, "title": spec.get("title", key),
+                        "photo": False, "mine": False, "procedural": True,
+                        "plate": os.path.isfile(p),
+                        "plate_bytes": os.path.getsize(p) if os.path.isfile(p) else 0})
+    out.sort(key=lambda s: (not s.get("mine"), not s.get("photo"), s["key"]))
+    return out
+
+
+def map_dirs():
+    """Every maps/<stem>/ on disk with its size, and which stones point at it.
+    maps/ itself is not listed: it is the gemini-* set, which is not this
+    studio's to sweep."""
+    used = {}
+    for key in sorted(added_keys()):
+        with open(os.path.join(STONES_DIR, key + ".json"), encoding="utf-8") as fh:
+            used.setdefault(json.load(fh).get("maps") or key, []).append(key)
+    out = []
+    for name in sorted(os.listdir(MAPS_DIR) if os.path.isdir(MAPS_DIR) else []):
+        d = os.path.join(MAPS_DIR, name)
+        if not os.path.isdir(d):
+            continue
+        total = sum(os.path.getsize(os.path.join(d, f))
+                    for f in os.listdir(d) if os.path.isfile(os.path.join(d, f)))
+        out.append({"stem": name, "bytes": total, "used_by": used.get(name, []),
+                    "complete": maps_complete(name)})
+    return out
+
+
+# ---------------------------------------------------------------------------
+# jobs
+# ---------------------------------------------------------------------------
+# One at a time, and that is a correctness rule rather than politeness: two
+# bakes are two Blenders writing the same slab.json and the same digest, and two
+# map builds of one stem are two processes writing the same PNGs. The page
+# greys its buttons while one is running and the server refuses anyway.
+
+class Job:
+    def __init__(self, kind, label):
+        self.id = "%d" % (time.time_ns() // 1000)
+        self.kind = kind
+        self.label = label
+        self.lines = []
+        self.done = False
+        self.ok = False
+        self.result = {}
+        self.lock = threading.Lock()
+
+    def log(self, text):
+        with self.lock:
+            for line in str(text).rstrip("\n").split("\n"):
+                self.lines.append(line)
+
+    def view(self, start):
+        with self.lock:
+            return {"id": self.id, "kind": self.kind, "label": self.label,
+                    "from": start, "lines": self.lines[start:],
+                    "total": len(self.lines), "done": self.done,
+                    "ok": self.ok, "result": self.result}
+
+
+class Runner:
+    def __init__(self):
+        self.job = None
+        self.lock = threading.Lock()
+        self.history = {}
+
+    def busy(self):
+        j = self.job
+        return j if (j is not None and not j.done) else None
+
+    def start(self, kind, label, fn):
+        with self.lock:
+            if self.busy():
+                return None
+            job = Job(kind, label)
+            self.job = job
+            self.history[job.id] = job
+        def wrap():
+            try:
+                job.result = fn(job) or {}
+                job.ok = True
+            except Exception as exc:
+                job.log("")
+                job.log("! %s: %s" % (type(exc).__name__, exc))
+            finally:
+                job.done = True
+        threading.Thread(target=wrap, daemon=True).start()
+        return job
+
+    def get(self, jid):
+        return self.history.get(jid)
+
+
+RUN = Runner()
+
+
+class Tee(io.TextIOBase):
+    """build_maps() reports what it is doing by printing, and it is worth
+    watching - the mineral split it prints is what decides between the `deep`
+    and `asis` grades. Redirecting the process-wide stdout is safe only because
+    exactly one job runs at a time and the request threads log to stderr."""
+
+    def __init__(self, job, also):
+        self.job, self.also, self.buf = job, also, ""
+
+    def write(self, text):
+        self.also.write(text)
+        self.buf += text
+        while "\n" in self.buf:
+            line, self.buf = self.buf.split("\n", 1)
+            self.job.log(line)
+        return len(text)
+
+    def flush(self):
+        self.also.flush()
+
+
+def stream(job, cmd, cwd=ROOT):
+    job.log("$ " + " ".join(('"%s"' % c if " " in c else c) for c in cmd))
+    p = subprocess.Popen(cmd, cwd=cwd, stdout=subprocess.PIPE,
+                         stderr=subprocess.STDOUT, text=True,
+                         encoding="utf-8", errors="replace", bufsize=1)
+    for line in p.stdout:
+        job.log(line)
+    return p.wait()
+
+
+def find_blender(explicit=None):
+    return add_stone.find_blender(explicit)
+
+
+# ---------------------------------------------------------------------------
+# the three things a job can be
+# ---------------------------------------------------------------------------
+
+def ensure_maps(job, src_name, size, square):
+    """The maps for one photograph, built if this triple has never been built.
+
+    Returns the stem. Never rebuilds a complete directory: the stem is a digest
+    of everything that decides what is in it, so a directory that exists and is
+    complete is by construction the right one.
+    """
+    src = os.path.join(SOURCES, os.path.basename(src_name))
+    if not os.path.isfile(src):
+        raise SystemExit("no such source: %s" % src_name)
+    # build_maps() resamples to whatever it is handed, UP as well as down, and a
+    # map upscaled past its source is cost with nothing in it. Clamped here the
+    # way add-stone.py clamps it, and against the edge that SURVIVES the crop, so
+    # a square cut out of a long photograph is measured as what it will be. The
+    # clamped number is what the stem is taken from, so asking for 3000 of a
+    # 2400px source lands in the same directory as asking for 2400.
+    info = probe(src)
+    edge = min(info["w"], info["h"]) if square else max(info["w"], info["h"])
+    size = min(int(size), edge) if size else 0
+    stem = maps_stem(src, size, square)
+    out = os.path.join(MAPS_DIR, stem)
+    if maps_complete(stem):
+        job.log("maps: reusing design/plinth/maps/%s" % stem)
+        return stem
+    job.log("== maps: design/plinth/maps/%s ==" % stem)
+    saved, sys.stdout = sys.stdout, Tee(job, sys.__stdout__)
+    try:
+        st = maps_mod.build_maps(src, out, size, square)
+    finally:
+        sys.stdout = saved
+    if st and st.get("w", 0) < add_stone.SOFT_PX:
+        job.log("! %dpx of width, and the plinth wants about %d - the fine "
+                "structure will be soft, and resampling cannot put it back."
+                % (st["w"], add_stone.SOFT_PX))
+    if st and st.get("ground", 1.0) < add_stone.THIN_GROUND:
+        job.log("! ground %.0f%% - a light stone classifies as almost all "
+                "calcite and the `deep` grade has little to crush. Try `asis`."
+                % (st["ground"] * 100))
+    return stem
+
+
+def bake_job(req):
+    def run(job):
+        key = req["key"]
+        stem = ensure_maps(job, req["src"], int(req["size"]), bool(req["square"]))
+        spec = {
+            "title": req["title"],
+            "grade": req["grade"],
+            "scale": float(req["scale"]),
+            "offset": float(req["offset"]),
+            "bump": [float(req["bump"][0]), float(req["bump"][1])],
+            "sss": float(req["sss"]),
+            "coat": [float(req["coat"][0]), float(req["coat"][1])],
+            "rough": float(req["rough"]),
+            "crack": bool(req["crack"]),
+            "room": req["room"],
+            "maps": stem,
+            "src": os.path.basename(req["src"]),
+        }
+        os.makedirs(STONES_DIR, exist_ok=True)
+        path = os.path.join(STONES_DIR, key + ".json")
+        with open(path, "w", encoding="utf-8", newline="\n") as fh:
+            json.dump(spec, fh, indent=2)
+            fh.write("\n")
+        job.log("wrote design/plinth/stones/%s.json" % key)
+        blender = find_blender(req.get("blender") or None)
+        if not blender:
+            raise SystemExit(
+                "no Blender found. Set the BLENDER environment variable, put "
+                "blender on PATH, or start this with --blender <path>. The maps "
+                "and the entry are written, so re-baking is the only step left.")
+        job.log("")
+        rc = stream(job, [blender, "-b", "-P",
+                          os.path.relpath(BUILD_SLAB, ROOT), "--", key])
+        if rc != 0:
+            raise SystemExit("blender exited %d - nothing was written to the "
+                             "stylesheet." % rc)
+        plate = plate_path(key)
+        if not os.path.isfile(plate):
+            raise SystemExit("blender reported success and there is no plate at "
+                             "portfolio/img/tex/plinth-%s.webp" % key)
+        job.log("")
+        job.log("plate  %.1f KB" % (os.path.getsize(plate) / 1024.0))
+        return {"key": key, "stem": stem, "version": sidecar().get("version")}
+    return run
+
+
+def refresh_job(job):
+    """Rewrite slab.json without rendering anything.
+
+    `none` is build-slab.py's empty group. It still starts Blender - the file
+    imports bpy at the top - but it renders no stone, so this is the three
+    seconds that make a deletion visible to the picker rather than a minute.
+    """
+    blender = find_blender()
+    if not blender:
+        raise SystemExit("no Blender found, so design/plinth/slab.json cannot "
+                         "be rewritten and the picker will keep listing what "
+                         "was just deleted until it is.")
+    rc = stream(job, [blender, "-b", "-P", os.path.relpath(BUILD_SLAB, ROOT),
+                      "--", "none"])
+    if rc != 0:
+        raise SystemExit("blender exited %d" % rc)
+    return {"version": sidecar().get("version")}
+
+
+def contract_job(job):
+    rc = stream(job, [sys.executable, os.path.relpath(CONTRACT, ROOT)])
+    job.log("")
+    job.log({0: "contract holds.",
+             1: "! the contract is BROKEN - see above.",
+             }.get(rc, "! could not run (exit %d)." % rc))
+    if rc != 0:
+        raise SystemExit("check-capture-contract.py exited %d" % rc)
+    return {"exit": rc}
+
+
+# ---------------------------------------------------------------------------
+# writing the stylesheet
+# ---------------------------------------------------------------------------
+
+def apply_stone(key):
+    """Point portfolio/styles.css at `key` and restamp every plinth ?v=.
+
+    Two edits and they are independent: WHICH plate the .panel block asks for,
+    and the digest on every plinth url() in the file including the candidate
+    rules. The second happens on its own whenever any stone has been baked,
+    which is why it is done even when the stone has not changed.
+    """
+    if not os.path.isfile(plate_path(key)):
+        raise SystemExit("no plate at portfolio/img/tex/plinth-%s.webp - bake "
+                         "it before pointing the site at it." % key)
+    version = sidecar().get("version")
+    if not version:
+        raise SystemExit("design/plinth/slab.json has no version. Bake "
+                         "something, or refresh the sidecar.")
+    with open(STYLESHEET, encoding="utf-8") as fh:
+        css = fh.read()
+    hits = SITE_SRC_RE.findall(css)
+    if len(hits) != 1:
+        raise SystemExit(
+            "found %d default --panel-plinth-src declarations in "
+            "portfolio/styles.css and expected exactly one. The stylesheet has "
+            "moved under this tool; fix it by hand and say so in "
+            "docs/agents/plinth-marble.md." % len(hits))
+    was = SITE_SRC_RE.search(css)
+    before = (was.group("key"), was.group("ver"))
+    css = SITE_SRC_RE.sub(
+        lambda m: "%simg/tex/plinth-%s.webp?v=%s%s"
+                  % (m.group("lead"), key, version, m.group("tail")), css, count=1)
+    css, stamped = ANY_SRC_RE.subn(
+        lambda m: "%s?v=%s%s" % (m.group("head"), version, m.group("tail")), css)
+    with open(STYLESHEET, "w", encoding="utf-8", newline="\n") as fh:
+        fh.write(css)
+    return {"stone": key, "version": version, "stamped": stamped,
+            "was_stone": before[0], "was_version": before[1]}
+
+
+def forget_stone(key):
+    """Delete a stone this studio (or add-stone.py) wrote: the entry and the
+    plate. Never a built-in - those are the table in build-slab.py and there is
+    no file here to delete. The maps are left; they are shared between stones
+    and `sweep` is what collects them."""
+    entry = os.path.join(STONES_DIR, key + ".json")
+    if not os.path.isfile(entry):
+        raise SystemExit("`%s` has no design/plinth/stones/ entry, so it is a "
+                         "built-in and this cannot delete it." % key)
+    site = read_site()
+    if site["stone"] == key:
+        raise SystemExit("portfolio/styles.css draws `%s`. Apply another stone "
+                         "first." % key)
+    os.remove(entry)
+    gone = ["design/plinth/stones/%s.json" % key]
+    p = plate_path(key)
+    if os.path.isfile(p):
+        os.remove(p)
+        gone.append("portfolio/img/tex/plinth-%s.webp" % key)
+    return {"removed": gone}
+
+
+def sweep_maps():
+    """Every maps/<stem>/ no stone points at. Fifty megabytes each, and a bake
+    at a new `size` makes a new one, so they accumulate fast."""
+    removed = []
+    for d in map_dirs():
+        if d["used_by"]:
+            continue
+        shutil.rmtree(os.path.join(MAPS_DIR, d["stem"]))
+        removed.append({"stem": d["stem"], "bytes": d["bytes"]})
+    return {"removed": removed,
+            "bytes": sum(r["bytes"] for r in removed)}
+
+
+# ---------------------------------------------------------------------------
+# the server
+# ---------------------------------------------------------------------------
+
+def state():
+    doc = sidecar()
+    site = read_site()
+    version = doc.get("version")
+    return {
+        "root": ROOT,
+        "blender": find_blender(),
+        "sources": list_sources(),
+        "stones": stones_state(doc),
+        "maps": map_dirs(),
+        "presets": add_stone.STYLES,
+        "grades": {g: v.get("title", g) for g, v in sorted(maps_mod.GRADES.items())},
+        "rooms": list(ROOMS),
+        "taken": sorted(taken_names(doc)),
+        "block": doc.get("block"),
+        "plate": doc.get("plate"),
+        "version": version,
+        "site": site,
+        "stale": bool(version and site["version"] and version != site["version"]),
+        "soft_px": add_stone.SOFT_PX,
+        "cap_px": add_stone.CAP_PX,
+        "busy": (RUN.busy().id if RUN.busy() else None),
+    }
+
+
+def validate_bake(req):
+    doc = sidecar()
+    key = str(req.get("key", "")).strip().lower()
+    if not NAME_RE.match(key):
+        return "`%s` is not a stone name - lowercase letters, digits and " \
+               "dashes, starting with a letter or digit. It becomes a " \
+               "filename, a JSON key and a URL." % key
+    if key in taken_names(doc) and key not in added_keys():
+        return "`%s` is a stone build-slab.py already defines. A file that " \
+               "shadowed one would render as something other than what that " \
+               "file documents, so it is refused rather than merged." % key
+    if req.get("grade") not in maps_mod.GRADES:
+        return "unknown grade `%s`" % req.get("grade")
+    if req.get("room") not in ROOMS:
+        return "unknown room `%s`" % req.get("room")
+    if not str(req.get("src", "")):
+        return "pick a source photograph first."
+    req["key"] = key
+    return None
+
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    server_version = "plinth-studio"
+
+    def __init__(self, *a, **kw):
+        super().__init__(*a, directory=ROOT, **kw)
+
+    # Everything here is a working file being rewritten while the page is open -
+    # a plate re-baked under the same name, slab.json rewritten under it. A
+    # conditional GET that answered 304 would be the studio showing the render
+    # before last.
+    def end_headers(self):
+        self.send_header("Cache-Control", "no-store")
+        super().end_headers()
+
+    # The page polls /api/job three times a second while a bake runs, and a
+    # console scrolling that away is a console the Blender output cannot be read
+    # in. str() and not args[0] directly: log_error passes an int status first.
+    def log_message(self, fmt, *args):
+        if "/api/job" not in (str(args[0]) if args else ""):
+            super().log_message(fmt, *args)
+
+    def send_json(self, obj, code=200):
+        body = json.dumps(obj).encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def fail(self, message, code=400):
+        # Close rather than keep alive. A POST refused before its body has been
+        # read leaves that body in the socket, and on a keep-alive connection the
+        # next request is then parsed out of the middle of a JPEG.
+        self.close_connection = True
+        self.send_json({"error": str(message)}, code)
+
+    def body(self):
+        n = int(self.headers.get("Content-Length") or 0)
+        return self.rfile.read(n) if n else b""
+
+    def do_GET(self):
+        parts = urllib.parse.urlparse(self.path)
+        if parts.path == "/":
+            self.send_response(302)
+            self.send_header("Location", STUDIO_PAGE)
+            self.end_headers()
+            return
+        if parts.path == "/api/state":
+            return self.send_json(state())
+        if parts.path == "/api/job":
+            q = urllib.parse.parse_qs(parts.query)
+            job = RUN.get((q.get("id") or [""])[0])
+            if not job:
+                return self.fail("no such job", 404)
+            return self.send_json(job.view(int((q.get("from") or ["0"])[0])))
+        if parts.path.startswith("/api/"):
+            return self.fail("no such endpoint", 404)
+        return super().do_GET()
+
+    def do_POST(self):
+        parts = urllib.parse.urlparse(self.path)
+        try:
+            if parts.path == "/api/upload":
+                return self.upload()
+            if parts.path == "/api/bake":
+                req = json.loads(self.body() or b"{}")
+                bad = validate_bake(req)
+                if bad:
+                    return self.fail(bad)
+                return self.spawn("bake", "bake " + req["key"], bake_job(req))
+            if parts.path == "/api/refresh":
+                return self.spawn("refresh", "refresh slab.json", refresh_job)
+            if parts.path == "/api/contract":
+                return self.spawn("contract", "capture contract", contract_job)
+            if parts.path == "/api/apply":
+                req = json.loads(self.body() or b"{}")
+                return self.send_json(apply_stone(str(req.get("key", ""))))
+            if parts.path == "/api/forget":
+                req = json.loads(self.body() or b"{}")
+                return self.send_json(forget_stone(str(req.get("key", ""))))
+            if parts.path == "/api/sweep":
+                return self.send_json(sweep_maps())
+        except SystemExit as exc:
+            return self.fail(exc)
+        except Exception as exc:
+            return self.fail("%s: %s" % (type(exc).__name__, exc), 500)
+        return self.fail("no such endpoint", 404)
+
+    def spawn(self, kind, label, fn):
+        job = RUN.start(kind, label, fn)
+        if job is None:
+            return self.fail("`%s` is still running - one at a time, because "
+                             "two of them write the same files."
+                             % RUN.busy().label, 409)
+        return self.send_json({"job": job.id})
+
+    def upload(self):
+        name = self.headers.get("X-Filename") or "image"
+        n = int(self.headers.get("Content-Length") or 0)
+        if n <= 0:
+            return self.fail("empty upload")
+        if n > MAX_UPLOAD:
+            return self.fail("%.0f MB is over the %d MB cap. The maps are "
+                             "capped at %d px anyway - downscale first."
+                             % (n / 1e6, MAX_UPLOAD // (1024 * 1024),
+                                add_stone.CAP_PX))
+        stem, ext = os.path.splitext(os.path.basename(name))
+        ext = ext.lower()
+        if ext not in IMAGE_EXT:
+            return self.fail("`%s` is not one of %s" % (ext, ", ".join(IMAGE_EXT)))
+        # The name is the uploader's and lands on disk, so it is rebuilt rather
+        # than cleaned: a slug of the stem plus an extension from the allow-list
+        # above cannot carry a separator, a drive letter or a leading dot.
+        safe = slug(stem)[:60] + ext
+        os.makedirs(SOURCES, exist_ok=True)
+        path = os.path.join(SOURCES, safe)
+        i = 2
+        while os.path.isfile(path) and i < 999:
+            path = os.path.join(SOURCES, "%s-%d%s" % (slug(stem)[:60], i, ext))
+            i += 1
+        with open(path, "wb") as fh:
+            fh.write(self.body())
+        try:
+            info = probe(path)
+        except Exception as exc:
+            os.remove(path)
+            return self.fail("that did not decode as an image (%s)" % exc)
+        info["name"] = os.path.basename(path)
+        info["url"] = "/design/plinth/sources/" + urllib.parse.quote(info["name"])
+        return self.send_json(info)
+
+
+class Server(http.server.ThreadingHTTPServer):
+    # SO_REUSEADDR IS OFF, AND THAT IS THE POINT. http.server turns it on, and
+    # on Windows that does not mean "reuse a socket in TIME_WAIT" - it means a
+    # second process may bind a port another process is still LISTENING on, at
+    # which point the two split the incoming connections between them with no
+    # error on either side. A studio left running in another window then answers
+    # half of this one's requests, from a different worktree, and the symptom is
+    # a page that intermittently shows the wrong stone and a curl that gets an
+    # empty reply. Off, the second one refuses to start and says the port is
+    # taken, which is the true statement.
+    allow_reuse_address = False
+    daemon_threads = True
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__.splitlines()[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="Serves the repository at 127.0.0.1 only. It writes to "
+               "design/plinth/{sources,maps,stones}/, portfolio/img/tex/, and "
+               "- when you press Apply - portfolio/styles.css.")
+    ap.add_argument("--port", type=int, default=4180)
+    ap.add_argument("--blender", default=None,
+                    help="path to blender.exe, if it is not on PATH, in "
+                         "$BLENDER, or where Windows put it")
+    ap.add_argument("--no-open", action="store_true",
+                    help="do not open a browser")
+    args = ap.parse_args()
+
+    if args.blender:
+        os.environ["BLENDER"] = args.blender
+    os.makedirs(SOURCES, exist_ok=True)
+
+    url = "http://127.0.0.1:%d%s" % (args.port, STUDIO_PAGE)
+    blender = find_blender()
+    print("plinth studio   %s" % url)
+    print("repository      %s" % ROOT)
+    print("blender         %s" % (blender or
+                                  "NOT FOUND - baking will fail. --blender, "
+                                  "$BLENDER, or PATH."))
+    site = read_site()
+    print("the site draws  %s  (?v=%s)" % (site["stone"], site["version"]))
+    print("\nctrl-c to stop.\n")
+    if not args.no_open:
+        threading.Timer(0.4, webbrowser.open, (url,)).start()
+    try:
+        srv = Server(("127.0.0.1", args.port), Handler)
+    except OSError as exc:
+        sys.exit("cannot listen on 127.0.0.1:%d (%s).\n\nAnother studio is "
+                 "probably already running - use it, or start this one with "
+                 "--port." % (args.port, exc))
+    try:
+        srv.serve_forever()
+    except KeyboardInterrupt:
+        print("")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/agents/plinth-marble.md
+++ b/docs/agents/plinth-marble.md
@@ -141,7 +141,34 @@ Then:
 
 `proc` | `photo` | `relit` | `all` | a single stone name. ~5 s each.
 
-### Putting a different photograph on the plinth
+### Putting a different photograph on the plinth, without a terminal
+
+`python design/plinth/plinth-studio.py`, then open what it prints. It is the
+whole pipeline behind one page: drop an image, move every slider a stone has,
+bake, look at it standing under the real Frame, write it into `styles.css`. Its
+own docstring is the reference; what matters from outside it is:
+
+- **It serves the tree it is started in**, like `render.mjs` and unlike
+  `preview_start` — so a stone tried out in a worktree is tried out against that
+  worktree's `/portfolio`.
+- **Maps are cached per photograph**, keyed by a digest of the image bytes and
+  the two options that change what the maps are (`size`, `square`). So a second
+  bake of one photograph at a different `scale` is fifteen seconds of Cycles and
+  not another fifty megabytes of PNG — which is the one thing `add-stone.py`
+  cannot do, because it is a one-shot and rebuilds them every run.
+- **It writes `portfolio/styles.css`** when Apply is pressed, and nothing else
+  outside `design/plinth/` and `portfolio/img/tex/`. It restamps every plinth
+  `?v=` in the file at the same time, which is the drift that went unnoticed for
+  two bakes in #106–#114. It does not commit, and applying a stone is a change to
+  `/portfolio`'s colour — run the capture contract before merging one.
+- **The only thing it draws rather than renders is the window**: the block's
+  footprint laid on the photograph, from `build_photo_material()`'s own
+  arithmetic. That answers `scale` and `offset` before paying for a bake, and it
+  is honest about answering nothing else. There is deliberately no GLSL previz of
+  a photographic material — see "Still open" for why the tuner does not have one
+  either.
+
+### Putting a different photograph on the plinth, from the command line
 
 `design/plinth/add-stone.py`, and **not** by running `build-portoro-maps.py` by
 hand — that writes `maps/`, which every `gemini-*` stone reads, so it silently
@@ -377,7 +404,12 @@ colour. It stays a gate for any change that points the stylesheet at a new stone
 - **`plinth-tuner.html` is stale and now more so.** It reimplements the
   procedural material in GLSL and cannot preview a photo-backed stone at all.
   `slab.json` carries `photo_candidates` so the tuner can list them and say it
-  cannot draw them. Issue #69 covers tuner work.
+  cannot draw them. Issue #69 covers tuner work. **The studio does not replace
+  it and does not try to**: the tuner previews a PROCEDURAL stone without
+  rendering it, which is the thing it is for, and the studio bakes a
+  PHOTOGRAPHIC one and shows the render. Neither can do the other's job — a
+  photograph cannot be previewed in GLSL without the photograph, and a
+  procedural stone has no photograph to drop on the studio.
 - **The top face is still the weak face.** In the dark room it is dark, which is
   correct for polished black stone in a dark room, but it leans entirely on the
   CSS reflection for interest.

--- a/portfolio/styles.css
+++ b/portfolio/styles.css
@@ -2474,12 +2474,19 @@ body::after {
      re-rendered plate under an unchanged URL is served stale for up to 24 hours
      while being right on localhost.
 
-     `gemini-noir` is the stone: cut from a photograph by design/plinth/add-stone.py
-     and lit in the dark room, which is the pair docs/agents/plinth-marble.md
-     measures as the one that keeps the black black. It replaces `nero`, the
-     procedural stone the earlier fitted room lit as flat grey smoke — kept below
-     as a candidate rather than dropped, because it is what every proportion in
-     this block was measured against. */
+     THE DECLARATION BELOW IS MACHINE-WRITTEN, so it and not this comment is
+     which stone the site draws. design/plinth/plinth-studio.py rewrites the one
+     line — the filename and the digest together — every time a stone is applied
+     in it, and it cannot rewrite prose, so a paragraph here naming a stone would
+     go stale the first time one was picked and read as authority while doing it.
+     Which stone is drawn and why is docs/agents/plinth-marble.md's to say.
+
+     What belongs here is the standing constraint: whatever is named, it is lit in
+     the DARK room. A surround fitted to a light stone pins a black ground at a
+     flat 24 whatever the texture under it says, which is the fault that doc took
+     three wrong diagnoses to find. `nero` is kept below as a candidate rather
+     than dropped, because it is the procedural stone every proportion in this
+     block was measured against. */
   --panel-plinth-src: url("img/tex/plinth-gemini-noir.webp?v=912aa827");
 
   position: relative;


### PR DESCRIPTION
Four commands in a fixed order stood between a photograph and a stone on
the site: build-portoro-maps.py to take the picture apart, build-slab.py
inside Blender to light it, add-stone.py over the top of both for four
fixed presets, and then portfolio/styles.css edited by hand with a digest
in it that goes stale without saying so. design/plinth/plinth-studio.py is
those four behind one page — drop an image, move every parameter a stone
has, bake, look at it standing under the real Frame, write it into the
stylesheet.

It is a server rather than a page, and it has to be: making a plinth means
resampling into four PBR maps and then path-tracing them, and a browser can
do neither. It serves the repository too, so /portfolio in its iframe and
the plates in its strip come off one origin — and off the tree it was
started in, which preview_start does not.

Three things it knows that the commands do not:

MAPS ARE PER-IMAGE, NOT PER-STONE. Cached under a digest of the image bytes
and the two options that change what the maps contain, so a second bake at a
different scale is fifteen seconds of Cycles and not another fifty megabytes
of PNG. Content-addressed and not name-addressed deliberately: a directory
keyed by a name is a directory the next photo.jpg silently overwrites, which
is the failure docs/agents/plinth-marble.md warns about for maps/ itself.

THE ?v= IS A DIGEST OF EVERY PLATE, so it moves whenever any stone is baked,
including one only being tried out. Apply rewrites the default declaration
and restamps every plinth url() in the file together, and the page carries a
warning whenever the two have drifted — the drift that survived #108 and
#114 unnoticed and shipped a day-stale name for a file that had changed
twice.

A STONE IT WRITES IS A FILE, not a table entry: design/plinth/stones/<key>.json,
the same door add-stone.py uses. A name build-slab.py already defines is
refused rather than merged, because a file that shadowed one would render as
something other than what that file documents.

The only thing on the page drawn rather than rendered is the WINDOW — the
block's footprint laid over the photograph, from build_photo_material()'s own
arithmetic, so scale and offset are answered before a bake is paid for. There
is no GLSL previz of a photographic material and there should not be one: the
plinth tuner has one for the procedural stones and says out loud that it
cannot draw these, and a plausible approximation of a path-traced mirror is
worse than no approximation.

Two small changes outside the new files. build-slab.py gains a `none` group,
which renders nothing and rewrites slab.json alone — three seconds of
starting Blender instead of a minute of re-rendering something to make the
picker notice a stone was deleted. And the WHICH STONE comment in styles.css
stops naming a stone: the declaration under it is machine-written now, and a
paragraph that cannot be rewritten with it would go stale the first time one
was applied while still reading as authority.

Verified end to end in the worktree: upload, bake, plate, strip, the stone
under the real Frame, apply, the stale-digest warning, delete, sweep. The
window guide's arris lands at exactly V = offset, measured off the canvas.
check-capture-contract.py passes — this change to /portfolio is a comment.
