### PR TITLE
Give the Panel several ways to leave, mixable per group (#74)

### DIFF
--- a/design/README.md
+++ b/design/README.md
@@ -61,24 +61,34 @@ design/
                          whole CANDIDATES table. WRITTEN BY IT, never by hand:
                          it is how the tuner below avoids holding a second copy
                          of constants that would drift out from under it.
-    plinth-tuner.html    interactive: the Panel's four by-eye decisions on one
+    plinth-tuner.html    interactive: the Panel's five by-eye decisions on one
                          page, all of them switched over the real /portfolio in
                          an iframe. Which STONE (a `data-marble` attribute and
                          nothing else, so comparing the baked plates is exact),
                          which of #57's five WORDINGS the subheading carries (the
                          two text nodes .panel-sub already has), WHAT SITS BEHIND
                          the titlebar's glass (three treatments, frame-glass.js's
-                         own), and the GLASS itself — twenty-one uniforms on
+                         own), the GLASS itself — twenty-one uniforms on
                          sliders, moved through the seam at the foot of that file
-                         so the material being judged is the material that ships.
+                         so the material being judged is the material that ships
+                         — and HOW THE COMPOSITION LEAVES (#74): the text, the
+                         Frame and the plinth each on their own chip, mixable,
+                         with the five numbers behind every treatment on sliders
+                         beside them. `crossing` loads a SECOND /portfolio and
+                         stands it on the first with its ground taken away, so
+                         the Panel leaving and the Panel arriving are on the
+                         screen together; the readout beside the scrub is how
+                         thin the two ever get at once, measured off both.
                          Its one approximate half is a WebGL previz of the
                          procedural stone's recipe, for asking what a change
                          would do without paying a minute of Cycles; it is stale
                          against the current material and says so. Exports a
                          CANDIDATES entry, the styles.css rule and the bake for
-                         the stone, and for the other three the markup line, what
+                         the stone; for the middle three the markup line, what
                          shipping a treatment would take, and a `glass-state v2`
-                         blob that imports straight into glass-tuner.html.
+                         blob that imports straight into glass-tuner.html; and
+                         for the exit the markup line, the moved numbers as the
+                         declarations they are, and an `exit-state v1` blob.
     plinth-studio.py     interactive, and the only tool in design/ that is a
     plinth-studio.html   SERVER rather than a page: photograph in, stone on the
                          site out, with no command in between. Drop an image,
@@ -92,14 +102,31 @@ design/
                      replays the GitHub profile README's hourly screenshot of
                      /portfolio against a local tree, so a change can be shown
                      not to have broken it. See docs/agents/capture-contract.md
+    check-panel-clip.mjs
+                     does the Panel's recording behave the way #65 asks — it
+                     plays, loops, is silent, and under prefers-reduced-motion
+                     not one byte of either video file is fetched
+    check-panel-exit.mjs
+                     do the Panel's exit treatments behave the way #74 asks. It
+                     reads one Panel TWICE, at t and at t - 1, because that is
+                     exactly the pair a crossing holds — so the "never an empty
+                     screen" criterion is measured before there is a second Panel
+                     to measure it against. Also: the settled composition is
+                     untouched, the Rail does not leave, the document does not
+                     grow mid-crossing, the three groups really are mixable, the
+                     recording keeps playing, reduced motion pins it settled, and
+                     a phone composites one layer instead of five
 ```
 
 The **lab** compares finished candidates; the **tuner** is for arriving at one.
 The **plate tuner** does the same job for the three photographs in the page's
 corners, and the **plinth tuner** for the whole of the Projects Panel — the
 stone it stands on, the wording of its subheading, what sits behind its glass,
-and what that glass is made of. Three of those four are the real page driven in
-an iframe, so what is being looked at is what would ship. The fourth is where it
+what that glass is made of, and how the whole composition comes apart when it is
+left. Every one of the five is the real page driven in
+an iframe, so what is being looked at is what would ship — the exit twice over,
+because `crossing` puts a second real page on top of the first rather than
+drawing a picture of one. THE STONE is where it
 is worth knowing which half of the page you are reading: the baked plates are the
 real render and comparing them is exact, while the previz beside them is an
 approximation of Cycles and says nothing reliable about where an individual vein

--- a/design/plinth/plinth-tuner.html
+++ b/design/plinth/plinth-tuner.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Panel tuner — the marble, the wording, the glass</title>
+  <title>Panel tuner — the marble, the wording, the glass, the exit</title>
   <style>
     :root { color-scheme: light dark; --ui: #1a1917; --ui-bg: #fcfbf8; --ui-panel: #f5f2ea; --ui-line: #d6d0c4; --ui-mut: #6f6a5d; --ui-hit: #8a5a2b; }
     @media (prefers-color-scheme: dark) {
@@ -115,6 +115,31 @@
     .vhead button { padding: 0.1rem 0.4rem; font-size: 11px; }
     .note { margin: 0.4rem 0.7rem 0; padding: 0.4rem 0.5rem; border-left: 2px solid var(--ui-line); color: var(--ui-mut); font-size: 11px; }
 
+    /* ---- the exit strip ----------------------------------------------------
+       The scrub is the one control on this page that is a POSITION IN TIME
+       rather than a value, so it gets the whole width the three chip rows leave
+       and sits on the strip that never scrolls. -1 is a Panel that has not
+       arrived, +1 one that has left, and the middle is the composition as it is
+       drawn. */
+    .exitrow { display: flex; align-items: center; gap: 0.3rem; }
+    .exitrow > strong { flex: 0 0 auto; }
+    #scrub { flex: 1 1 12rem; min-width: 8rem; accent-color: var(--ui-hit); }
+    #presence { font: 11px/1 ui-monospace, Consolas, monospace; color: var(--ui-mut); min-width: 15rem; }
+    #presence.thin { color: var(--ui-hit); }
+
+    /* THE TWO COMPOSITIONS, ONE OVER THE OTHER, which is the only arrangement
+       that answers the question the crossing asks: is there ever a moment when
+       neither is on the screen. Side by side would show two Panels and no
+       crossing. The incoming copy takes no pointer events — it is a picture of
+       what is arriving, not a second page to drive. */
+    .pair { position: relative; flex: 0 0 auto; align-self: flex-start; }
+    .pair iframe { display: block; }
+    #ghost {
+      position: absolute; inset: 0; width: 100%; height: 100%;
+      pointer-events: none; background: transparent;
+    }
+    #ghost[hidden] { display: none; }
+
     /* ---- export drawer ---------------------------------------------------- */
     .drawer { flex: 0 0 auto; border-top: 1px solid var(--ui-line); background: var(--ui-panel); }
     .drawer > .ghead { border-top: 0; }
@@ -164,6 +189,45 @@ size with the Frame biting the real amount out of the second line."></select>
     <span class="badge" id="glasscount" data-n="0">0 moved</span>
     <button id="glassreset">reset glass</button>
   </div>
+  <!-- THE EXIT, AND IT IS THREE CHOICES RATHER THAN ONE. #74 asks for the text,
+       the Frame and the plinth to be able to leave differently — direction, rate,
+       and whether they go together or separately — so the three rows here are
+       independent and the point of the page is the COMBINATION. The five numbers
+       behind each treatment are in the sidebar; these chips are the starting
+       points, and dragging past one of them is the intended use rather than an
+       abuse of it.
+
+       THE SCRUB RUNS FROM -1 TO +1 and the whole design of the treatments is in
+       that sign. +1 is this Panel gone, -1 is this Panel not arrived yet, and a
+       crossing at progress t holds the outgoing Panel at t and the incoming one
+       at t - 1. So the scrub is not "how far through the animation" — it is
+       where in the crossing THIS composition stands, and `crossing` below puts
+       the other one on top of it at the other value. -->
+  <div class="top exitrow">
+    <strong>exit</strong>
+    <div class="chips" id="exit-text"></div>
+    <div class="chips" id="exit-frame"></div>
+    <div class="chips" id="exit-plinth"></div>
+    <span class="badge" id="exitcount" data-n="0">0 moved</span>
+    <button id="exitreset">reset exit</button>
+  </div>
+  <div class="top exitrow">
+    <strong>scrub</strong>
+    <input type="range" id="scrub" min="-1" max="1" step="0.005" value="0"
+           aria-label="where in the crossing this Panel stands"
+           title="-1 arriving · 0 settled · +1 gone. A crossing holds the outgoing Panel
+at t and the incoming one at t - 1, which is what `crossing` shows.">
+    <span class="ms" id="scrubval">0.000</span>
+    <button id="settle">settle</button>
+    <button id="play">play ▶</button>
+    <button id="crossing" aria-pressed="false"
+            title="Loads a SECOND /portfolio and stands it on top of this one at t - 1, so the
+Panel leaving and the Panel arriving are on the screen together. It is a whole
+second page — a second WebGL titlebar and a second recording — so it is off
+until asked for.">crossing</button>
+    <span class="grow"></span>
+    <span id="presence"></span>
+  </div>
   <p class="warn" id="warn"></p>
 
   <div class="wrap">
@@ -184,13 +248,22 @@ size with the Frame biting the real amount out of the second line."></select>
             <h3>the wording, the backdrop, the glass <button id="copy-panel">copy</button></h3>
             <textarea id="out-panel" spellcheck="false" readonly style="height:13rem"></textarea>
           </div>
+          <div class="out">
+            <h3>the exit treatments <button id="copy-exit">copy</button></h3>
+            <textarea id="out-exit" spellcheck="false" readonly style="height:13rem"></textarea>
+          </div>
         </div>
       </div>
     </aside>
 
     <main class="stage">
       <div class="sheet"><ol id="sheet"></ol></div>
-      <iframe id="frame" src="/portfolio/" title="/portfolio"></iframe>
+      <div class="pair">
+        <iframe id="frame" src="/portfolio/" title="/portfolio"></iframe>
+        <!-- No `src` until `crossing` is pressed, so the second page is never
+             fetched by a session that is not judging a crossing. -->
+        <iframe id="ghost" title="/portfolio — the Panel arriving" hidden></iframe>
+      </div>
     </main>
   </div>
 
@@ -298,6 +371,13 @@ size with the Frame biting the real amount out of the second line."></select>
   var behindEl = document.getElementById("behind");
   var glassCountEl = document.getElementById("glasscount");
   var glassMsEl = document.getElementById("glassms");
+  var outExit = document.getElementById("out-exit");
+  var ghost = document.getElementById("ghost");
+  var scrubEl = document.getElementById("scrub");
+  var scrubValEl = document.getElementById("scrubval");
+  var presenceEl = document.getElementById("presence");
+  var exitCountEl = document.getElementById("exitcount");
+  var crossBtn = document.getElementById("crossing");
 
   var slab = null;           /* what build-slab.py says */
   var doc = null, win = null, panel = null;
@@ -318,7 +398,17 @@ size with the Frame biting the real amount out of the second line."></select>
   var glassDefaults = null;  /* window.panelGlass.defaults, once the frame is up */
   var stoneEl = null;        /* the stone's own controls, rebuilt per stone */
   var glassEl = null;        /* the glass's, built once */
+  var exitEl = null;         /* the exit's, rebuilt when a treatment changes */
   var clipLoop = 0;          /* the rAF that keeps a MOVING backdrop moving */
+  var exitPick = {};         /* group -> treatment name */
+  var exitShipped = {};      /* what the page arrived carrying, or null */
+  var exitChosen = false;    /* did exitPick come from a stored session */
+  var exitVals = {};         /* "text.rate" -> number, sparse, moved off the treatment */
+  var exitDefaults = {};     /* the same keys, read off the page under the treatment */
+  var exitT = 0;             /* the scrub: where in the crossing this Panel stands */
+  var crossing = false;      /* is the second /portfolio loaded and standing on this one */
+  var ghostDoc = null, ghostPanel = null;
+  var playLoop = 0;          /* the rAF running a crossing, in THIS document */
 
   function warn(msg) { warnEl.textContent = msg || ""; }
 
@@ -469,6 +559,101 @@ size with the Frame biting the real amount out of the second line."></select>
       tip: "The recording carrying on up under the chrome. The only one of the three that is\nvisibly not the design render, and the only one that costs: the backdrop moves, so\nthe four passes run EVERY FRAME for as long as the page is open. Nothing else on\nthis Panel renders per frame.\nSelecting it starts that loop here so the cost is a number you can read beside the\npicture rather than a warning you have to believe." }
   ];
 
+  /* ---- the exit -----------------------------------------------------------
+     #74: how the composition comes apart when it is left. THREE GROUPS THAT DO
+     NOT KNOW ABOUT EACH OTHER, which is the whole ticket — the point is the
+     combination, not a menu of presets, so the text, the Frame and the plinth
+     are three independent picks and everything below is per group.
+
+     THE CHIPS ARE STARTING POINTS AND THE SLIDERS ARE THE CONTROL. Every named
+     treatment in styles.css is exactly five numbers — x, y, scale, fade and the
+     rate — and there is no rule over there that knows a treatment's name, so
+     dragging past a chip is not leaving the system, it is using it. That is why
+     the export writes the five numbers as well as the name: a mixture arrived at
+     here is as shippable as one of the five.
+
+     NOTHING HERE RESTATES WHAT THE PAGE IS SET TO. The defaults are read off the
+     real .panel under the treatment currently applied, the same way the glass
+     reads `window.panelGlass.defaults` — so "moved" means moved from what the
+     chip gives you, and a number edited in styles.css arrives here as the new
+     default rather than being shadowed by a copy of the old one.
+
+     WHY THE RATE IS SHAPED AND NOT SCALED, because it is the one control whose
+     obvious form is wrong and the slider gives no hint. "Leaves faster" as a
+     multiplier on the crossing empties the screen: a group at twice the rate is
+     gone half way through while the incoming copy of it has not begun. So the
+     rate re-shapes a ramp that still spans the whole crossing —
+     f(u) = rate*u + (1-rate)*u*u — and the readout beside the scrub is what
+     that costs, measured off both compositions rather than asserted here. */
+  var EXIT_ROWS = [
+    { k: "rate", prop: "rate", label: "rate", min: 0, max: 2, step: 0.01, dp: 2,
+      tip: "The SHAPE of the ramp, not its speed — the group always spans the whole crossing.\n1 is a straight line and conserves presence exactly. Below 1 it hangs on and then\ngoes; above 1 it goes at once and eases in, and both compositions are thinner in\nthe middle of the crossing for it. The presence readout beside the scrub is the\nnumber that costs." },
+    { k: "dir", prop: "dir", label: "direction", min: -1, max: 1, step: 2, dp: 0,
+      tip: "Flips x and y together, so `lift` and a fall are one treatment and a sign rather\nthan two names. -1 or +1." },
+    { k: "x", prop: "x", label: "travel across", min: -0.3, max: 0.3, step: 0.005, dp: 3,
+      tip: "A share of --panel-w, the composition's own width — so the drawing travels the same\nfraction of itself at every window size. Negative is leftwards.\nThe section clips across, so a slab or a Frame going sideways is cut at the page's\nedge rather than making a scrollbar." },
+    { k: "y", prop: "y", label: "travel down", min: -0.3, max: 0.3, step: 0.005, dp: 3,
+      tip: "A share of --panel-w, as across. Positive is downwards.\nThe section clips both ways while a crossing can happen — see THE EXIT TREATMENTS —\nso a plinth sinking does not make the document taller for the length of it." },
+    { k: "scale", prop: "scale", label: "shrink by", min: 0, max: 0.6, step: 0.005, dp: 3,
+      tip: "How much of itself the group gives up by the far end. The Frame scales about its\nFOOT, because it stands on the plinth and the reflection is folded about that same\nline — scaling about the middle floats the window off the stone." },
+    { k: "fade", prop: "fade", label: "fade by", min: 0, max: 1, step: 0.01, dp: 2,
+      tip: "How much opacity the group gives up by the far end. 1 leaves nothing; 0 is the\n`hold` treatment — the group does not leave at all." }
+  ];
+
+  /* The text's three blocks travel different DISTANCES over one ramp rather than
+     at different times, which is what keeps the stagger from opening a gap per
+     block on the way in. A negative multiplier sends a block the other way — it
+     is what `scatter` is. */
+  var EXIT_TEXT_ROWS = [
+    { k: "headK", prop: "head-k", label: "masthead x", min: -3, max: 3, step: 0.1, dp: 1,
+      tip: "The masthead and the subheading, as a multiple of the text group's travel." },
+    { k: "copyK", prop: "copy-k", label: "paragraph x", min: -3, max: 3, step: 0.1, dp: 1,
+      tip: "The paragraph. Negative sends it the other way from the rest, which is the whole\nof `scatter`: the composition opens down its middle instead of moving as a block." },
+    { k: "pointsK", prop: "points-k", label: "points x", min: -3, max: 3, step: 0.1, dp: 1,
+      tip: "The four engineering points — furthest from the masthead, so furthest travelled." }
+  ];
+
+  var EXIT_GROUPS = [
+    { k: "text", label: "text", attr: "data-exit-text",
+      probe: ".panel-head",
+      names: [
+        { k: "lift", label: "text · lift", ship: true,
+          tip: "The masthead, the paragraph and the points rise and fade together, each travelling a\ndifferent distance — the masthead least, because it is the thing the eye is holding\non to. What ships." },
+        { k: "slide", label: "text · slide",
+          tip: "The same three go sideways instead. Flip the direction to send them the other way;\nthe section clips across, so nothing reaches the page's edge." },
+        { k: "close", label: "text · close",
+          tip: "No travel at all: the type shrinks in place and fades. The quietest of the five and\nthe one that reads as the composition receding rather than leaving." },
+        { k: "dissolve", label: "text · dissolve",
+          tip: "Opacity and nothing else. The cheapest, and what the whole composition collapses to\non a phone." },
+        { k: "scatter", label: "text · scatter",
+          tip: "The paragraph goes the opposite way from the masthead and the points, so the\ncomposition opens down its middle. A negative `paragraph x` and nothing else — the\nstagger is already a per-block number and this is that number's sign." }
+      ] },
+    { k: "frame", label: "Frame", attr: "data-exit-frame",
+      probe: ".panel-stage > .panel-frame",
+      names: [
+        { k: "recede", label: "Frame · recede", ship: true,
+          tip: "The window backs off towards the stone it stands on, scaling about its own foot, and\ndims. The reflection scales with it and stays in contact. What ships." },
+        { k: "slide", label: "Frame · slide",
+          tip: "The window travels sideways off the composition, taking its reflection with it —\nacross is preserved by a mirror, so the two go the same way." },
+        { k: "sink", label: "Frame · sink",
+          tip: "The window goes down into the plinth and the reflection comes UP to meet it: the fold\nis about the contact line, so down is negated. The two meet on the marble." },
+        { k: "dissolve", label: "Frame · dissolve",
+          tip: "Opacity only. Worth trying against a plinth that holds — a window fading off a stone\nthat stays is the cheapest thing on this page that still reads as a change of\nproject." }
+      ] },
+    { k: "plinth", label: "plinth", attr: "data-exit-plinth",
+      probe: ".panel-plinth",
+      names: [
+        { k: "sink", label: "plinth · sink", ship: true,
+          tip: "The stone goes down out of the composition, taking the reflection lying in it. What\nships." },
+        { k: "slide", label: "plinth · slide",
+          tip: "The slab travels sideways. It is already wider than the composition and runs off the\npage's right edge, so this is the treatment the section's clipping was written for." },
+        { k: "dissolve", label: "plinth · dissolve",
+          tip: "Opacity only." },
+        { k: "hold", label: "plinth · hold",
+          tip: "THE STONE STAYS. The projects change and the floor they stand on does not — which is\nonly legible against a Frame and a text that DO leave, and is the reason for mixing\nrather than choosing a preset.\nIt is also the one whose crossing wants the two Panels to share a plinth rather than\nhold one each, and sharing is an arrangement only #72 can make: turn `crossing` on\nwith this selected and you are looking at two slabs in the same place. Which is\nexactly right while they are the same stone." }
+      ] }
+  ];
+
   /* ---- the glass ----------------------------------------------------------
      EVERY ROW HERE IS A UNIFORM frame-glass.js ALREADY CARRIES. Nothing is added
      and nothing is invented: the keys are its GLASS keys, spelled the way
@@ -560,13 +745,17 @@ size with the Frame biting the real amount out of the second line."></select>
      at the defaults and remembers nothing. */
   buildSubPicker();
   buildBehind();
-  /* Two hosts inside one scroller, in this order and made once: the stone's
-     controls are rebuilt every time a stone is picked and the glass's are not, so
-     they cannot share a parent that gets emptied. */
+  buildExitChips();
+  /* Three hosts inside one scroller, in this order and made once: the stone's
+     controls are rebuilt every time a stone is picked and the exit's every time
+     a treatment is — the glass's never are — so they cannot share a parent that
+     gets emptied. */
   stoneEl = document.createElement("div");
   glassEl = document.createElement("div");
+  exitEl = document.createElement("div");
   controlsEl.appendChild(stoneEl);
   controlsEl.appendChild(glassEl);
+  controlsEl.appendChild(exitEl);
 
   fetch(SIDECAR, { cache: "no-store" }).then(function (r) {
     if (!r.ok) throw new Error(r.status + " " + r.statusText);
@@ -623,6 +812,11 @@ size with the Frame biting the real amount out of the second line."></select>
        document to write into and applyGlass() has no seam to reach. */
     applySub();
     applyGlass(true);
+    /* Fourth of the four, and it races the frame's load event exactly as the
+       three above do: whichever arrives second is what the page ends up wearing,
+       and both ends read the defaults before they build the rows. */
+    applyExit();
+    buildExitControls();
     sizeFrame();
     checkShaderCurrent();
   }).catch(function (e) {
@@ -676,6 +870,14 @@ size with the Frame biting the real amount out of the second line."></select>
     doc.addEventListener("keydown", keys);
     apply();
     applySub();
+    /* The exit's defaults are the shipping page's own under whichever treatment
+       is selected, so like the glass's they cannot be read before this. Read
+       what the page arrived wearing, put the mixture on it, and only then build
+       the rows — a row built earlier would hold a `was` of nothing and call
+       every untouched slider moved. */
+    readExitShipped();
+    applyExit();
+    buildExitControls();
     /* Last, and with a redraw asked for: the glass is the only one of the four
        that costs a render, and the page has just drawn itself once with what
        ships. */
@@ -1601,6 +1803,339 @@ size with the Frame biting the real amount out of the second line."></select>
   });
 
   /* ======================================================================= */
+  /*  the exit treatments                                                    */
+  /* ======================================================================= */
+
+  /* THE PROPERTY A ROW DRIVES, and the one irregularity in the naming: the three
+     text-block multipliers belong to blocks rather than to the group, so they
+     are --exit-head-k and not --exit-text-head-k. Spelled out here rather than
+     derived twice. */
+  function exitProp(g, prop) {
+    return /-k$/.test(prop) ? "--exit-" + prop : "--exit-" + g + "-" + prop;
+  }
+  function exitRowsFor(g) {
+    return g === "text" ? EXIT_ROWS.concat(EXIT_TEXT_ROWS) : EXIT_ROWS;
+  }
+  function exitValue(g, k) {
+    var id = g + "." + k;
+    return exitVals[id] !== undefined ? exitVals[id] : exitDefaults[id];
+  }
+  function exitGroup(k) {
+    var found = null;
+    EXIT_GROUPS.forEach(function (g) { if (g.k === k) found = g; });
+    return found;
+  }
+
+  /* WHAT THE TREATMENT GIVES YOU, read off the real .panel with every inline
+     override taken away first — so "moved" means moved from the chip that is
+     selected, and changing chip changes what counts as moved. The same
+     discipline the glass reads its defaults under, one step further on: there
+     the defaults are a constant of the page, here they are a function of the
+     attribute, so they are re-read rather than cached. */
+  function readExitDefaults() {
+    if (!panel || !win) return;
+    var cs = win.getComputedStyle(panel);
+    EXIT_GROUPS.forEach(function (g) {
+      exitRowsFor(g.k).forEach(function (r) {
+        var v = parseFloat(cs.getPropertyValue(exitProp(g.k, r.prop)));
+        exitDefaults[g.k + "." + r.k] = isNaN(v) ? 0 : v;
+      });
+    });
+  }
+
+  /* One composition, put where a crossing at progress `t` would have it. Called
+     twice when the second page is up: the outgoing Panel at t and the incoming
+     one at t - 1, which is the whole of why the scrub is signed. */
+  function applyExitTo(p, t, isReal) {
+    EXIT_GROUPS.forEach(function (g) {
+      p.setAttribute(g.attr, exitPick[g.k]);
+      exitRowsFor(g.k).forEach(function (r) { p.style.removeProperty(exitProp(g.k, r.prop)); });
+    });
+    /* Between the clear and the re-apply is the ONE moment the page is showing
+       what the treatment alone says, which is the only moment its defaults can
+       be read. */
+    if (isReal) readExitDefaults();
+    EXIT_GROUPS.forEach(function (g) {
+      exitRowsFor(g.k).forEach(function (r) {
+        var id = g.k + "." + r.k;
+        if (exitVals[id] !== undefined) {
+          p.style.setProperty(exitProp(g.k, r.prop), String(exitVals[id]));
+        }
+      });
+    });
+    p.style.setProperty("--exit", String(t));
+  }
+
+  function applyExit() {
+    markExit();
+    if (!panel) { writeExit(); return; }
+    applyExitTo(panel, exitT, true);
+    if (ghostPanel) applyExitTo(ghostPanel, exitT - 1, false);
+    measurePresence();
+    writeExit();
+  }
+
+  /* ---- how thin the two compositions ever get, MEASURED ---------------------
+     #74's hardest criterion is that the outgoing Panel leaving and the incoming
+     one arriving never leave an empty screen, and the treatments are built so
+     that they cannot — every ramp is odd in --exit and spans the whole crossing,
+     so whatever has left one composition has arrived on the other. This reads
+     that back off the page rather than restating it: each group's opacity at t
+     plus the same group's opacity at t - 1, swept, and the worst of them.
+
+     1.000 is presence exactly conserved and is what the straight ramp gives.
+     Anything below is the rate control being pushed, and the readout goes amber
+     rather than the page pretending it is free. Zero would be an empty screen
+     and no setting of these sliders can reach it.
+     design/tools/check-panel-exit.mjs asserts the same number at 51 samples
+     across every treatment; 21 here is enough to drag against. */
+  var PRESENCE_FLOOR = 0.995;
+  function measurePresence() {
+    if (!panel || !win || !doc) { presenceEl.textContent = ""; return; }
+    var probes = EXIT_GROUPS.map(function (g) { return doc.querySelector(g.probe); });
+    if (probes.some(function (el) { return !el; })) { presenceEl.textContent = ""; return; }
+    function opacitiesAt(t) {
+      panel.style.setProperty("--exit", String(t));
+      return probes.map(function (el) { return parseFloat(win.getComputedStyle(el).opacity); });
+    }
+    var worst = Infinity, worstAt = 0, worstG = "";
+    for (var i = 0; i <= 20; i++) {
+      var u = i / 20;
+      var a = opacitiesAt(u), b = opacitiesAt(u - 1);
+      for (var j = 0; j < probes.length; j++) {
+        var s = a[j] + b[j];
+        if (s < worst - 1e-9) { worst = s; worstAt = u; worstG = EXIT_GROUPS[j].label; }
+      }
+    }
+    panel.style.setProperty("--exit", String(exitT));
+    presenceEl.textContent = "thinnest moment " + worst.toFixed(3) +
+      " of one composition — " + worstG + ", t " + worstAt.toFixed(2);
+    presenceEl.className = worst < PRESENCE_FLOOR ? "thin" : "";
+  }
+
+  /* ---- the chips ---------------------------------------------------------- */
+  function buildExitChips() {
+    EXIT_GROUPS.forEach(function (g) {
+      var host = document.getElementById("exit-" + g.k);
+      host.textContent = "";
+      g.names.forEach(function (t) {
+        var b = document.createElement("button");
+        b.type = "button";
+        b.dataset.exit = t.k;
+        b.textContent = t.label;
+        b.title = t.tip;
+        b.addEventListener("click", function () {
+          exitPick[g.k] = t.k;
+          exitChosen = true;
+          /* The treatment changes what the sliders' defaults ARE, so the rows
+             are rebuilt rather than repainted — a row holding the old `was`
+             would call an untouched value moved. */
+          applyExit();
+          buildExitControls();
+          save();
+        });
+        host.appendChild(b);
+      });
+      if (!exitPick[g.k]) exitPick[g.k] = g.names[0].k;
+    });
+    markExit();
+  }
+
+  function countExitMoved() {
+    var n = Object.keys(exitVals).length;
+    EXIT_GROUPS.forEach(function (g) {
+      if (exitShipped[g.k] && exitPick[g.k] !== exitShipped[g.k]) n += 1;
+    });
+    exitCountEl.textContent = n + " moved";
+    exitCountEl.dataset.n = n;
+  }
+
+  function markExit() {
+    EXIT_GROUPS.forEach(function (g) {
+      var host = document.getElementById("exit-" + g.k);
+      Array.prototype.forEach.call(host.querySelectorAll("button"), function (b) {
+        b.setAttribute("aria-pressed", b.dataset.exit === exitPick[g.k] ? "true" : "false");
+      });
+    });
+    scrubEl.value = String(exitT);
+    scrubValEl.textContent = (exitT < 0 ? "" : "+") + exitT.toFixed(3);
+    countExitMoved();
+  }
+
+  /* WHICH MIXTURE THE PAGE ARRIVED CARRYING, read rather than remembered — the
+     same reason readShippedSub() reads the subheading off the document. The three
+     attributes are in index.html precisely so that this question has an answer;
+     a page that has moved on to a treatment this table does not know reads back
+     as null and the export says so instead of quietly calling one of ours
+     shipped. */
+  function readExitShipped() {
+    if (!doc || !panel) return;
+    EXIT_GROUPS.forEach(function (g) {
+      var v = panel.getAttribute(g.attr);
+      var known = g.names.some(function (t) { return t.k === v; });
+      exitShipped[g.k] = known ? v : null;
+      if (!exitChosen && known) exitPick[g.k] = v;
+    });
+  }
+
+  /* ---- the sliders -------------------------------------------------------- */
+  function buildExitControls() {
+    /* No page, no defaults — and a row built against an undefined `was` calls
+       every slider moved and reads back NaN. The frame's load event and the
+       sidecar's promise both come back here once there is one. */
+    if (!exitEl || !panel) return;
+    exitEl.textContent = "";
+    EXIT_GROUPS.forEach(function (g) {
+      group(exitEl, "exit — " + g.label, "exit-" + g.k, function (body) {
+        exitRowsFor(g.k).forEach(function (r) {
+          var id = g.k + "." + r.k;
+          row(body, {
+            label: r.label, min: r.min, max: r.max, step: r.step, dp: r.dp, tip: r.tip,
+            onchange: applyExit
+          }, function () { return exitValue(g.k, r.k); },
+             function (v) {
+               /* Back to exactly the treatment's own number is not an override,
+                  it is having changed your mind — so it leaves the sparse set
+                  rather than sitting in it as a value that happens to match. */
+               if (Math.abs(v - exitDefaults[id]) < 1e-9) delete exitVals[id];
+               else exitVals[id] = v;
+             },
+             exitDefaults[id]);
+        });
+      });
+    });
+  }
+
+  /* ---- the scrub, and running it ------------------------------------------
+     WHERE YOU ARE STANDING IS NOT WHAT YOU HAVE CHOSEN, and separating the two
+     is what keeps `play` smooth. applyExit() re-reads the defaults, re-applies
+     every override and sweeps 21 samples to measure the crossing — none of which
+     can change while only the scrub moves, and all of which would run sixty
+     times a second through a play. This writes the one number that did change,
+     to both compositions. */
+  function positionExit() {
+    markExit();
+    if (!panel) return;
+    panel.style.setProperty("--exit", String(exitT));
+    if (ghostPanel) ghostPanel.style.setProperty("--exit", String(exitT - 1));
+  }
+  function setExit(t) {
+    exitT = Math.max(-1, Math.min(1, t));
+    positionExit();
+  }
+  scrubEl.addEventListener("input", function () {
+    stopPlay();
+    setExit(parseFloat(scrubEl.value));
+  });
+  document.getElementById("settle").addEventListener("click", function () {
+    stopPlay();
+    setExit(0);
+  });
+
+  /* A CROSSING, RUN. The scrub answers "what does it look like here"; this
+     answers "does it read", which is the question a still cannot be asked. It
+     runs -1 to +1 because that is one whole crossing seen from one Panel — the
+     composition arrives, settles for no time at all, and leaves. */
+  var PLAY_MS = 2000;
+  function stopPlay() {
+    if (playLoop) { cancelAnimationFrame(playLoop); playLoop = 0; }
+    document.getElementById("play").textContent = "play ▶";
+  }
+  document.getElementById("play").addEventListener("click", function () {
+    if (playLoop) { stopPlay(); return; }
+    this.textContent = "stop ■";
+    var t0 = performance.now();
+    (function step() {
+      var u = (performance.now() - t0) / PLAY_MS;
+      if (u >= 1) { stopPlay(); setExit(1); return; }
+      setExit(-1 + 2 * u);
+      playLoop = requestAnimationFrame(step);
+    })();
+  });
+
+  /* ---- the Panel arriving --------------------------------------------------
+     A SECOND /portfolio, STOOD ON THE FIRST WITH ITS GROUND TAKEN AWAY, and the
+     stripping is the truthful model rather than a cheat: in a real crossing
+     there is ONE page and two compositions on it, so a second document keeping
+     its own body background would be showing something that never happens. What
+     is left of the second page is the section and nothing else.
+
+     IT IS THE SAME PROJECT, BECAUSE THERE IS ONLY ONE. #58 puts the Eater Map
+     and the Record Engine out of scope and #72 is where a second Panel arrives,
+     so what stands here is this composition arriving — which is exactly the
+     right thing to judge a crossing on, and would be even if there were three.
+     Its Rail is moved to the second project so the two can be told apart at a
+     glance; that is the one thing about it that is a stand-in. */
+  /* WHAT IS TAKEN OFF THE SECOND PAGE, AND WHAT IS DELIBERATELY LEFT ON IT.
+     Only things that are out of flow are hidden — the effect stack, the three
+     corner pictures, the loading line — so the ghost's layout is the real one to
+     the pixel and its composition lands exactly where the first page's does.
+
+     .page IS LEFT ALONE, which looks like an omission and is the opposite. It is
+     a screen above the Panel and never on the ghost's screen at all; hiding it
+     would change where the section begins in the document, and arrival.js
+     measures the crossing into dark against exactly that — so a hidden CV gives
+     the ghost a different --dark and a different palette from the page under it,
+     which is the one difference that would make the two look like two documents.
+
+     .cut-title GOES INVISIBLE RATHER THAN AWAY, for the reason its own block in
+     styles.css gives about the masthead it stands in for: cut-morph.js measures
+     it on every scroll, and a display:none element measures as nothing and hands
+     the script NaN, which it then writes into an SVG path. `visibility: hidden`
+     draws nothing and measures the same as ever. There is one PROJECTS on a
+     page and this is the second page's copy of it. */
+  function styleGhost() {
+    if (!ghostDoc) return;
+    var s = ghostDoc.createElement("style");
+    s.textContent =
+      "html, body { background: transparent !important; }" +
+      ".fx, .loading, .car, .eye, .fx-ascii { display: none !important; }" +
+      "body::after { display: none !important; }" +
+      ".cut-title { visibility: hidden !important; }";
+    ghostDoc.head.appendChild(s);
+    var rail = ghostDoc.querySelectorAll(".panel-rail li");
+    if (rail.length > 1) {
+      rail[0].classList.remove("is-selected");
+      rail[1].classList.add("is-selected");
+    }
+  }
+
+  ghost.addEventListener("load", function () {
+    ghostDoc = ghost.contentDocument;
+    ghostPanel = ghostDoc && ghostDoc.getElementById("projects");
+    if (!ghostPanel) return;
+    styleGhost();
+    ghostPanel.scrollIntoView({ block: "end", behavior: "instant" });
+    applyExit();
+  });
+
+  function markCrossing() {
+    crossBtn.setAttribute("aria-pressed", crossing ? "true" : "false");
+    ghost.hidden = !crossing;
+    if (crossing && !ghost.getAttribute("src")) ghost.setAttribute("src", "/portfolio/");
+  }
+  crossBtn.addEventListener("click", function () {
+    crossing = !crossing;
+    markCrossing();
+    applyExit();
+    save();
+  });
+
+  document.getElementById("exitreset").addEventListener("click", function () {
+    exitVals = {};
+    EXIT_GROUPS.forEach(function (g) {
+      if (exitShipped[g.k]) exitPick[g.k] = exitShipped[g.k];
+    });
+    exitChosen = false;
+    exitT = 0;
+    /* The full path and not setExit(), because this is the one place the scrub
+       moves AND the values behind it do. */
+    applyExit();
+    buildExitControls();
+    save();
+  });
+
+  /* ======================================================================= */
   /*  the previz                                                             */
   /* ======================================================================= */
 
@@ -2252,6 +2787,95 @@ size with the Frame biting the real amount out of the second line."></select>
     outPanel.value = L.join("\n") + "\n";
   }
 
+  /* ---- the export: the exit -----------------------------------------------
+     THE MIXTURE AND THEN THE NUMBERS, in that order, because they are two
+     different sizes of decision. Picking three chips is a markup line; dragging
+     a slider past one of them is a stylesheet change, and it is written out as
+     the declarations it actually is rather than as a table to be transcribed.
+
+     A MOVED SLIDER IS OFFERED TWO WAYS AND BOTH ARE HONEST. Pasted into the
+     named rule it redefines that treatment for everything that ever selects it;
+     pasted as a new name it becomes a sixth chip. Which one is wanted is a
+     question about whether the author has improved `lift` or invented something
+     else, and no tuner can answer that — so it says both and names the file.
+
+     THE PRESENCE FIGURE TRAVELS WITH IT, because it is the one number that can
+     be pushed into a defect by a slider that looks harmless. 1.000 is presence
+     exactly conserved across a crossing; the rate control is the only thing that
+     moves it and the export says where it ended up. */
+  function writeExit() {
+    if (!outExit) return;
+    var L = [];
+    L.push("panel tuner — the exit treatments, #74");
+    L.push("");
+
+    if (!panel) {
+      L.push("the frame has not loaded yet, so nothing has been read off the page.");
+      outExit.value = L.join("\n") + "\n";
+      return;
+    }
+
+    var same = EXIT_GROUPS.every(function (g) { return exitPick[g.k] === exitShipped[g.k]; });
+    var unknown = EXIT_GROUPS.filter(function (g) { return !exitShipped[g.k]; });
+    L.push("THE MIXTURE — " + EXIT_GROUPS.map(function (g) {
+      return g.k + " " + exitPick[g.k];
+    }).join(", ") + (same ? ", which is what ships" : ", moved from what ships"));
+    L.push("portfolio/index.html, on <section class=\"panel\">:");
+    L.push("    " + EXIT_GROUPS.map(function (g) {
+      return g.attr + '="' + exitPick[g.k] + '"';
+    }).join(" "));
+    if (unknown.length) {
+      L.push("The page is carrying " + unknown.map(function (g) {
+        return g.attr + '="' + (panel.getAttribute(g.attr) || "nothing") + '"';
+      }).join(" and ") + ", which this table does not know.");
+      L.push("Either index.html has moved on or EXIT_GROUPS in the tuner has.");
+    }
+    L.push("");
+
+    var moved = Object.keys(exitVals);
+    L.push("THE NUMBERS — " + moved.length + " slider" + (moved.length === 1 ? "" : "s") +
+           " moved off the treatment" + (moved.length ? ":" : ", so the three chips are the whole of it."));
+    if (moved.length) {
+      EXIT_GROUPS.forEach(function (g) {
+        var mine = exitRowsFor(g.k).filter(function (r) {
+          return exitVals[g.k + "." + r.k] !== undefined;
+        });
+        if (!mine.length) return;
+        L.push("portfolio/styles.css — into .panel[" + g.attr + '="' + exitPick[g.k] + '"],');
+        L.push("  or under a name of its own beside it:");
+        mine.forEach(function (r) {
+          var id = g.k + "." + r.k;
+          L.push("    " + exitProp(g.k, r.prop) + ": " + fmt(exitVals[id], r.dp) + ";" +
+                 "    /* " + fmt(exitDefaults[id], r.dp) + " under `" + exitPick[g.k] + "` */");
+        });
+      });
+      L.push("");
+      L.push("Every travel is a share of --panel-w, the composition's own width, so a");
+      L.push("number here holds its look at every window size. The rate is a SHAPE and");
+      L.push("not a speed: the group spans the whole crossing whatever it is set to,");
+      L.push("which is what stops a crossing opening a hole. See THE EXIT TREATMENTS.");
+      L.push("");
+    }
+
+    L.push("THE CROSSING — " + (presenceEl.textContent || "not measured"));
+    L.push("Presence is each group's opacity at t plus its own at t - 1, swept: 1.000");
+    L.push("is a crossing that conserves it exactly. Nothing here can reach 0.");
+    L.push("`node design/tools/check-panel-exit.mjs` asserts the same at 51 samples,");
+    L.push("across every treatment and five rates, and checks the rest of #74 with it.");
+    L.push("");
+    L.push("NOTHING DRIVES --exit ON THE SHIPPING PAGE YET. It is declared 0 in the");
+    L.push("sheet and only a crossing between Panels moves it; #72 is that crossing.");
+    L.push("So pasting the above changes what a departure LOOKS like and does not");
+    L.push("make one happen.");
+    L.push("");
+
+    var state = { mixture: {}, values: {} };
+    EXIT_GROUPS.forEach(function (g) { state.mixture[g.k] = exitPick[g.k]; });
+    Object.keys(exitVals).forEach(function (id) { state.values[id] = exitVals[id]; });
+    L.push("exit-state v1: " + JSON.stringify(state));
+    outExit.value = L.join("\n") + "\n";
+  }
+
   function copy(el) {
     el.select();
     try { navigator.clipboard.writeText(el.value); } catch (_) { document.execCommand("copy"); }
@@ -2261,6 +2885,7 @@ size with the Frame biting the real amount out of the second line."></select>
   document.getElementById("copy-py").addEventListener("click", function (e) { e.stopPropagation(); copy(outPy); });
   document.getElementById("copy-css").addEventListener("click", function (e) { e.stopPropagation(); copy(outCss); });
   document.getElementById("copy-panel").addEventListener("click", function (e) { e.stopPropagation(); copy(outPanel); });
+  document.getElementById("copy-exit").addEventListener("click", function (e) { e.stopPropagation(); copy(outExit); });
   document.getElementById("drawer-head").addEventListener("click", function () {
     var body = document.getElementById("drawer-body");
     var hid = !body.hidden;
@@ -2294,7 +2919,19 @@ size with the Frame biting the real amount out of the second line."></select>
            a candidate and called the shipped wording moved. With the flag beside
            it an unchosen `sub` is re-corrected to whatever index.html says every
            time, and a chosen one is never touched. */
-        sub: sub, subChosen: subChosen, behind: behind, glass: glass
+        sub: sub, subChosen: subChosen, behind: behind, glass: glass,
+        /* `exitChosen` travels with `exitPick` for exactly the reason
+           `subChosen` travels with `sub` — save() is reached before the frame's
+           load event has read what the page is wearing, so a first visit would
+           otherwise store the table's first chip and call it a decision next
+           session. `exitVals` is the sparse moved set and not a snapshot, same
+           argument as `glass` above: a number edited in styles.css then arrives
+           as the new default instead of being shadowed by a stored copy.
+           THE SCRUB IS DELIBERATELY NOT STORED. It is where you are standing,
+           not what you have chosen, and a tuner that opened at --exit 0.62 would
+           open on a composition half gone with no clue why. */
+        exitPick: exitPick, exitChosen: exitChosen, exitVals: exitVals,
+        crossing: crossing
       }));
     } catch (_) {}
   }
@@ -2321,6 +2958,20 @@ size with the Frame biting the real amount out of the second line."></select>
         }
         if (s.behind && BEHIND.some(function (t) { return t.k === s.behind; })) behind = s.behind;
         if (s.glass && typeof s.glass === "object") glass = s.glass;
+        /* Every stored chip checked against the table it has to be in, for the
+           reason the stored wording is bounds-checked: a treatment can leave
+           EXIT_GROUPS between sessions, and an attribute the stylesheet has no
+           rule for would silently fall back to the base declarations while the
+           chips said something else entirely. */
+        if (s.exitPick && typeof s.exitPick === "object") {
+          EXIT_GROUPS.forEach(function (g) {
+            var v = s.exitPick[g.k];
+            if (v && g.names.some(function (t) { return t.k === v; })) exitPick[g.k] = v;
+          });
+          exitChosen = !!s.exitChosen;
+        }
+        if (s.exitVals && typeof s.exitVals === "object") exitVals = s.exitVals;
+        if (typeof s.crossing === "boolean") crossing = s.crossing;
         /* The stored stone is only put back if it is still the SAME stone —
            a re-render that changed the table should win over a session that
            was dragging the old one, and silently reviving numbers the script
@@ -2338,6 +2989,8 @@ size with the Frame biting the real amount out of the second line."></select>
        this had read anything. */
     markSub();
     markBehind();
+    markExit();
+    markCrossing();
     ready = true;
   }
 })();

--- a/design/plinth/plinth-tuner.html
+++ b/design/plinth/plinth-tuner.html
@@ -1929,7 +1929,16 @@ until asked for.">crossing</button>
           exitChosen = true;
           /* The treatment changes what the sliders' defaults ARE, so the rows
              are rebuilt rather than repainted — a row holding the old `was`
-             would call an untouched value moved. */
+             would call an untouched value moved.
+
+             A MOVED SLIDER SURVIVES THE CHIP, which is deliberate and is the
+             one thing about this control worth knowing: the chips are starting
+             points and the sliders are the choice, so a travel dragged under
+             `lift` is still there under `dissolve` and that treatment then
+             travels. It cannot happen quietly — the row stays amber against its
+             new default, the badge counts it, and the export writes the number
+             beside what the chip would have given. `reset exit` is the way back
+             to the chips alone. */
           applyExit();
           buildExitControls();
           save();

--- a/design/tools/check-panel-exit.mjs
+++ b/design/tools/check-panel-exit.mjs
@@ -1,0 +1,475 @@
+/* ============================================================================
+   check-panel-exit.mjs — do the Panel's exit treatments behave the way #74 says?
+
+     node design/tools/check-panel-exit.mjs
+
+   Exit 0 if every one of #74's behavioural criteria holds, 1 if any does not,
+   and it names which. It serves the tree it is invoked from, so it answers for
+   the working copy rather than for whatever is deployed — `preview_start`
+   serves the main checkout in this repository and would silently report on
+   `development` while looking like it reported on the branch.
+
+   WHAT IS BEING ASSERTED, AND WHAT IS DELIBERATELY NOT. Choosing a treatment is
+   not a test: it is the author scrubbing design/plinth/plinth-tuner.html and
+   picking one. What is testable is that whichever mixture is picked behaves —
+   that it settles, that it never opens a hole, that it leaves the recording
+   alone, that it disappears under `prefers-reduced-motion`, and that a phone
+   composites one layer rather than five.
+
+   THE CROSSING IS SIMULATED FROM ONE PANEL, WHICH IS THE HONEST THING TO DO
+   AND NOT A SHORTCUT. There is one Panel on the page — #72 is where a second
+   one arrives — but the whole design of the treatments is that arrival IS
+   departure reflected through zero: a crossing at progress t puts the outgoing
+   Panel at --exit t and the incoming one at t - 1. So one Panel, read twice,
+   is exactly the pair, and reading it twice is the only way to measure the pair
+   before there are two of them.
+
+   PRESENCE IS MEASURED AS COMPUTED OPACITY, and that is the right measure here
+   rather than a screenshot: every named treatment fades to nothing by the far
+   end except `hold`, which is the one that fades to nothing at all, and no
+   treatment reaches for a property that opacity does not stand for — the block
+   in styles.css is a transform and an opacity and nothing else, on purpose. A
+   pixel comparison would answer the same question more slowly and with the
+   recording, the glass and the marble in the way of it.
+   ========================================================================== */
+
+import http from "node:http";
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
+import { dirname, extname, join, normalize, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, "..", "..");
+const PAGE = "/portfolio/";
+
+/* The three groups, each named by the attribute that picks its treatment and by
+   the element the treatment actually moves. The Rail is here as a FOURTH row
+   that must not move: it names the three projects and is what a reader
+   navigates by, so a crossing that took it away would leave nothing to arrive
+   at. Asserting that is asserting a decision, which is what it is for. */
+const GROUPS = [
+  { key: "text",   attr: "data-exit-text",   sel: ".panel-head",
+    names: ["lift", "slide", "close", "dissolve", "scatter"] },
+  { key: "frame",  attr: "data-exit-frame",  sel: ".panel-stage > .panel-frame",
+    names: ["recede", "slide", "sink", "dissolve"] },
+  { key: "plinth", attr: "data-exit-plinth", sel: ".panel-plinth",
+    names: ["sink", "slide", "dissolve", "hold"] },
+];
+
+/* How thin both compositions are ever allowed to be at once. The straight ramp
+   — rate 1, which is what ships — conserves presence exactly and sums to 1 at
+   every t; the floor is below that because the rate is a control and its ends
+   are legitimately thinner in the middle of a crossing. Zero would be an empty
+   screen and is the thing #74 forbids; 0.5 is "one whole composition's worth of
+   ink, shared between the two", which is the weakest thing worth calling not
+   empty. */
+const FLOOR = 0.5;
+const RATES = [0, 0.5, 1, 1.5, 2];
+
+const MIME = {
+  ".html": "text/html; charset=utf-8", ".css": "text/css; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8", ".json": "application/json",
+  ".svg": "image/svg+xml", ".png": "image/png", ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg", ".webp": "image/webp", ".woff2": "font/woff2",
+  ".webm": "video/webm", ".mp4": "video/mp4",
+  ".ico": "image/x-icon", ".txt": "text/plain; charset=utf-8",
+};
+
+async function resolveFile(urlPath) {
+  const clean = decodeURIComponent(urlPath.split("?")[0]);
+  const target = resolve(ROOT, "." + normalize(clean).replace(/^([/\\])+/, sep));
+  if (target !== ROOT && !target.startsWith(ROOT + sep)) return null;
+  try {
+    const info = await stat(target);
+    if (info.isDirectory()) {
+      const index = join(target, "index.html");
+      await stat(index);
+      return index;
+    }
+    return target;
+  } catch {
+    return null;
+  }
+}
+
+function serve() {
+  const server = http.createServer(async (req, res) => {
+    const file = await resolveFile(req.url);
+    if (!file) return void res.writeHead(404).end("not found");
+    res.writeHead(200, { "content-type": MIME[extname(file).toLowerCase()] ?? "application/octet-stream" });
+    createReadStream(file).pipe(res);
+  });
+  return new Promise((ok) => server.listen(0, "127.0.0.1", () => ok(server)));
+}
+
+async function open(browser, origin, options) {
+  const context = await browser.newContext({
+    viewport: { width: 1440, height: 900 },
+    deviceScaleFactor: 1,
+    reducedMotion: "no-preference",
+    ...options,
+  });
+  const page = await context.newPage();
+  await page.goto(origin + PAGE, { waitUntil: "load" });
+  /* Long enough for the clip to have started and for the reflection to have
+     been cloned in — both are things the sweep below reads. */
+  await page.waitForTimeout(2500);
+  await page.evaluate(() => {
+    document.querySelector(".panel").scrollIntoView({ block: "end", behavior: "instant" });
+  });
+  await page.waitForTimeout(400);
+  return { context, page };
+}
+
+/* ---------------------------------------------------------------------------
+   The sweep. Everything below runs INSIDE the page in one call, because 51
+   samples x 2 sides x 14 treatments is 1400 reads and a round trip each would
+   make this a minute rather than a moment.
+   ------------------------------------------------------------------------ */
+const SWEEP = ([GROUPS, RATES]) => {
+  const panel = document.querySelector(".panel");
+  const shipped = {};
+  for (const g of GROUPS) shipped[g.key] = panel.getAttribute(g.attr);
+
+  const read = (sel) => {
+    const el = document.querySelector(sel);
+    if (!el) return null;
+    const cs = getComputedStyle(el);
+    return {
+      opacity: Number(cs.opacity),
+      translate: cs.translate,
+      scale: cs.scale,
+    };
+  };
+  /* `translate: 0px 0px` and `translate: none` are the same picture and the
+     browser reports whichever the declaration said. Settled means "does not
+     move", not "declares nothing". */
+  const still = (v) =>
+    v !== null &&
+    Math.abs(v.opacity - 1) < 1e-6 &&
+    (v.translate === "none" || /^(0px)( 0px)?$/.test(v.translate)) &&
+    (v.scale === "none" || v.scale === "1" || v.scale === "1 1");
+
+  const at = (t, sel) => {
+    panel.style.setProperty("--exit", String(t));
+    return read(sel);
+  };
+
+  const out = { shipped, settled: {}, sweeps: [], rail: null, growth: null, mix: null };
+
+  /* ---- 1. the settled state ------------------------------------------------ */
+  panel.style.setProperty("--exit", "0");
+  for (const g of GROUPS) out.settled[g.key] = read(g.sel);
+  out.settled.rail = read(".panel-rail");
+  out.settled.copy = read(".panel-copy");
+  out.settled.points = read(".panel-points");
+  out.settled.mirror = read(".panel-mirror > .panel-frame");
+  out.settled.stillness = Object.fromEntries(
+    Object.entries(out.settled).filter(([, v]) => v && typeof v === "object" && "opacity" in v)
+      .map(([k, v]) => [k, still(v)]),
+  );
+
+  /* ---- 2. every named treatment, at every rate, either side of zero -------- */
+  const steps = [];
+  for (let i = 0; i <= 50; i++) steps.push(i / 50);
+
+  for (const g of GROUPS) {
+    for (const name of g.names) {
+      panel.setAttribute(g.attr, name);
+      for (const rate of RATES) {
+        panel.style.setProperty("--exit-" + g.key + "-rate", String(rate));
+        let worst = Infinity, worstAt = 0, monotone = true, last = -1;
+        for (const t of steps) {
+          const leaving = at(t, g.sel);
+          const arriving = at(t - 1, g.sel);
+          const sum = leaving.opacity + arriving.opacity;
+          if (sum < worst) { worst = sum; worstAt = t; }
+          /* The ramp has to be monotone in t as well as onto [0,1], or a
+             composition would come back before it had finished going. */
+          if (leaving.opacity > last + 1e-6 && last >= 0) monotone = false;
+          last = leaving.opacity;
+        }
+        out.sweeps.push({ group: g.key, name, rate, worst, worstAt, monotone });
+      }
+      panel.style.removeProperty("--exit-" + g.key + "-rate");
+    }
+    panel.setAttribute(g.attr, shipped[g.key]);
+  }
+
+  /* ---- 3. the Rail does not leave ----------------------------------------- */
+  const railAt = steps.map((t) => at(t, ".panel-rail"));
+  out.rail = {
+    moved: railAt.some((v, i) => v.translate !== railAt[0].translate || v.scale !== railAt[0].scale),
+    faded: railAt.some((v) => Math.abs(v.opacity - railAt[0].opacity) > 1e-6),
+    opacity: railAt[0].opacity,
+  };
+
+  /* ---- 3b. past the ends, nothing keeps going -----------------------------
+     Whatever ends up driving a crossing will overshoot — an ease that settles,
+     a scroll position past the last Panel — and a composition that goes on
+     travelling after it has faded out drifts back into shot when the overshoot
+     comes back. --exit-c is the clamp that stops it and this is what says so. */
+  out.clamp = GROUPS.map((g) => ({
+    group: g.key,
+    far: JSON.stringify(at(1, g.sel)) === JSON.stringify(at(2, g.sel)),
+    near: JSON.stringify(at(-1, g.sel)) === JSON.stringify(at(-3, g.sel)),
+  }));
+
+  /* ---- 4. the document does not grow -------------------------------------- */
+  panel.style.setProperty("--exit", "0");
+  const rest = document.documentElement.scrollHeight;
+  let tallest = rest;
+  for (const t of steps) {
+    panel.style.setProperty("--exit", String(t));
+    tallest = Math.max(tallest, document.documentElement.scrollHeight);
+    panel.style.setProperty("--exit", String(t - 1));
+    tallest = Math.max(tallest, document.documentElement.scrollHeight);
+  }
+  out.growth = { rest, tallest };
+
+  /* ---- 5. the three are genuinely independent ------------------------------
+     Mixing is the whole ticket, so it is asserted rather than assumed: each
+     group is read alone at a treatment that is not the shipped one, then all
+     three are set at once and read again. Same numbers both ways means the
+     three attributes touch disjoint variables and a combination really is its
+     three parts. */
+  const alone = {}, together = {};
+  const other = (g) => g.names.find((n) => n !== shipped[g.key]);
+  for (const g of GROUPS) {
+    for (const h of GROUPS) h !== g && panel.setAttribute(h.attr, shipped[h.key]);
+    panel.setAttribute(g.attr, other(g));
+    alone[g.key] = at(0.5, g.sel);
+  }
+  for (const g of GROUPS) panel.setAttribute(g.attr, other(g));
+  for (const g of GROUPS) together[g.key] = at(0.5, g.sel);
+  for (const g of GROUPS) panel.setAttribute(g.attr, shipped[g.key]);
+  out.mix = GROUPS.map((g) => ({
+    group: g.key,
+    treatment: other(g),
+    same: JSON.stringify(alone[g.key]) === JSON.stringify(together[g.key]),
+    alone: alone[g.key], together: together[g.key],
+  }));
+
+  panel.style.setProperty("--exit", "0");
+  return out;
+};
+
+/* ---------------------------------------------------------------------------
+   The run
+   ------------------------------------------------------------------------ */
+const server = await serve();
+const origin = `http://127.0.0.1:${server.address().port}`;
+const browser = await chromium.launch();
+
+let sweep, clip, still, phone;
+try {
+  {
+    const { context, page } = await open(browser, origin);
+    sweep = await page.evaluate(SWEEP, [GROUPS.map((g) => ({ key: g.key, attr: g.attr, sel: g.sel, names: g.names })), RATES]);
+
+    /* The recording, through a whole crossing. Driven in real time rather than
+       stepped, because "keeps playing" is a statement about wall-clock: a clip
+       that has been paused reports the same currentTime however many values of
+       --exit are written over it. */
+    clip = await page.evaluate(async () => {
+      const panel = document.querySelector(".panel");
+      const video = document.querySelector(".panel-stage > .panel-frame .panel-clip");
+      if (!video) return null;
+      const started = video.currentTime;
+      const pausedAt = [];
+      const t0 = performance.now();
+      await new Promise((done) => {
+        const step = () => {
+          const u = Math.min(1, (performance.now() - t0) / 1200);
+          panel.style.setProperty("--exit", String(u));
+          if (video.paused) pausedAt.push(Number(u.toFixed(2)));
+          if (u < 1) requestAnimationFrame(step); else done();
+        };
+        requestAnimationFrame(step);
+      });
+      const ended = video.currentTime;
+      panel.style.setProperty("--exit", "0");
+      return { started, ended, advanced: ended - started, pausedAt, paused: video.paused,
+               readyState: video.readyState };
+    });
+    await context.close();
+  }
+  {
+    const { context, page } = await open(browser, origin, { reducedMotion: "reduce" });
+    still = await page.evaluate(() => {
+      const panel = document.querySelector(".panel");
+      /* Written the way a driver that never asked about the setting would write
+         it — inline, on the section — which is exactly the case the `!important`
+         in the sheet exists for. */
+      panel.style.setProperty("--exit", "1");
+      const one = (sel) => {
+        const cs = getComputedStyle(document.querySelector(sel));
+        return { opacity: Number(cs.opacity), translate: cs.translate, scale: cs.scale };
+      };
+      return {
+        exit: getComputedStyle(panel).getPropertyValue("--exit").trim(),
+        head: one(".panel-head"),
+        frame: one(".panel-stage > .panel-frame"),
+        plinth: one(".panel-plinth"),
+      };
+    });
+    await context.close();
+  }
+  {
+    /* Inside the phone gate by width alone — the gate is
+       `(max-width: 900px) and (pointer: coarse), (max-width: 600px)` and 390
+       satisfies the second half, so this does not depend on how faithfully
+       touch is emulated. */
+    const { context, page } = await open(browser, origin,
+      { viewport: { width: 390, height: 844 }, hasTouch: true, isMobile: true });
+    phone = await page.evaluate(() => {
+      const panel = document.querySelector(".panel");
+      panel.style.setProperty("--exit", "0.5");
+      const moving = (sel) => {
+        const el = document.querySelector(sel);
+        if (!el) return null;
+        const cs = getComputedStyle(el);
+        const t = cs.translate, s = cs.scale;
+        return (t !== "none" && !/^(0px)( 0px)?$/.test(t)) ||
+               (s !== "none" && s !== "1" && s !== "1 1") ||
+               Math.abs(Number(cs.opacity) - 1) > 1e-6;
+      };
+      const layers = [".panel-inner", ".panel-head", ".panel-copy", ".panel-points",
+                      ".panel-stage > .panel-frame", ".panel-plinth", ".panel-mirror > .panel-frame"];
+      const state = {};
+      for (const sel of layers) state[sel] = moving(sel);
+      panel.style.setProperty("--exit", "0");
+      return state;
+    });
+    await context.close();
+  }
+} finally {
+  await browser.close();
+  server.close();
+}
+
+/* ---------------------------------------------------------------------------
+   The report
+   ------------------------------------------------------------------------ */
+const problems = [];
+const say = (label, value) => console.log(`${label.padEnd(22)}${value}`);
+
+console.log(`serving               ${ROOT}`);
+console.log(`page                  ${PAGE}\n`);
+
+/* ---- what the page says it is wearing ----------------------------------- */
+say("shipped mixture", GROUPS.map((g) => `${g.key}=${sweep.shipped[g.key] ?? "UNSET"}`).join("  "));
+for (const g of GROUPS) {
+  if (!sweep.shipped[g.key]) {
+    problems.push(`the section carries no ${g.attr}, so nothing on the page says which ${g.key} treatment ships`);
+  } else if (!g.names.includes(sweep.shipped[g.key])) {
+    problems.push(`${g.attr}="${sweep.shipped[g.key]}" is not one of the treatments this check knows: ${g.names.join(", ")}`);
+  }
+}
+
+/* ---- 1. settled --------------------------------------------------------- */
+const notStill = Object.entries(sweep.settled.stillness).filter(([, ok]) => !ok).map(([k]) => k);
+say("settled at --exit 0", notStill.length ? `MOVED: ${notStill.join(", ")}` : "every group still, every opacity 1");
+if (notStill.length) {
+  problems.push(`at --exit 0 these are not at rest: ${notStill.join(", ")} — the treatments cost the composition something before anything has moved`);
+}
+
+/* ---- 2. the crossing never empties -------------------------------------- */
+const thin = sweep.sweeps.filter((s) => s.worst < FLOOR);
+const notMono = sweep.sweeps.filter((s) => !s.monotone);
+const worst = sweep.sweeps.reduce((a, b) => (b.worst < a.worst ? b : a));
+console.log("");
+say("treatments swept", `${sweep.sweeps.length} = ${GROUPS.map((g) => g.names.length).reduce((a, b) => a + b)} treatments x ${RATES.length} rates, 51 samples each`);
+say("thinnest moment", `${worst.worst.toFixed(3)} of one composition — ${worst.group}/${worst.name} at rate ${worst.rate}, t ${worst.worstAt.toFixed(2)}`);
+say("at the shipped rate", sweep.sweeps.filter((s) => s.rate === 1)
+  .reduce((a, b) => Math.min(a, b.worst), Infinity).toFixed(3));
+say("monotone", notMono.length ? `NO — ${notMono.length} of ${sweep.sweeps.length}` : "every ramp, every rate");
+if (thin.length) {
+  problems.push(`${thin.length} treatment/rate pairs fall below ${FLOOR} of one composition mid-crossing, the thinnest being ` +
+    `${thin[0].group}/${thin[0].name} at rate ${thin[0].rate} (${thin[0].worst.toFixed(3)} at t ${thin[0].worstAt.toFixed(2)})`);
+}
+if (notMono.length) {
+  problems.push(`${notMono.length} ramps are not monotone in the crossing's progress — a composition that comes back before it has finished going`);
+}
+
+/* ---- 3. the Rail -------------------------------------------------------- */
+say("the Rail", sweep.rail.moved || sweep.rail.faded
+  ? `LEAVES — moved ${sweep.rail.moved}, faded ${sweep.rail.faded}`
+  : `stands, at opacity ${sweep.rail.opacity}`);
+if (sweep.rail.moved || sweep.rail.faded) {
+  problems.push("the Rail moves or fades with the composition; it is the index and has to survive the crossing");
+}
+
+/* ---- 3b. the clamp ------------------------------------------------------ */
+const drifting = sweep.clamp.filter((c) => !c.far || !c.near).map((c) => c.group);
+say("past the ends", drifting.length
+  ? `KEEPS GOING — ${drifting.join(", ")}`
+  : "--exit 2 draws what 1 draws, and -3 what -1 does");
+if (drifting.length) {
+  problems.push(`${drifting.join(", ")} go on travelling past --exit +-1, so an overshooting driver sends a faded-out composition further and brings it back on the way in`);
+}
+
+/* ---- 4. the document's height ------------------------------------------- */
+say("document height", sweep.growth.tallest === sweep.growth.rest
+  ? `${sweep.growth.rest}px throughout`
+  : `GREW from ${sweep.growth.rest} to ${sweep.growth.tallest}`);
+if (sweep.growth.tallest !== sweep.growth.rest) {
+  problems.push(`the page grows by ${sweep.growth.tallest - sweep.growth.rest}px mid-crossing — a scrollbar that appears and goes away again`);
+}
+
+/* ---- 5. mixable --------------------------------------------------------- */
+const notMixable = sweep.mix.filter((m) => !m.same);
+say("mixable", notMixable.length
+  ? `NO — ${notMixable.map((m) => m.group).join(", ")} read differently alone and together`
+  : `yes — ${sweep.mix.map((m) => `${m.group}=${m.treatment}`).join("  ")} identical alone and combined`);
+if (notMixable.length) {
+  problems.push(`${notMixable.map((m) => m.group).join(", ")} do not compose: setting all three at once is not the same as setting each alone, so the treatments are presets rather than a mixture`);
+}
+
+/* ---- 6. the recording --------------------------------------------------- */
+console.log("");
+if (!clip) {
+  problems.push("there is no .panel-clip in the stage at all");
+} else {
+  say("recording", clip.pausedAt.length
+    ? `PAUSED at --exit ${clip.pausedAt.slice(0, 6).join(", ")}${clip.pausedAt.length > 6 ? " ..." : ""}`
+    : `played throughout, ${clip.advanced.toFixed(2)}s of it over a 1.2s crossing`);
+  if (clip.pausedAt.length) problems.push("the recording stops during a crossing; #74 asks it to keep playing");
+  if (clip.advanced <= 0) problems.push(`the recording did not advance across the crossing (${clip.started} -> ${clip.ended})`);
+}
+
+/* ---- 7. reduced motion -------------------------------------------------- */
+const settledUnderReduce =
+  still.exit === "0" &&
+  [still.head, still.frame, still.plinth].every((v) =>
+    Math.abs(v.opacity - 1) < 1e-6 &&
+    (v.translate === "none" || /^(0px)( 0px)?$/.test(v.translate)) &&
+    (v.scale === "none" || v.scale === "1" || v.scale === "1 1"));
+say("reduced motion", settledUnderReduce
+  ? "--exit pinned to 0 against an inline 1; settled state reached directly"
+  : `NOT REMOVED — --exit computed to "${still.exit}"`);
+if (!settledUnderReduce) {
+  problems.push("under prefers-reduced-motion a driver writing --exit still moves the composition; #74 asks for the treatments removed, not shortened");
+}
+
+/* ---- 8. lighter on a phone ---------------------------------------------- */
+const inner = phone[".panel-inner"];
+const parts = Object.entries(phone).filter(([sel]) => sel !== ".panel-inner");
+const movingParts = parts.filter(([, m]) => m).map(([sel]) => sel);
+say("on a phone", `${movingParts.length + (inner ? 1 : 0)} composited layer(s): ` +
+  (inner ? ".panel-inner" : "NOT .panel-inner") +
+  (movingParts.length ? ` and ${movingParts.join(", ")}` : " alone"));
+if (!inner) problems.push("at phone widths nothing moves at all — the treatment did not survive the reflow");
+if (movingParts.length) {
+  problems.push(`at phone widths ${movingParts.length} inner box(es) still move separately (${movingParts.join(", ")}); #74 asks for a lighter treatment there`);
+}
+
+/* ---- the report --------------------------------------------------------- */
+if (problems.length) {
+  console.error("\nFAILED");
+  for (const problem of problems) console.error(`  ${problem}`);
+  process.exit(1);
+}
+console.log("\nthe Panel's exit treatments behave the way #74 asks");

--- a/design/tools/check-panel-exit.mjs
+++ b/design/tools/check-panel-exit.mjs
@@ -152,6 +152,16 @@ const SWEEP = ([GROUPS, RATES]) => {
     (v.translate === "none" || /^(0px)( 0px)?$/.test(v.translate)) &&
     (v.scale === "none" || v.scale === "1" || v.scale === "1 1");
 
+  /* A page that has lost one of the three attributes reads back as null, and
+     `setAttribute(attr, null)` writes the STRING "null" — a value no rule
+     matches, so the sweeps that follow would run against the base declarations
+     while the report said the attribute was merely missing. Put back as absent
+     when it was absent. */
+  const restoreShipped = (g) => {
+    if (shipped[g.key]) panel.setAttribute(g.attr, shipped[g.key]);
+    else panel.removeAttribute(g.attr);
+  };
+
   const at = (t, sel) => {
     panel.style.setProperty("--exit", String(t));
     return read(sel);
@@ -195,7 +205,7 @@ const SWEEP = ([GROUPS, RATES]) => {
       }
       panel.style.removeProperty("--exit-" + g.key + "-rate");
     }
-    panel.setAttribute(g.attr, shipped[g.key]);
+    restoreShipped(g);
   }
 
   /* ---- 3. the Rail does not leave ----------------------------------------- */
@@ -238,13 +248,13 @@ const SWEEP = ([GROUPS, RATES]) => {
   const alone = {}, together = {};
   const other = (g) => g.names.find((n) => n !== shipped[g.key]);
   for (const g of GROUPS) {
-    for (const h of GROUPS) h !== g && panel.setAttribute(h.attr, shipped[h.key]);
+    for (const h of GROUPS) if (h !== g) restoreShipped(h);
     panel.setAttribute(g.attr, other(g));
     alone[g.key] = at(0.5, g.sel);
   }
   for (const g of GROUPS) panel.setAttribute(g.attr, other(g));
   for (const g of GROUPS) together[g.key] = at(0.5, g.sel);
-  for (const g of GROUPS) panel.setAttribute(g.attr, shipped[g.key]);
+  for (const g of GROUPS) restoreShipped(g);
   out.mix = GROUPS.map((g) => ({
     group: g.key,
     treatment: other(g),

--- a/docs/agents/plinth-marble.md
+++ b/docs/agents/plinth-marble.md
@@ -483,11 +483,14 @@ colour. It stays a gate for any change that points the stylesheet at a new stone
 - **`plinth-tuner.html`'s PREVIZ is stale; the rest of the page is not.** The
   page is now the Panel's variant tuner and covers all four of the things #57
   left to be chosen by eye — the stone, the subheading's wording, what sits
-  behind the titlebar's glass, and the glass itself. Three of those four are
+  behind the titlebar's glass, and the glass itself — plus #74's exit
+  treatments, which are the fifth. All of those are
   driven over the real `/portfolio` in the iframe and are exact: the stone is a
   `data-marble` attribute, the wording is the two text nodes `.panel-sub` already
-  carries, and the glass is `portfolio/frame-glass.js`'s own uniforms moved
-  through the seam at the foot of that file. What is stale is only the GLSL
+  carries, the glass is `portfolio/frame-glass.js`'s own uniforms moved
+  through the seam at the foot of that file, and the exit is three attributes and
+  one signed custom property on the section — `--exit`, which is 0 on the
+  shipping page and only a crossing between Panels moves. What is stale is only the GLSL
   material previz, which still draws the pre-bedding level sets and cannot
   preview a photo-backed stone at all — `slab.json` carries `photo_candidates`
   so the tuner can list them and say it cannot draw them. **The studio does not

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -357,7 +357,28 @@
        six other properties the capture overrides by name. The palette is
        --panel-*, declared on the section itself, so the theme toggle governs
        the page above and this composition is the same one either way. -->
-  <section class="panel" id="projects" aria-labelledby="panel-masthead">
+  <!-- HOW THIS COMPOSITION COMES APART WHEN IT IS LEFT — #74, and the three
+       attributes are the whole of the choice. The text lifts, the Frame backs
+       off towards the stone it stands on, and the plinth sinks; each of the
+       three is independent of the other two, which is the point — the treatments
+       are meant to be MIXED rather than picked as a set, and every one of them
+       is five numbers in THE EXIT TREATMENTS block in styles.css rather than a
+       rule that knows its own name. design/plinth/plinth-tuner.html is where a
+       mixture is arrived at, over this page in an iframe, by watching.
+
+       STATED HERE AND NOT LEFT TO THE STYLESHEET'S DEFAULTS, which carry these
+       same three, so that the page SAYS what it is wearing: the tuner reads
+       these three attributes off the real document to know what it is being
+       asked to beat, exactly as it reads the subheading's two text nodes. A
+       default nobody has written down is not something a tuner can call shipped.
+
+       NOTHING MOVES BECAUSE OF THEM. --exit is 0 and is declared 0 in the
+       sheet, so all three treatments resolve to the settled composition — the
+       page is byte-identical to one without them, measured, at two widths. What
+       writes --exit is a crossing between Panels, and there is only one Panel:
+       #72 is where these start being driven. -->
+  <section class="panel" id="projects" aria-labelledby="panel-masthead"
+           data-exit-text="lift" data-exit-frame="recede" data-exit-plinth="sink">
     <!-- The Rail. Three projects, one Panel: Photo Vault is the selected one and
          the other two are grey and inert until they have compositions of their
          own. They are not links yet — there is nowhere to send anyone — and #72

--- a/portfolio/styles.css
+++ b/portfolio/styles.css
@@ -3488,6 +3488,325 @@ body::after {
 }
 
 /* ============================================================================
+   THE EXIT TREATMENTS
+   ============================================================================
+   How the composition comes apart when it is left, and how the next one arrives
+   — #74. The text, the Frame and the plinth each leave in their own direction,
+   at their own rate, and the point is the COMBINATION rather than a set of
+   presets: three groups, five numbers each, mixable, and nothing here decides
+   which mixture is right. design/plinth/plinth-tuner.html is where that is
+   chosen, over the real composition, by watching.
+
+   ONE NUMBER DRIVES ALL OF IT, AND IT IS SIGNED.
+
+     --exit   -1 . . . 0 . . . +1
+              arriving  settled  gone
+
+   +1 is a Panel that has left. -1 is a Panel that has not arrived yet. Zero is
+   the composition as it is drawn today, and it is what the sheet declares — so
+   a browser that runs nothing, a reader who asked for reduced motion, and the
+   profile capture all get the settled composition and there is nothing here for
+   any of them to fast-forward into. #73 says at length why that matters and the
+   same discipline applies: no @keyframes, no animation-timeline, no registered
+   property with a scroll timeline on it. Every value below is a function of one
+   number, and that number is 0 unless something writes it.
+
+   THE ARRIVAL IS THE DEPARTURE RUN BACKWARDS THROUGH ZERO, which is not a
+   convenience — it is the whole of "the outgoing Panel leaving and the incoming
+   one arriving never leave an empty screen". A crossing at progress t puts the
+   outgoing Panel at --exit t and the incoming one at t - 1, so the two are
+   always the same distance either side of the settled state. Every ramp below
+   is ODD in --exit and MONOTONE ONTO its whole range, and those two properties
+   together are what make a hole impossible: whatever has left the outgoing
+   composition has arrived on the incoming one, in the same amount, at the same
+   instant. design/tools/check-panel-exit.mjs measures the sum across a sweep
+   rather than taking that on trust.
+
+   WHICH IS WHY THE RATE IS A SHAPE AND NOT A GAIN. "Leaves faster" written as a
+   multiplier on --exit is the obvious form and it is the one that opens the
+   hole: a group at twice the rate is gone by t = 0.5 while the incoming copy of
+   it does not begin arriving until t = 0.5, and for that instant neither is
+   drawn. So the rate below re-shapes a ramp that still spans the whole crossing:
+
+     f(u) = rate * u + (1 - rate) * u * u        u = |--exit|,  rate in [0, 2]
+
+   rate 1 is the straight line. Below 1 the group hangs on and then goes; above
+   1 it goes at once and eases in. Monotone and onto for every rate in the range
+   — f(0) = 0, f(1) = 1, f'(u) = rate + 2(1 - rate)u, which is non-negative at
+   both ends and so throughout. The signed form is `--exit * (rate + (1-rate)u)`,
+   which carries the sign in --exit itself and needs neither sign() nor pow():
+   its magnitude is exactly f(u), and a browser that has `max()` has all of it.
+
+   A TREATMENT IS FIVE NUMBERS, AND THERE IS ONE GEOMETRY.
+   Every group moves the same way and differs only in what it is told:
+
+     x       travel across, as a share of --panel-w
+     y       travel down
+     scale   how much of itself it gives up by the far end
+     fade    how much opacity it gives up by the far end
+     rate    the shape above
+
+   plus --exit-*-dir, +1 or -1, which flips x and y together. So `lift` and
+   `fall` are one treatment and a direction rather than two treatments, and a
+   combination the author reaches by dragging is expressible as five numbers per
+   group rather than as a name somebody has to have thought of first. The named
+   sets below are starting points, not the menu.
+
+   THE RAIL DOES NOT LEAVE. It names the three projects and it is what a reader
+   navigates by; a crossing that took the index away with the page would leave
+   nothing to arrive at. It keeps the --enter opacity the landing gives it and
+   nothing in this block reaches it.
+
+   THE TEXT'S STAGGER IS IN DISTANCE AND NOT IN TIME, which is the second place
+   the no-hole rule bites. Giving the masthead, the paragraph and the points
+   their own delays reads well going out and opens a gap per block coming in —
+   the outgoing masthead is gone at 0.4 while the incoming one has not started at
+   0.6. Giving them different DISTANCES over the same ramp reads as the same
+   composition coming apart and keeps every block's ramp onto its own range.
+
+   EVERYTHING IS A TRANSFORM AND AN OPACITY AND NOTHING ELSE. No blur, no
+   filter, no box-shadow, no colour interpolation — those are the properties
+   that cost a repaint per frame, and #58's user story 18 asks for the animation
+   to stay off the main thread where it can. `translate`, `scale` and `opacity`
+   composite. That is also what makes the mobile half below a reduction in
+   LAYERS rather than in movement.
+
+   THE INDIVIDUAL TRANSFORM PROPERTIES AND NOT `transform`, for one hard reason:
+   the reflection in the marble is a clone of the Frame and already carries
+   `transform: scaleY(-1)`. `translate` and `scale` compose with it instead of
+   replacing it, so the reflection can be moved without the fold being rewritten
+   here — see .panel-mirror > .panel-frame at the foot of this block, which is
+   where the one asymmetry lives. */
+.panel {
+  /* Where in the crossing this Panel is. Declared, never animated. */
+  --exit: 0;
+  /* AND THE ONLY VALUE ANYTHING BELOW READS, which is not the same property and
+     the difference is what makes this safe to hand to a driver. A crossing runs
+     one Panel from 0 to 1 while the other runs from -1 to 0, and anything
+     driving that off a scroll position, a velocity or an eased overshoot will
+     hand it 1.06 sooner or later. Unclamped, the travel keeps growing while the
+     opacity has already bottomed out, so a composition that is gone goes on
+     going — visible as a Panel that drifts back into shot when the ease
+     settles. Clamped here rather than in every driver, because there is going
+     to be more than one and they should not each have to know. */
+  --exit-c: clamp(-1, var(--exit), 1);
+  /* |--exit-c|, once, because all three groups need it and `max` is the whole of
+     abs(): the larger of a number and its negation. */
+  --exit-u: max(var(--exit-c), calc(-1 * var(--exit-c)));
+
+  /* ---- the text: the masthead, the subheading, the paragraph, the points ---- */
+  --exit-text-rate: 1;
+  --exit-text-dir:  1;
+  --exit-text-x:    0;
+  --exit-text-y:    -0.055;
+  --exit-text-scale: 0;
+  --exit-text-fade: 1;
+  /* The distance stagger — see above for why it is distances and not delays.
+     The masthead travels least because it is the thing the eye is holding on
+     to; the points travel most because they are the furthest from it. */
+  --exit-head-k:   1;
+  --exit-copy-k:   1.5;
+  --exit-points-k: 2.1;
+
+  /* ---- the Frame, and the reflection that goes with it --------------------- */
+  --exit-frame-rate: 1;
+  --exit-frame-dir:  1;
+  --exit-frame-x:    0;
+  --exit-frame-y:    0.012;
+  --exit-frame-scale: 0.14;
+  --exit-frame-fade: 1;
+
+  /* ---- the plinth ---------------------------------------------------------- */
+  --exit-plinth-rate: 1;
+  --exit-plinth-dir:  1;
+  --exit-plinth-x:    0;
+  --exit-plinth-y:    0.06;
+  --exit-plinth-scale: 0;
+  --exit-plinth-fade: 1;
+
+  /* ---- what each group's numbers come out at ------------------------------
+     -p is signed and is what travels; -m is its magnitude and is what is given
+     up. Two properties rather than one because a length wants the sign and an
+     opacity does not, and because `abs()` of an already-substituted expression
+     is the one thing this arrangement is written to avoid needing. */
+  --exit-text-p: calc(var(--exit-c) * (var(--exit-text-rate)
+                      + (1 - var(--exit-text-rate)) * var(--exit-u)));
+  --exit-text-m: calc(var(--exit-u) * (var(--exit-text-rate)
+                      + (1 - var(--exit-text-rate)) * var(--exit-u)));
+  --exit-frame-p: calc(var(--exit-c) * (var(--exit-frame-rate)
+                       + (1 - var(--exit-frame-rate)) * var(--exit-u)));
+  --exit-frame-m: calc(var(--exit-u) * (var(--exit-frame-rate)
+                       + (1 - var(--exit-frame-rate)) * var(--exit-u)));
+  --exit-plinth-p: calc(var(--exit-c) * (var(--exit-plinth-rate)
+                        + (1 - var(--exit-plinth-rate)) * var(--exit-u)));
+  --exit-plinth-m: calc(var(--exit-u) * (var(--exit-plinth-rate)
+                        + (1 - var(--exit-plinth-rate)) * var(--exit-u)));
+
+  /* The travel, resolved to lengths once per group so that the three text
+     blocks below are their own multiplier and nothing else. */
+  --exit-text-dx: calc(var(--exit-text-p) * var(--exit-text-dir)
+                       * var(--exit-text-x) * var(--panel-w));
+  --exit-text-dy: calc(var(--exit-text-p) * var(--exit-text-dir)
+                       * var(--exit-text-y) * var(--panel-w));
+  --exit-frame-dx: calc(var(--exit-frame-p) * var(--exit-frame-dir)
+                        * var(--exit-frame-x) * var(--panel-w));
+  --exit-frame-dy: calc(var(--exit-frame-p) * var(--exit-frame-dir)
+                        * var(--exit-frame-y) * var(--panel-w));
+  --exit-plinth-dx: calc(var(--exit-plinth-p) * var(--exit-plinth-dir)
+                         * var(--exit-plinth-x) * var(--panel-w));
+  --exit-plinth-dy: calc(var(--exit-plinth-p) * var(--exit-plinth-dir)
+                         * var(--exit-plinth-y) * var(--panel-w));
+
+  /* The opacity FACTOR and not the opacity, because .panel-copy already has one
+     of its own from the landing's --enter and two `opacity` declarations on one
+     element is the later one winning rather than the two multiplying. Everything
+     below multiplies by its factor instead, and the landing block does the same
+     where it sets the paragraph's. */
+  --exit-text-o:   clamp(0, calc(1 - var(--exit-text-m) * var(--exit-text-fade)), 1);
+  --exit-frame-o:  clamp(0, calc(1 - var(--exit-frame-m) * var(--exit-frame-fade)), 1);
+  --exit-plinth-o: clamp(0, calc(1 - var(--exit-plinth-m) * var(--exit-plinth-fade)), 1);
+
+  /* AND THE SECTION CLIPS BOTH WAYS WHILE A CROSSING CAN HAPPEN. It already
+     clipped across — the slab is deliberately wider than the composition and
+     runs off the page's right edge — and the reason generalises the moment
+     anything in here travels down: transformed overflow contributes to the
+     document's scrollable area at the end edges, so a plinth sinking 0.06 of
+     the composition would make the page a hundred pixels taller for the length
+     of the transition and then give it back. A scrollbar that grows mid-scroll
+     is a bug wherever it comes from. `clip` and not `hidden`, as everywhere
+     else on this page: `hidden` would make .panel a scroll container and take
+     `scroll-snap-align` with it. */
+  overflow: clip;
+}
+
+/* ---- the named starting points ---------------------------------------------
+   Each of these is the five numbers and nothing else — there is no rule below
+   that knows a treatment's name, so a combination the tuner arrives at by
+   dragging is the same kind of thing as one of these and pastes as five
+   declarations. `dir` is deliberately not set by any of them: it is the
+   author's, and flipping it turns `lift` into a fall and `slide` into a slide
+   the other way without needing a sixth name for either. */
+.panel[data-exit-text="lift"]     { --exit-text-x: 0;     --exit-text-y: -0.055; --exit-text-scale: 0;    }
+.panel[data-exit-text="slide"]    { --exit-text-x: -0.09; --exit-text-y: 0;      --exit-text-scale: 0;    }
+.panel[data-exit-text="close"]    { --exit-text-x: 0;     --exit-text-y: 0;      --exit-text-scale: 0.06; }
+.panel[data-exit-text="dissolve"] { --exit-text-x: 0;     --exit-text-y: 0;      --exit-text-scale: 0;    }
+/* The one that is not a direction: the paragraph goes the other way from the
+   masthead and the points, so the composition opens down its middle rather than
+   travelling as a block. A negative multiplier and not a second axis — the
+   stagger is already a per-block number and this is that number's sign. */
+.panel[data-exit-text="scatter"]  { --exit-text-x: -0.05; --exit-text-y: -0.045; --exit-text-scale: 0;
+                                    --exit-copy-k: -1.5; }
+
+.panel[data-exit-frame="recede"]   { --exit-frame-x: 0;     --exit-frame-y: 0.012; --exit-frame-scale: 0.14; }
+.panel[data-exit-frame="slide"]    { --exit-frame-x: -0.16; --exit-frame-y: 0;     --exit-frame-scale: 0;    }
+.panel[data-exit-frame="sink"]     { --exit-frame-x: 0;     --exit-frame-y: 0.10;  --exit-frame-scale: 0;    }
+.panel[data-exit-frame="dissolve"] { --exit-frame-x: 0;     --exit-frame-y: 0;     --exit-frame-scale: 0;    }
+
+.panel[data-exit-plinth="sink"]     { --exit-plinth-x: 0;     --exit-plinth-y: 0.06; --exit-plinth-fade: 1; }
+.panel[data-exit-plinth="slide"]    { --exit-plinth-x: -0.16; --exit-plinth-y: 0;    --exit-plinth-fade: 1; }
+.panel[data-exit-plinth="dissolve"] { --exit-plinth-x: 0;     --exit-plinth-y: 0;    --exit-plinth-fade: 1; }
+/* THE STONE STAYS. The projects change and the floor they stand on does not —
+   which is the treatment that makes mixing worth having at all, because it is
+   only legible against a Frame and a text that do leave. It is also the one
+   whose crossing wants the two Panels to SHARE a plinth rather than to hold one
+   each, and sharing is an arrangement only #72 can make; until it does, two
+   Panels crossing with `hold` both draw their own slab in the same place. Which
+   is exactly right when the two slabs are the same stone, and is worth knowing
+   before a second marble is chosen for a second project. */
+.panel[data-exit-plinth="hold"] { --exit-plinth-x: 0; --exit-plinth-y: 0;
+                                  --exit-plinth-scale: 0; --exit-plinth-fade: 0; }
+
+/* ---- and what each group actually does with its numbers -------------------- */
+.panel-head {
+  translate: calc(var(--exit-text-dx) * var(--exit-head-k))
+             calc(var(--exit-text-dy) * var(--exit-head-k));
+  scale: calc(1 - var(--exit-text-m) * var(--exit-text-scale));
+  opacity: var(--exit-text-o);
+}
+.panel-copy {
+  translate: calc(var(--exit-text-dx) * var(--exit-copy-k))
+             calc(var(--exit-text-dy) * var(--exit-copy-k));
+  scale: calc(1 - var(--exit-text-m) * var(--exit-text-scale));
+  opacity: var(--exit-text-o);
+}
+.panel-points {
+  translate: calc(var(--exit-text-dx) * var(--exit-points-k))
+             calc(var(--exit-text-dy) * var(--exit-points-k));
+  scale: calc(1 - var(--exit-text-m) * var(--exit-text-scale));
+  opacity: var(--exit-text-o);
+}
+/* The Frame, AND THE REFLECTION WITH IT, because both are `.panel-frame` — the
+   copy in the marble is a clone of this element and carries the class. So the
+   fade and the shrink reach the reflection by not being scoped, which is the
+   right answer: a window that dims has a dimmer reflection, and one that backs
+   off has a smaller one. Only the travel has to be told apart, below. */
+.panel-frame {
+  scale: calc(1 - var(--exit-frame-m) * var(--exit-frame-scale));
+  opacity: var(--exit-frame-o);
+}
+.panel-stage > .panel-frame {
+  translate: var(--exit-frame-dx) var(--exit-frame-dy);
+  /* ABOUT ITS FOOT AND NOT ITS MIDDLE, because the window stands on the plinth:
+     a Frame shrinking about its centre lifts off the stone and floats, and the
+     reflection under it — which is folded about the contact line and so already
+     has this origin — would disagree with it about where the two touch. */
+  transform-origin: bottom;
+}
+/* THE ONE ASYMMETRY IN THE BLOCK, and it is the only thing a mirror ever asks
+   for: the fold is about a horizontal line, so across is preserved and down is
+   negated. Lift the window and its reflection sinks; slide it left and the
+   reflection goes left with it. What then happens is that the reflection is cut
+   off almost at once by .panel-mirror's own `overflow: hidden` — the box is
+   3.28% of the window tall — which is also what happens in life when you lift
+   something off polished stone. */
+.panel-mirror > .panel-frame {
+  translate: var(--exit-frame-dx) calc(-1 * var(--exit-frame-dy));
+}
+.panel-plinth {
+  translate: var(--exit-plinth-dx) var(--exit-plinth-dy);
+  scale: calc(1 - var(--exit-plinth-m) * var(--exit-plinth-scale));
+  opacity: var(--exit-plinth-o);
+}
+
+/* ---- lighter on a phone: one layer instead of five --------------------------
+   #74 asks for the treatments to be lighter on mobile so that a weaker device
+   does not stutter, and the honest reduction is not in how far anything travels
+   — every property above already composites — but in HOW MANY THINGS ARE
+   COMPOSITED. Five separately transformed and separately faded boxes, two of
+   them holding a playing video and a WebGL canvas, become one: .panel-inner
+   moves and fades as a piece and nothing inside it does anything.
+
+   IT IS THE TEXT GROUP'S NUMBERS THAT SURVIVE, so a combination chosen on a
+   desktop still leaves in the direction the author chose and at the rate they
+   chose — it just leaves in one piece. That is what "lighter" costs here and it
+   is worth saying rather than discovering: on a phone the Frame does not recede
+   and the plinth cannot hold.
+
+   THE SAME GATE AS THE REFLOW ABOVE, restated rather than shared, because a
+   media query buys no specificity and these rules have to beat the ones a
+   hundred lines up. Keep the two in step.
+
+   An opacity on .panel-inner makes it a stacking context, and that is safe
+   where the same thing on .panel-stage would not be: everything the Frame has
+   to paint over — the subheading's hanging second line — is inside .panel-inner
+   with it, so their order is untouched. The .fx exclusions that DO depend on
+   .panel-stage not being one are inside the 1100px landing block and cannot
+   apply at these widths. */
+@media (max-width: 900px) and (pointer: coarse), (max-width: 600px) {
+  .panel-inner {
+    translate: var(--exit-text-dx) var(--exit-text-dy);
+    opacity: var(--exit-text-o);
+  }
+  .panel-head, .panel-copy, .panel-points,
+  .panel-frame, .panel-stage > .panel-frame, .panel-mirror > .panel-frame,
+  .panel-plinth {
+    translate: none;
+    scale: none;
+    opacity: 1;
+  }
+}
+
+/* ============================================================================
    THE EFFECT STACK
    ============================================================================
    Ten optical treatments laid over the finished page, each one a token in
@@ -4442,6 +4761,22 @@ body::after {
   .carousel { transition: none; }        /* the edge dissolve, --fade-l / --fade-r */
   .track { scroll-behavior: auto; }
   body, .theme-toggle__thumb { transition: none; }
+  /* THE EXIT TREATMENTS, REMOVED RATHER THAN SHORTENED — #74, and the same
+     posture #73 takes for the crossing and this block already takes for the
+     page turn. Every one of the three groups is a function of --exit and of
+     nothing else, so pinning that one number settles all of them: the text
+     stands where it stands, the Frame does not recede, the plinth does not sink,
+     and a navigation still arrives — at the settled state, directly.
+
+     `!important`, WHICH IS THE POINT AND NOT EMPHASIS. Whatever drives a
+     crossing writes --exit on the section, and an inline declaration beats a
+     stylesheet rule of any specificity — but not an `!important` one. So this
+     holds even against a driver that never asked about the setting, which means
+     the guarantee is the sheet's and does not have to be re-made in every file
+     that ever moves a Panel. A driver should still return early, the way
+     arrival.js does; this is what makes that a courtesy rather than the only
+     thing standing between a reader and the movement they asked not to have. */
+  .panel { --exit: 0 !important; }
 }
 @keyframes page-held-in-still {
   0%, 62.5% { opacity: 0; }
@@ -4881,8 +5216,18 @@ body::after {
      the section is below the fold at rest and has nothing to hide from, and an
      opacity on a block that carries a z-index or contains one would make a
      stacking context where the paint order above depends on there not being one.
-     Both of these are leaves. */
-  .panel-copy, .panel-rail { opacity: clamp(0, calc(var(--enter) / 0.34), 1); }
+     Both of these are leaves.
+
+     THE PARAGRAPH'S IS MULTIPLIED BY THE EXIT'S AND THE RAIL'S IS NOT, which is
+     the one place the two blocks meet. `opacity` does not accumulate across
+     declarations — the later one simply wins — so the paragraph, which is the
+     only thing on the page carrying an opacity from both, has to be written as
+     the product here rather than left to the exit block a thousand lines up. The
+     Rail is not in that product on purpose: it does not leave. See THE EXIT
+     TREATMENTS, which is where --exit-text-o comes from and why every other
+     block in the section reaches its own factor directly. */
+  .panel-copy { opacity: calc(clamp(0, calc(var(--enter) / 0.34), 1) * var(--exit-text-o)); }
+  .panel-rail { opacity: clamp(0, calc(var(--enter) / 0.34), 1); }
 }
 
 /* ---- print: clean text CV, no photos ------------------------------------- */

--- a/portfolio/styles.css
+++ b/portfolio/styles.css
@@ -2508,7 +2508,15 @@ body::after {
      that a crop rather than a horizontal scrollbar. `hidden` would do the same
      job and also make the section a scroll container, which would break the
      Rail; `clip` clips without scrolling. The `-y: visible` half is left alone
-     so nothing that leaves the section vertically is affected. */
+     here so nothing that leaves the section vertically is affected — AND THE
+     EXIT BLOCK TAKES IT BACK, which is the one place this rule is overridden.
+     It has to: a treatment that travels downwards is transformed overflow at the
+     end edge, which contributes to the document's scrollable height, so a
+     sinking plinth would make the page taller for the length of a crossing and
+     then give it back. See THE EXIT TREATMENTS, where the same `clip` is
+     restated for both axes and the reason is written out. Nothing was leaving
+     vertically for it to break: the composition is byte-identical either way at
+     1440x900, 900x1200 and 390x844. */
   overflow-x: clip;
   /* The Rail runs the full height and the composition sits in the middle of
      whatever is left over — see .panel-rail and .panel-inner, which take the two


### PR DESCRIPTION
#74. The text, the Frame and the plinth each leave in their own direction, at
their own rate, and the three are independent — the point is the combination
rather than a menu of presets, so **a treatment is five numbers** (x, y, scale,
fade, rate) rather than a rule that knows its own name. Five for the text, four
each for the Frame and the plinth, mixable across all three.

## One signed number

`--exit` runs `-1` (arriving) through `0` (settled) to `+1` (gone), and a
crossing at progress *t* holds the outgoing Panel at *t* and the incoming one at
*t − 1*. Every ramp is **odd in `--exit` and monotone onto its whole range**, and
those two properties together are what make "never an empty screen" a property of
the mechanism rather than something to be careful about: whatever has left one
composition has arrived on the other, in the same amount, at the same instant.

That is also why **the rate is a shape and not a gain**. "Leaves faster" written
as a multiplier is the obvious form and is the one that opens the hole — a group
at twice the rate is gone half way through while the incoming copy of it has not
begun. So the rate re-shapes a ramp that still spans the whole crossing,
`f(u) = rate·u + (1−rate)·u²`, which stays monotone and onto for `rate ∈ [0, 2]`
and needs neither `sign()` nor `pow()`.

`--exit` is declared `0` in the sheet and nothing animates it, so there is
nothing for the profile capture's `animations: "disabled"` to fast-forward — the
same discipline #73 argued for the crossing into dark.

## Acceptance criteria

- [x] **Several treatments built for each of text, Frame and Plinth** — 5 / 4 / 4.
- [x] **Mixed across the three groups, not only whole presets** — three
      independent attributes over disjoint variables, and the check proves it:
      setting all three at once reads identically to setting each alone.
- [x] **Switchable live in the tuner over the real composition** — a fifth
      decision in `design/plinth/plinth-tuner.html`: three chip rows, the five
      numbers behind each on sliders, a scrub, a play, and `crossing` — a second
      real `/portfolio` stood on the first with its ground taken away.
- [x] **Exportable through the existing export drawer** — a fourth box: the
      markup line, the moved numbers as the declarations they are with the
      treatment's own value beside each, and an `exit-state v1` blob.
- [x] **The outgoing Panel leaving and the incoming one arriving never leave an
      empty screen** — by construction, and measured: thinnest moment **1.000**
      at the shipped rate (presence exactly conserved) and **0.500** at the ends
      of the rate control, across 65 treatment/rate sweeps at 51 samples.
- [x] **The recording keeps playing throughout a transition** — 1.22s of it over
      a 1.2s crossing, never paused.
- [x] **Under `prefers-reduced-motion` the treatments are removed and the settled
      state is reached directly** — `--exit: 0 !important`, which beats the
      inline declaration a driver writes, so the guarantee is the sheet's.
- [x] **Lighter on mobile** — one composited layer instead of five: `.panel-inner`
      moves and fades as a piece, keeping the direction and rate chosen.
- [x] **Ticket 62's check still passes** — 592 / 852 / 80 / 80, light 188.4,
      dark 46.1, separation 142.3.

## The settled page did not move

Byte-identical PNGs against `origin/development` at 1440×900, 900×1200 and
390×844, with every box in the same place. `check-panel-clip.mjs` unchanged.

## New check

`design/tools/check-panel-exit.mjs` reads **one Panel twice**, at *t* and at
*t − 1*, because that is exactly the pair a crossing holds — so the criterion is
measured before there is a second Panel to measure it against. It also asserts
the settled state is still, every ramp monotone, nothing travelling past ±1, the
Rail standing, the document not growing mid-crossing, the three groups mixable,
the recording playing, reduced motion settled, and one layer on a phone.

## What this does not do

**Nothing drives `--exit` on the shipping page.** There is one Panel and a
crossing needs two; #72 is that crossing, and it writes one number. The
attributes are in `index.html` so the page says what it is wearing and the tuner
has something to read.
