### PR TITLE
Carry the reader into the section, and let the Rail take them there

### DIFF
--- a/design/plinth/plinth-tuner.html
+++ b/design/plinth/plinth-tuner.html
@@ -650,7 +650,7 @@ until asked for.">crossing</button>
         { k: "dissolve", label: "plinth · dissolve",
           tip: "Opacity only." },
         { k: "hold", label: "plinth · hold",
-          tip: "THE STONE STAYS. The projects change and the floor they stand on does not — which is\nonly legible against a Frame and a text that DO leave, and is the reason for mixing\nrather than choosing a preset.\nIt is also the one whose crossing wants the two Panels to share a plinth rather than\nhold one each, and sharing is an arrangement only #72 can make: turn `crossing` on\nwith this selected and you are looking at two slabs in the same place. Which is\nexactly right while they are the same stone." }
+          tip: "THE STONE STAYS. The projects change and the floor they stand on does not — which is\nonly legible against a Frame and a text that DO leave, and is the reason for mixing\nrather than choosing a preset.\nIt is also the one whose crossing wants the two Panels to share a plinth rather than\nhold one each, and sharing is an arrangement that needs a second Panel: turn `crossing` on\nwith this selected and you are looking at two slabs in the same place. Which is\nexactly right while they are the same stone." }
       ] }
   ];
 
@@ -1863,7 +1863,24 @@ until asked for.">crossing</button>
         }
       });
     });
-    p.style.setProperty("--exit", String(t));
+    setExitOn(p, t);
+  }
+
+  /* WHERE --exit IS WRITTEN, AND WHY IT IS NOT WRITTEN DIRECTLY. Since #72 the
+     shipping page drives --exit itself, off the scroll position, from
+     arrival.js — so an inline value set from out here is overwritten by the next
+     scroll or resize inside the iframe, and this tuner produces both: it puts
+     the Panel on screen with scrollIntoView, and its own panes are laid out
+     against the window. So the scrub asks arrival.js to HOLD the number instead,
+     through the handle that file exposes for exactly this, the way
+     design/cut-title/morph-tuner.html holds the morph's T.
+     The direct write is kept as the fallback and is not dead: arrival.js returns
+     before it defines anything under `prefers-reduced-motion`, and then there is
+     no driver to fight and nothing to ask. */
+  function setExitOn(p, t) {
+    var w = p.ownerDocument && p.ownerDocument.defaultView;
+    if (w && w.__arrival && w.__arrival.setExit) w.__arrival.setExit(t);
+    else p.style.setProperty("--exit", String(t));
   }
 
   function applyExit() {
@@ -1907,7 +1924,7 @@ until asked for.">crossing</button>
         if (s < worst - 1e-9) { worst = s; worstAt = u; worstG = EXIT_GROUPS[j].label; }
       }
     }
-    panel.style.setProperty("--exit", String(exitT));
+    setExitOn(panel, exitT);
     presenceEl.textContent = "thinnest moment " + worst.toFixed(3) +
       " of one composition — " + worstG + ", t " + worstAt.toFixed(2);
     presenceEl.className = worst < PRESENCE_FLOOR ? "thin" : "";
@@ -2025,8 +2042,8 @@ until asked for.">crossing</button>
   function positionExit() {
     markExit();
     if (!panel) return;
-    panel.style.setProperty("--exit", String(exitT));
-    if (ghostPanel) ghostPanel.style.setProperty("--exit", String(exitT - 1));
+    setExitOn(panel, exitT);
+    if (ghostPanel) setExitOn(ghostPanel, exitT - 1);
   }
   function setExit(t) {
     exitT = Math.max(-1, Math.min(1, t));
@@ -2070,7 +2087,7 @@ until asked for.">crossing</button>
      is left of the second page is the section and nothing else.
 
      IT IS THE SAME PROJECT, BECAUSE THERE IS ONLY ONE. #58 puts the Eater Map
-     and the Record Engine out of scope and #72 is where a second Panel arrives,
+     and the Record Engine out of scope and #72 shipped without adding one,
      so what stands here is this composition arriving — which is exactly the
      right thing to judge a crossing on, and would be even if there were three.
      Its Rail is moved to the second project so the two can be told apart at a
@@ -2102,10 +2119,21 @@ until asked for.">crossing</button>
       "body::after { display: none !important; }" +
       ".cut-title { visibility: hidden !important; }";
     ghostDoc.head.appendChild(s);
+    /* The ghost's Rail names the second project, so the two compositions can be
+       told apart at a glance. `aria-current` COMES OFF AND DOES NOT MOVE, which
+       matters since #72 made the first entry a link and put the announcement on
+       it: left where it was, the ghost would draw one project as selected while
+       announcing another, and the second entry has no link to move it to —
+       putting it on the bare <li> is the thing #64 argued against, because a
+       screen reader is not obliged to say anything about it there. So the ghost
+       announces no current project, which is the truth about a stand-in for a
+       Panel that does not exist. It is a dev preview either way. */
     var rail = ghostDoc.querySelectorAll(".panel-rail li");
     if (rail.length > 1) {
       rail[0].classList.remove("is-selected");
       rail[1].classList.add("is-selected");
+      var was = rail[0].querySelector("[aria-current]");
+      if (was) was.removeAttribute("aria-current");
     }
   }
 
@@ -2872,10 +2900,11 @@ until asked for.">crossing</button>
     L.push("`node design/tools/check-panel-exit.mjs` asserts the same at 51 samples,");
     L.push("across every treatment and five rates, and checks the rest of #74 with it.");
     L.push("");
-    L.push("NOTHING DRIVES --exit ON THE SHIPPING PAGE YET. It is declared 0 in the");
-    L.push("sheet and only a crossing between Panels moves it; #72 is that crossing.");
-    L.push("So pasting the above changes what a departure LOOKS like and does not");
-    L.push("make one happen.");
+    L.push("WHAT DRIVES --exit ON THE SHIPPING PAGE is the scroll position, since #72:");
+    L.push("arrival.js writes (turn - 1) on the section, so the Panel ARRIVES as the");
+    L.push("page crosses into it. A departure needs a second Panel to depart towards,");
+    L.push("so pasting the above changes what one would look like rather than making");
+    L.push("one happen.");
     L.push("");
 
     var state = { mixture: {}, values: {} };

--- a/design/tools/check-panel-exit.mjs
+++ b/design/tools/check-panel-exit.mjs
@@ -17,8 +17,9 @@
    composites one layer rather than five.
 
    THE CROSSING IS SIMULATED FROM ONE PANEL, WHICH IS THE HONEST THING TO DO
-   AND NOT A SHORTCUT. There is one Panel on the page — #72 is where a second
-   one arrives — but the whole design of the treatments is that arrival IS
+   AND NOT A SHORTCUT. There is one Panel on the page — #72 drove --exit off the
+   scroll position and did not add a second, and #58 puts the other two out of
+   scope — but the whole design of the treatments is that arrival IS
    departure reflected through zero: a crossing at progress t puts the outgoing
    Panel at --exit t and the incoming one at t - 1. So one Panel, read twice,
    is exactly the pair, and reading it twice is the only way to measure the pair

--- a/design/tools/check-panel-nav.mjs
+++ b/design/tools/check-panel-nav.mjs
@@ -1,0 +1,647 @@
+/* ============================================================================
+   check-panel-nav.mjs — does the reader get carried into the section, and does
+   the Rail tell the truth? #72.
+
+     node design/tools/check-panel-nav.mjs
+
+   Exit 0 if every one of #72's criteria holds, 1 if any does not, and it names
+   which. It serves the tree it is invoked from, so it answers for the working
+   copy rather than for whatever is deployed — `preview_start` serves the main
+   checkout in this repository and would silently report on `development` while
+   looking like it reported on the branch.
+
+   WHAT IS BEING ASSERTED. #58's testing note asks for the reader's experience
+   rather than the mechanism: that scrolling reaches the section, that the Rail
+   reports the right selection, that a reversal does not snap, that reduced
+   motion removes the movement and leaves the navigation. So nothing below reads
+   an easing function or a property by name to check its shape. What it reads is
+   where the page ended up, what the composition was drawn at while it got there,
+   and what a screen reader would be handed.
+
+   THE ARRIVAL IS AFFINE IN THE SCROLL POSITION, WHICH IS THE WHOLE ARGUMENT.
+   --exit is (scroll / landing) - 1 and holds no state, so continuity, reversal
+   and fast scrolling are not three behaviours to test but one identity to
+   measure: if the composition is welded to the page at every frame, then
+   whatever the page does smoothly the composition does smoothly, and there is
+   nothing to strand. Section 2 measures the weld frame by frame through a real
+   mid-flight reversal; sections 3 and 4 then only have to show that the PAGE
+   behaves — which is app.js's quintic, and unchanged by this ticket.
+
+   ONE PANEL, WHICH BOUNDS WHAT CAN BE ASSERTED AND IS SAID RATHER THAN WORKED
+   AROUND. #58 puts the other two Panels out of scope, so "the selected label
+   always matches what is on screen" has one Panel to be right about and the two
+   inert entries are asserted to be inert — no link, nothing to follow, and said
+   out loud to a screen reader. When a second Panel arrives, section 5's count of
+   routes changes and nothing else here has to.
+   ========================================================================== */
+
+import http from "node:http";
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
+import { dirname, extname, join, normalize, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, "..", "..");
+const PAGE = "/portfolio/";
+
+/* The turn regime is `(min-width: 1100px) and (min-height: 700px)`, and this is
+   the window check-panel-exit.mjs and the render harness both use, so the three
+   answer about the same drawing. */
+const DESK = { width: 1440, height: 900 };
+
+/* One wheel notch, in the units the page's own DETENT is written in. */
+const NOTCH = 120;
+
+const MIME = {
+  ".html": "text/html; charset=utf-8", ".css": "text/css; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8", ".json": "application/json",
+  ".svg": "image/svg+xml", ".png": "image/png", ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg", ".webp": "image/webp", ".woff2": "font/woff2",
+  ".webm": "video/webm", ".mp4": "video/mp4",
+  ".ico": "image/x-icon", ".txt": "text/plain; charset=utf-8",
+};
+
+async function resolveFile(urlPath) {
+  const clean = decodeURIComponent(urlPath.split("?")[0]);
+  const target = resolve(ROOT, "." + normalize(clean).replace(/^([/\\])+/, sep));
+  if (target !== ROOT && !target.startsWith(ROOT + sep)) return null;
+  try {
+    const info = await stat(target);
+    if (info.isDirectory()) {
+      const index = join(target, "index.html");
+      await stat(index);
+      return index;
+    }
+    return target;
+  } catch {
+    return null;
+  }
+}
+
+function serve() {
+  const server = http.createServer(async (req, res) => {
+    const file = await resolveFile(req.url);
+    if (!file) return void res.writeHead(404).end("not found");
+    res.writeHead(200, { "content-type": MIME[extname(file).toLowerCase()] ?? "application/octet-stream" });
+    createReadStream(file).pipe(res);
+  });
+  return new Promise((ok) => server.listen(0, "127.0.0.1", () => ok(server)));
+}
+
+async function open(browser, origin, options) {
+  const context = await browser.newContext({
+    viewport: DESK,
+    deviceScaleFactor: 1,
+    reducedMotion: "no-preference",
+    ...options,
+  });
+  const page = await context.newPage();
+  await page.goto(origin + PAGE, { waitUntil: "load" });
+  /* The corner pictures settle the CV's height, and the CV's height IS the
+     landing. Everything below is measured against it, so nothing may be read
+     until they have arrived. */
+  await page.waitForTimeout(2500);
+  return { context, page };
+}
+
+/* The page's own numbers, read once per context: where it comes to rest, and the
+   divisor arrival.js writes --exit against. Both are computed the way that file
+   computes them rather than restated, so a change to the landing shows up here
+   as a moved measurement instead of as a passing test. */
+const GEOMETRY = () => {
+  const panel = document.querySelector(".panel");
+  const cs = getComputedStyle(panel);
+  const docTop = (el) => { let y = 0; for (let n = el; n; n = n.offsetParent) y += n.offsetTop; return y; };
+  const pageMax = document.documentElement.scrollHeight - window.innerHeight;
+  return {
+    regime: cs.scrollSnapAlign !== "none",
+    port: Math.min(pageMax, docTop(panel) - (parseFloat(cs.scrollMarginTop) || 0)),
+    pageMax,
+  };
+};
+
+/* ---------------------------------------------------------------------------
+   1. the arrival is welded to the scroll position
+   ------------------------------------------------------------------------ */
+const WELD = async ({ port, samples }) => {
+  const panel = document.querySelector(".panel");
+  const head = document.querySelector(".panel-head");
+  const read = () => ({
+    y: window.scrollY,
+    exit: Number(getComputedStyle(panel).getPropertyValue("--exit").trim()),
+    head: Number(getComputedStyle(head).opacity),
+  });
+  /* THREE FRAMES BETWEEN MOVING THE PAGE AND READING IT, and reading sooner is
+     the trap that cost the first run of this file three false failures. The
+     driver is a scroll listener that queues a rAF, so a synchronous read after
+     scrollTo() gets the value written for wherever the page WAS — the whole
+     sweep came back at -1 and looked like a driver that never ran. One frame for
+     the scroll event to be delivered, one for the rAF it queues to run, one to
+     be sure. */
+  const settle = () => new Promise((done) => {
+    requestAnimationFrame(() => requestAnimationFrame(() => requestAnimationFrame(done)));
+  });
+  const at = async (y) => { window.scrollTo(0, y); await settle(); return read(); };
+  const down = [], up = [];
+  for (let i = 0; i <= samples; i++) down.push(await at((port * i) / samples));
+  for (let i = samples; i >= 0; i--) up.push(await at((port * i) / samples));
+  up.reverse();
+  return { down, up };
+};
+
+/* ---------------------------------------------------------------------------
+   2. a real mid-flight reversal, frame by frame
+   ------------------------------------------------------------------------
+   Recorded from inside the page because what is being measured is per-FRAME
+   continuity, and a round trip per sample would be slower than the thing it is
+   sampling. The recorder is started, the wheels are dispatched from outside, and
+   the trace is collected afterwards. */
+const RECORD = (frames) => {
+  const panel = document.querySelector(".panel");
+  window.__trace = [];
+  const step = (ts) => {
+    window.__trace.push([ts, window.scrollY, Number(getComputedStyle(panel).getPropertyValue("--exit").trim())]);
+    if (window.__trace.length < frames) requestAnimationFrame(step);
+  };
+  requestAnimationFrame(step);
+};
+
+/* ---------------------------------------------------------------------------
+   The run
+   ------------------------------------------------------------------------ */
+const server = await serve();
+const origin = `http://127.0.0.1:${server.address().port}`;
+const browser = await chromium.launch();
+
+const problems = [];
+const pad = 22;
+const say = (k, v) => console.log(k.padEnd(pad) + " " + v);
+
+let geo, weld, reversal, burst, touch, railShape, keyboard, tree, still, turn;
+
+try {
+  /* ---- the desktop context, which is most of the ticket ------------------- */
+  {
+    const { context, page } = await open(browser, origin);
+    geo = await page.evaluate(GEOMETRY);
+    if (!geo.regime) throw new Error(`${DESK.width}x${DESK.height} is not in the turn regime`);
+
+    weld = await page.evaluate(WELD, { port: geo.port, samples: 40 });
+
+    /* ---- the reversal ---------------------------------------------------- */
+    await page.evaluate((y) => window.scrollTo(0, y), 0);
+    await page.waitForTimeout(400);
+    /* Away from the carousel, so the capture-phase listener in app.js assigns
+       the gesture to the page rather than to the strip. The left margin at the
+       foot of the first screen is the Rail's column and holds nothing else. */
+    await page.mouse.move(20, DESK.height - 40);
+    await page.evaluate(RECORD, 90);
+    await page.mouse.wheel(0, NOTCH);              // start the turn down
+    await page.waitForTimeout(220);                // ~13 frames in
+    await page.mouse.wheel(0, -NOTCH);             // and reverse it mid-flight
+    await page.waitForTimeout(1600);
+    reversal = await page.evaluate(() => ({
+      trace: window.__trace,
+      y: window.scrollY,
+      exit: Number(getComputedStyle(document.querySelector(".panel")).getPropertyValue("--exit").trim()),
+    }));
+
+    /* ---- fast scrolling -------------------------------------------------- */
+    await page.evaluate((y) => window.scrollTo(0, y), 0);
+    await page.waitForTimeout(400);
+    for (let i = 0; i < 12; i++) await page.mouse.wheel(0, NOTCH * 4);
+    await page.waitForTimeout(1800);
+    burst = await page.evaluate(() => ({
+      y: window.scrollY,
+      exit: Number(getComputedStyle(document.querySelector(".panel")).getPropertyValue("--exit").trim()),
+    }));
+
+    /* ---- the page turn, unchanged --------------------------------------- */
+    await page.evaluate((y) => window.scrollTo(0, y), 0);
+    await page.waitForTimeout(400);
+    await page.mouse.wheel(0, NOTCH);
+    await page.waitForTimeout(1400);
+    const downTo = await page.evaluate(() => window.scrollY);
+    await page.mouse.wheel(0, -NOTCH);
+    await page.waitForTimeout(1400);
+    const upTo = await page.evaluate(() => window.scrollY);
+    /* And the strip still takes a gesture that begins on it, without turning
+       the page — the arbitration this ticket had to cooperate with rather than
+       join. The pointer goes onto a photograph and the wheel is vertical, which
+       is the case the capture-phase listener exists to settle. */
+    const strip = await page.locator(".track").boundingBox();
+    await page.mouse.move(strip.x + strip.width / 2, strip.y + strip.height / 2);
+    const before = await page.evaluate(() => ({ y: window.scrollY, x: document.querySelector(".track").scrollLeft }));
+    await page.mouse.wheel(0, NOTCH * 2);
+    await page.waitForTimeout(900);
+    const after = await page.evaluate(() => ({ y: window.scrollY, x: document.querySelector(".track").scrollLeft }));
+    turn = { port: geo.port, downTo, upTo, stripBefore: before, stripAfter: after };
+
+    /* ---- the Rail's shape, and what it says ------------------------------ */
+    railShape = await page.evaluate(() => {
+      const rail = document.querySelector(".panel-rail");
+      if (!rail) return null;
+      const items = [...rail.querySelectorAll("li")];
+      const onScreen = [...document.querySelectorAll(".panel")];
+      return {
+        tag: rail.tagName.toLowerCase(),
+        label: rail.getAttribute("aria-label"),
+        listRole: rail.querySelector("ul") ? rail.querySelector("ul").getAttribute("role") : null,
+        panels: onScreen.map((p) => p.id),
+        entries: items.map((li) => {
+          const a = li.querySelector("a[href]");
+          return {
+            text: li.textContent.trim(),
+            selected: li.classList.contains("is-selected"),
+            href: a ? a.getAttribute("href") : null,
+            /* The resolved URL, which is the whole of the base-href trap: a
+               fragment that resolves to a different path is a page RELOAD. */
+            samePath: a ? new URL(a.href).pathname === location.pathname : null,
+            current: a ? a.getAttribute("aria-current") : null,
+            hidden: [...li.querySelectorAll(".visually-hidden")].map((s) => s.textContent.trim()),
+          };
+        }),
+      };
+    });
+
+    /* ---- the Rail as a route -------------------------------------------- */
+    await page.evaluate((y) => window.scrollTo(0, y), 0);
+    await page.waitForTimeout(400);
+    /* Activated the way a reader would, from the keyboard, which also proves the
+       entry is operable rather than merely focusable. The Rail is drawn at
+       nothing at the top of the page, so this is also the one activation that
+       could not happen with a pointer. */
+    const link = page.locator(".panel-rail a").first();
+    await link.focus();
+    const focused = await page.evaluate(() => {
+      const a = document.activeElement;
+      const cs = getComputedStyle(a);
+      return {
+        inRail: !!a.closest(".panel-rail"),
+        tag: a.tagName.toLowerCase(),
+        /* :focus-visible is the page's convention and cannot be read off a
+            computed style directly, so the ring is read as what a focused
+            element resolves to under `matches`. */
+        focusVisible: a.matches(":focus-visible"),
+        outlineStyle: cs.outlineStyle,
+        outlineWidth: parseFloat(cs.outlineWidth),
+        railOpacity: Number(getComputedStyle(document.querySelector(".panel-rail")).opacity),
+        /* .panel is `overflow: clip` and the Rail stands at `left: 0` in the turn
+           regime, so a ring drawn 3px outside its box could be cut off by the
+           section's own edge. What saves it is that the ITEM is centred in a
+           --corner-wide column and measures one line of type across — measured
+           rather than argued, because it is the difference between "an outline is
+           computed" and "a reader can see one". */
+        ringRoom: Math.round(a.getBoundingClientRect().left -
+                             document.querySelector(".panel").getBoundingClientRect().left),
+        /* And the Rail is not a pointer target while it is still fading in: an
+           opacity-0 link over the CV's bottom-left corner would take a click. */
+        faint: document.querySelector(".panel-rail").hasAttribute("data-faint"),
+        pointerEvents: getComputedStyle(document.querySelector(".panel-rail")).pointerEvents,
+      };
+    });
+    /* How far into the tab order it is, from the top of the document — the
+       criterion is "reachable", and a number says it rather than a boolean. */
+    await page.evaluate(() => { document.activeElement.blur(); window.scrollTo(0, 0); });
+    let tabs = 0, reached = false;
+    for (; tabs < 60 && !reached; tabs++) {
+      await page.keyboard.press("Tab");
+      reached = await page.evaluate(() => !!(document.activeElement && document.activeElement.closest(".panel-rail a")));
+    }
+    keyboard = { ...focused, tabs: reached ? tabs : null };
+
+    await link.focus();
+    await page.keyboard.press("Enter");
+    await page.waitForTimeout(1800);
+    const routed = await page.evaluate(() => ({
+      y: window.scrollY,
+      exit: Number(getComputedStyle(document.querySelector(".panel")).getPropertyValue("--exit").trim()),
+      hash: location.hash,
+      selected: [...document.querySelectorAll(".panel-rail li.is-selected")].map((li) => li.textContent.trim()),
+      current: [...document.querySelectorAll(".panel-rail [aria-current]")].map((a) => a.textContent.trim()),
+    }));
+    keyboard.routed = routed;
+
+    /* ---- and what a screen reader is handed -----------------------------
+       THE BROWSER'S OWN ARIA TREE, and not a reading of the markup. The
+       criterion is that the Rail IS ANNOUNCED as a list of projects, and the gap
+       between "the markup says <ul>" and "the browser computes a list" is
+       exactly where `list-style: none` costs a list its role. Only the tree can
+       tell those two apart, and it is printed whole in the report because it is
+       the most readable thing this file produces.
+
+       `aria-current` IS NOT IN IT, and that is a limitation of the tools rather
+       than of the page: neither this snapshot nor CDP's own AXPropertyName enum
+       carries `current`, so the one criterion the tree cannot answer is asserted
+       off the DOM in section 5 instead. Said here so the next reader does not go
+       looking for it and conclude it was forgotten. */
+    tree = await page.locator(".panel-rail").ariaSnapshot();
+
+    await context.close();
+  }
+
+  /* ---- touch ------------------------------------------------------------- */
+  {
+    /* A touch drag never reaches app.js's wheel listener — the comment on the
+       turn says so — so this is the one input where the whole of the movement is
+       the browser's own scroll plus mandatory snap, and the arrival has to
+       follow it anyway. Dispatched through CDP because Playwright's touchscreen
+       taps and does not drag. */
+    const { context, page } = await open(browser, origin, { hasTouch: true });
+    const g = await page.evaluate(GEOMETRY);
+    const cdp = await context.newCDPSession(page);
+    /* Down the left margin, clear of the carousel — a drag that began on the
+       strip would scroll the strip, which is the arbitration working and not the
+       thing being measured here. Far enough that snap has a nearer port to choose
+       than the one it started from: the drag is repeated from wherever it got to,
+       because one finger's travel is a window's height at most and the turn is a
+       little more than that. */
+    const x = 20, y0 = DESK.height - 60, step = 40, moves = 18;
+    await cdp.send("Input.dispatchTouchEvent", { type: "touchStart", touchPoints: [{ x, y: y0 }] });
+    for (let i = 1; i <= moves; i++) {
+      await cdp.send("Input.dispatchTouchEvent", { type: "touchMove", touchPoints: [{ x, y: y0 - i * step }] });
+    }
+    /* Read inside the drag rather than after it: "the arrival follows the drag"
+       is a statement about the middle of it, and after the release snap has
+       already tidied the ends. */
+    const during = await page.evaluate(() => ({
+      y: window.scrollY,
+      exit: Number(getComputedStyle(document.querySelector(".panel")).getPropertyValue("--exit").trim()),
+    }));
+    await cdp.send("Input.dispatchTouchEvent", { type: "touchEnd", touchPoints: [] });
+    await page.waitForTimeout(1800);
+    const settled = await page.evaluate(() => ({
+      y: window.scrollY,
+      exit: Number(getComputedStyle(document.querySelector(".panel")).getPropertyValue("--exit").trim()),
+    }));
+    touch = { regime: g.regime, port: g.port, during, settled };
+    await context.close();
+  }
+
+  /* ---- reduced motion ---------------------------------------------------- */
+  {
+    const { context, page } = await open(browser, origin, { reducedMotion: "reduce" });
+    const g = await page.evaluate(GEOMETRY);
+    const pinned = await page.evaluate(({ port }) => {
+      const panel = document.querySelector(".panel");
+      const seen = [];
+      for (let i = 0; i <= 20; i++) {
+        window.scrollTo(0, (port * i) / 20);
+        seen.push(Number(getComputedStyle(panel).getPropertyValue("--exit").trim()));
+      }
+      window.scrollTo(0, 0);
+      return seen;
+    }, { port: g.port });
+    /* And the Rail still navigates, by the anchor rather than by a turn — which
+       is what "the movement is removed, not shortened" has to mean for a link. */
+    await page.waitForTimeout(300);
+    await page.locator(".panel-rail a").first().click();
+    await page.waitForTimeout(900);
+    const arrived = await page.evaluate(() => ({
+      y: window.scrollY,
+      hash: location.hash,
+      exit: Number(getComputedStyle(document.querySelector(".panel")).getPropertyValue("--exit").trim()),
+    }));
+    still = { port: g.port, pinned, arrived };
+    await context.close();
+  }
+} finally {
+  await browser.close();
+  server.close();
+}
+
+/* ===========================================================================
+   The report
+   ======================================================================== */
+say("serving", ROOT);
+say("page", PAGE);
+say("window", `${DESK.width}x${DESK.height}`);
+say("rest position", `${geo.port}px, document max ${geo.pageMax}px`);
+console.log("");
+
+/* ---- 1. the arrival ------------------------------------------------------ */
+const EPS = 6e-4;                       // arrival.js writes --exit to four places
+const expect = (y) => y / geo.port - 1;
+const off = weld.down.map((s) => Math.abs(s.exit - expect(s.y)));
+const worstOff = Math.max(...off);
+const ends = { top: weld.down[0], rest: weld.down[weld.down.length - 1] };
+const monotone = weld.down.every((s, i) => i === 0 || s.exit >= weld.down[i - 1].exit - EPS);
+const headMono = weld.down.every((s, i) => i === 0 || s.head >= weld.down[i - 1].head - 1e-3);
+say("arrival", `--exit tracks scroll to within ${worstOff.toFixed(5)} over 41 samples`);
+say("ends", `${ends.top.exit.toFixed(4)} at the top, ${ends.rest.exit.toFixed(4)} at rest`);
+say("monotone", monotone && headMono ? "--exit and the composition's opacity, both" : "NO");
+if (worstOff > EPS) problems.push(`--exit is not the scroll position: it is out by up to ${worstOff.toFixed(5)} across the turn`);
+if (ends.top.exit !== -1) problems.push(`at the top of the page --exit is ${ends.top.exit}, so the composition has already partly arrived`);
+if (ends.rest.exit !== 0) problems.push(`at rest --exit is ${ends.rest.exit} and not 0, so the composition never quite settles`);
+if (!monotone || !headMono) problems.push("the arrival is not monotone in the scroll position — the composition comes back before it has finished arriving");
+
+/* ---- 1b. no hysteresis -------------------------------------------------- */
+const hyst = Math.max(...weld.down.map((s, i) => Math.abs(s.exit - weld.up[i].exit)));
+say("no hysteresis", hyst === 0
+  ? "every sample identical scrolling up and scrolling down"
+  : `DIFFERS by up to ${hyst.toFixed(5)}`);
+if (hyst !== 0) problems.push(`the arrival depends on which way the page was scrolled (up to ${hyst.toFixed(5)}), so a reversal cannot be continuous`);
+
+/* ---- 2. the reversal ---------------------------------------------------- */
+console.log("");
+const tr = reversal.trace.filter((_, i, a) => i === 0 || a[i][0] !== a[i - 1][0]);
+const moved = tr.filter((s, i) => i > 0 && Math.abs(s[1] - tr[i - 1][1]) > 0.01);
+/* The quintic's peak speed from REST: 1.875 x distance over the duration, and
+   the duration is TURN scaled by the square root of the fraction of the document
+   being crossed, floored at 0.45. A whole turn is the whole document, so the
+   fraction is 1 and the duration is TURN. Reported, and NOT asserted against,
+   for a reason worth writing down rather than rediscovering: the recorder below
+   and the turn are two separate rAF callbacks, and which of the two runs first
+   within a frame can flip — turnPage() re-registers its own every frame and
+   cancels it on a reversal. When it flips, one sample sees no movement and the
+   next sees two frames of it, so a per-frame VELOCITY off this trace reads 2x
+   high at random. Measured at 2.13, 3.23 and 4.40 px/ms across three runs of the
+   same reversal, which is a property of the sampling and not of the page.
+
+   A PER-FRAME DISTANCE IS NO BETTER, for a second reason found the same way:
+   headless Chromium starves the turn's own rAF down to about 10Hz while the
+   recorder keeps running, so a single turn frame legitimately carries 150px of a
+   782px turn. Any bound loose enough to allow that is too loose to catch
+   anything.
+
+   SO THE ASSERTIONS COUNT RATHER THAN DIVIDE, which nothing about frame rate can
+   fool. A reversal that CARRIES its speed leaves the page travelling the old way
+   for a while, reaches a far point past where it ends up, and traverses back
+   through every position in between. A restart from the current position flips
+   to full speed the other way within a frame of the input — no far point, and
+   nothing between it and the landing. So: is there an overshoot, and how many
+   distinct positions are there on the way back. Both are reported as numbers. */
+const PEAK = (1.875 * geo.port) / 800;
+const WAYPOINTS = 5;
+const steps = [];
+for (let i = 1; i < tr.length; i++) {
+  const dt = tr[i][0] - tr[i - 1][0];
+  if (dt > 0) steps.push({ dt, dy: tr[i][1] - tr[i - 1][1], v: (tr[i][1] - tr[i - 1][1]) / dt });
+}
+const fastest = steps.reduce((a, s) => Math.max(a, Math.abs(s.v)), 0);
+const biggest = steps.reduce((a, s) => Math.max(a, Math.abs(s.dy)), 0);
+/* THE SIGNATURE OF A CARRIED REVERSAL, and the reason this is not measured as an
+   acceleration: frame timing in a headless browser jitters, and an acceleration
+   is a second difference of a jittery number. An OVERSHOOT is discrete. A turn
+   that restarts from the current position reverses within one frame of the
+   input; one that carries its speed and its force keeps going the old way,
+   slows, stops, and comes back — so the trace has a maximum past which it
+   returns, and that maximum is after the reversing wheel. */
+const peakY = tr.reduce((a, s) => (s[1] > a[1] ? s : a), tr[0]);
+const landedAt = tr[tr.length - 1][1];
+const overshoot = peakY[1] - landedAt;
+const framesAfterPeak = tr.length - 1 - tr.indexOf(peakY);
+/* How many distinct places the page was seen at on the way back down, strictly
+   between the far point and where it came to rest. A snap has none. */
+const waypoints = new Set(tr.slice(tr.indexOf(peakY) + 1)
+  .map((s) => s[1])
+  .filter((y) => y > landedAt + 0.5 && y < peakY[1] - 0.5)
+  .map((y) => Math.round(y))).size;
+/* And the composition never lags the page by more than the frame it is being
+   drawn in: arrival.js writes --exit from its own rAF, so a sample may catch the
+   value written for the previous frame's position and no older. */
+const lag = tr.filter((s) => {
+  const here = Math.abs(s[2] - expect(s[1]));
+  return here > EPS;
+}).length;
+const lagWorse = tr.filter((s, i) => {
+  if (i === 0) return false;
+  const here = Math.abs(s[2] - expect(s[1]));
+  const prev = Math.abs(s[2] - expect(tr[i - 1][1]));
+  return here > EPS && prev > EPS;
+}).length;
+say("reversal trace", `${tr.length} frames, ${moved.length} of them moving`);
+say("fastest frame", `${biggest.toFixed(0)}px, nominally ${fastest.toFixed(2)} px/ms ` +
+  `against ${PEAK.toFixed(2)} from rest — reported, not asserted; see the note`);
+say("carried through", overshoot > 0.5
+  ? `yes — ${overshoot.toFixed(0)}px past where it landed, ${framesAfterPeak} frames of coming back`
+  : `NO — the page reversed without overshooting (${overshoot.toFixed(1)}px)`);
+say("through, not over", `${waypoints} distinct positions between the far point and the landing`);
+say("welded", lagWorse === 0
+  ? `every frame, ${lag} of ${tr.length} matching the previous frame's position`
+  : `${lagWorse} frames where the composition is neither at this position nor the last`);
+say("landed", `${reversal.y}px, --exit ${reversal.exit.toFixed(4)}`);
+if (overshoot <= 0.5) problems.push("the page reversed direction without carrying its speed through zero: a reversal mid-transition restarts rather than continuing");
+if (waypoints < WAYPOINTS) problems.push(`the page was seen at only ${waypoints} positions between the far point and the landing, so the way back is a snap rather than a traverse`);
+if (lagWorse !== 0) problems.push(`${lagWorse} frames of the reversal draw the composition at a scroll position the page was not at — the arrival is not welded to the page`);
+if (reversal.y !== 0 || reversal.exit !== -1) problems.push(`the reversal did not land back at the top: ${reversal.y}px, --exit ${reversal.exit}`);
+
+/* ---- 3. fast scrolling -------------------------------------------------- */
+console.log("");
+const stranded = burst.y !== 0 && burst.y !== geo.port;
+say("12 notches fast", `landed at ${burst.y}px, --exit ${burst.exit.toFixed(4)}`);
+if (stranded) problems.push(`a fast scroll left the page at ${burst.y}px, which is neither port — the page is stranded mid-transition`);
+if (!stranded && burst.exit !== (burst.y === 0 ? -1 : 0)) problems.push(`the page settled on a port but the composition did not: --exit ${burst.exit}`);
+
+/* ---- 4. the turn and the carousel, unchanged ---------------------------- */
+const stripMoved = turn.stripAfter.x !== turn.stripBefore.x;
+const pageHeld = turn.stripAfter.y === turn.stripBefore.y;
+say("one notch down", `${turn.downTo}px — the port is ${turn.port}px`);
+say("one notch up", `${turn.upTo}px`);
+say("a notch on the strip", `strip ${turn.stripBefore.x} -> ${turn.stripAfter.x}, page ${turn.stripBefore.y} -> ${turn.stripAfter.y}`);
+if (turn.downTo !== turn.port) problems.push(`one notch down landed at ${turn.downTo}px rather than on the port at ${turn.port}px`);
+if (turn.upTo !== 0) problems.push(`one notch up landed at ${turn.upTo}px rather than back at the top`);
+if (!stripMoved) problems.push("a wheel notch over the carousel no longer moves the strip");
+if (!pageHeld) problems.push("a wheel notch over the carousel now turns the page as well — the gesture arbitration has been broken");
+
+/* ---- 5. the Rail -------------------------------------------------------- */
+console.log("");
+if (!railShape) {
+  problems.push("there is no .panel-rail on the page at all");
+} else {
+  const routes = railShape.entries.filter((e) => e.href);
+  const inert = railShape.entries.filter((e) => !e.href);
+  const selected = railShape.entries.filter((e) => e.selected);
+  const current = railShape.entries.filter((e) => e.current);
+  say("the Rail", `<${railShape.tag}> named "${railShape.label}", list role "${railShape.listRole}", ${railShape.entries.length} entries`);
+  say("routes", `${routes.length} — ${routes.map((e) => e.text).join(", ") || "none"}`);
+  say("inert", `${inert.length} — ${inert.map((e) => e.text.replace(/\s+/g, " ")).join("; ") || "none"}`);
+  say("selection", `${selected.length} drawn, ${current.length} announced` +
+    (selected.length === 1 && current.length === 1 ? ` — ${selected[0].text}` : ""));
+  say("same document", routes.every((e) => e.samePath) ? "every route resolves to this page's own path" : "NO — a route would RELOAD");
+  if (railShape.entries.length !== railShape.panels.length + inert.length) {
+    problems.push(`the Rail has ${railShape.entries.length} entries and ${routes.length} routes against ${railShape.panels.length} Panels on the page`);
+  }
+  if (routes.length !== railShape.panels.length) problems.push(`${routes.length} Rail entries are links against ${railShape.panels.length} Panels — an entry that leads nowhere or a Panel with no way to it`);
+  if (selected.length !== 1) problems.push(`${selected.length} Rail entries are drawn as selected; exactly one is on screen`);
+  if (current.length !== 1) problems.push(`${current.length} Rail entries carry aria-current; exactly one is on screen`);
+  if (selected.length === 1 && current.length === 1 && selected[0].text !== current[0].text) {
+    problems.push(`the Rail draws "${selected[0].text}" as selected and announces "${current[0].text}" — they have to be the same entry`);
+  }
+  if (!inert.every((e) => e.hidden.length)) problems.push("an inert Rail entry says nothing about being inert, so a screen reader is read a project with no way to reach it and no explanation");
+  if (!routes.every((e) => e.samePath)) problems.push("a Rail route resolves to a different path from the document's own, so following it reloads the page to reach an anchor one frame away");
+}
+
+/* ---- 6. the keyboard ---------------------------------------------------- */
+console.log("");
+say("focus", keyboard.inRail ? `reaches the Rail's <${keyboard.tag}>` : "DOES NOT reach the Rail");
+say("in the tab order", keyboard.tabs === null ? "NOT REACHED in 60 tabs" : `${keyboard.tabs} tabs from the top of the document`);
+say("focus ring", `${keyboard.outlineStyle} ${keyboard.outlineWidth}px, :focus-visible ${keyboard.focusVisible}`);
+say("and visible", `the Rail is drawn at opacity ${keyboard.railOpacity} while it holds focus, ` +
+  `${keyboard.ringRoom}px clear of the section's clip`);
+say("not a click target", `at the top of the page: data-faint ${keyboard.faint}, ` +
+  `pointer-events ${keyboard.pointerEvents}`);
+say("Enter", `${keyboard.routed.y}px, --exit ${keyboard.routed.exit.toFixed(4)}, url "${keyboard.routed.hash}"`);
+if (!keyboard.inRail) problems.push("the Rail's entries cannot be focused");
+if (keyboard.tabs === null) problems.push("the Rail is not reachable by tabbing from the top of the document");
+if (!keyboard.focusVisible || keyboard.outlineStyle === "none" || !(keyboard.outlineWidth > 0)) {
+  problems.push(`a focused Rail entry draws no ring (${keyboard.outlineStyle} ${keyboard.outlineWidth}px)`);
+}
+if (keyboard.railOpacity !== 1) problems.push(`the Rail is drawn at opacity ${keyboard.railOpacity} while focused, so the focus ring is on something invisible`);
+if (!(keyboard.ringRoom > keyboard.outlineWidth + 3)) {
+  problems.push(`the focused entry sits ${keyboard.ringRoom}px from the section's clip and its ring is drawn ${keyboard.outlineWidth + 3}px outside it, so the ring is cut off`);
+}
+if (!keyboard.faint || keyboard.pointerEvents !== "none") {
+  problems.push("at the top of the page the Rail is invisible and still takes clicks — a link nobody can see over the foot of the CV");
+}
+if (keyboard.routed.y !== geo.port || keyboard.routed.exit !== 0) {
+  problems.push(`activating the Rail left the page at ${keyboard.routed.y}px with --exit ${keyboard.routed.exit}, not settled on the section`);
+}
+if (keyboard.routed.hash !== "#projects") problems.push(`the url after following the Rail is "${keyboard.routed.hash}", so a reload would not land on the section`);
+if (keyboard.routed.selected.length !== 1 || keyboard.routed.current.length !== 1) {
+  problems.push("after following the Rail the selection is no longer exactly one entry");
+}
+
+/* ---- 7. what a screen reader is handed --------------------------------- */
+console.log("");
+const lines = String(tree || "").split("\n").filter((l) => l.trim());
+const roleCount = (r) => lines.filter((l) => new RegExp(`- ${r}\\b`).test(l)).length;
+say("announced as", lines[0] ? lines[0].replace(/^-\s*/, "").replace(/:$/, "") : "NOTHING");
+say("containing", `${roleCount("list") ? "a list" : "NO list"} of ${roleCount("listitem")} items, ${roleCount("link")} link(s)`);
+console.log("");
+for (const l of lines) console.log("  " + l);
+if (!/^- navigation "Projects"/.test(lines[0] || "")) problems.push("the Rail is not announced as a navigation named Projects");
+if (!roleCount("list")) problems.push("the Rail is not announced as a list — #72 asks for a list of projects");
+if (roleCount("listitem") !== 3) problems.push(`the Rail is announced as ${roleCount("listitem")} list items rather than 3 projects`);
+if (!lines.some((l) => /no page yet/i.test(l))) problems.push("the two inert entries are not announced as unavailable");
+
+/* ---- 8. touch ---------------------------------------------------------- */
+console.log("");
+say("touch drag", `moved the page to ${touch.during.y}px, --exit ${touch.during.exit.toFixed(4)} mid-drag`);
+say("and settled", `${touch.settled.y}px, --exit ${touch.settled.exit.toFixed(4)} — the port is ${touch.port}px`);
+if (!(touch.during.y > 0)) problems.push("a touch drag did not scroll the page at all, so nothing about the arrival was measured under touch");
+if (touch.during.exit <= -1 || touch.during.exit > 0) problems.push(`mid-drag the composition is at --exit ${touch.during.exit}, so it is not following a touch scroll`);
+if (touch.settled.y !== touch.port && touch.settled.y !== 0) problems.push(`a touch drag left the page at ${touch.settled.y}px, which is neither port`);
+if (touch.settled.exit !== (touch.settled.y === 0 ? -1 : 0)) problems.push(`after a touch drag the page is on a port and the composition is not: --exit ${touch.settled.exit}`);
+
+/* ---- 9. reduced motion ------------------------------------------------- */
+console.log("");
+const anyMovement = still.pinned.filter((v) => v !== 0);
+say("reduced motion", anyMovement.length
+  ? `MOVES — --exit reached ${anyMovement.map((v) => v.toFixed(3)).join(", ")}`
+  : "--exit is 0 at all 21 scroll positions across the turn");
+say("and the Rail", `still navigates — ${still.arrived.y}px against a port of ${still.port}px, url "${still.arrived.hash}"`);
+if (anyMovement.length) problems.push("under prefers-reduced-motion the composition still arrives as the page scrolls; #72 asks for the movement removed");
+if (still.arrived.y !== still.port) problems.push(`under prefers-reduced-motion the Rail left the page at ${still.arrived.y}px rather than on the section at ${still.port}px`);
+if (still.arrived.hash !== "#projects") problems.push(`under prefers-reduced-motion following the Rail did not set the fragment ("${still.arrived.hash}")`);
+
+/* ---- and the verdict -------------------------------------------------- */
+console.log("");
+if (problems.length) {
+  console.log(`${problems.length} problem${problems.length === 1 ? "" : "s"}:`);
+  for (const p of problems) console.log("  - " + p);
+  process.exit(1);
+}
+console.log("scrolling carries the reader into the section and the Rail tells the truth — #72");

--- a/portfolio/app.js
+++ b/portfolio/app.js
@@ -566,6 +566,105 @@
       if (turnRaf === null || turnTarget !== target) turnPage(target);
     }, { passive: false });
 
+    // ---- the Rail, as the direct route into the section ----------------------
+    // #72. The Rail names the projects and is what a reader navigates by; this
+    // is the half of it that has to know about the turn. The other half — the
+    // composition arriving as the page crosses — is one number in arrival.js and
+    // knows nothing about this.
+    //
+    // A THIRD CONSUMER OF THE ARBITRATION ABOVE, NOT A SECOND LISTENER, which is
+    // why it is inside this block with the turn rather than in a file of its own.
+    // It does not read the wheel at all: it calls the same turnPage() the wheel
+    // handler calls, so a notch taken while a Rail-initiated turn is in the air
+    // arrives at the handler above with the turn already running and RETARGETS it
+    // — the two carried terms in the quintic take the speed and the force the
+    // Rail's turn was carrying and reverse them continuously. A second listener
+    // easing the window itself would have been the same journey driven twice, and
+    // the reversal would have been the thing that showed it.
+    //
+    // WITH ONE PANEL THE SECTION HAS ONE STOP, and it is the port the turn
+    // already targets, so nothing here competes with the page turn for a gesture
+    // and the turn behaves exactly as it did. When the other two Panels exist,
+    // panelFor() below already resolves each Rail entry to its own section and
+    // what has to grow is panelPort(), from one port to one per Panel. #58 says
+    // that plainly: the machinery is built for three, and there is one to move to.
+    var rail = document.querySelector(".panel-rail");
+    if (rail) {
+      // THE BASE-HREF TRAP, and the same fix panelHref exists for further up. The
+      // Rail is static markup so it cannot compute this; written as "#projects"
+      // it resolves against <base href="/portfolio/"> rather than against the
+      // document, and following it would RELOAD the page to reach an anchor one
+      // frame away. Only the fragment is kept from what the markup said.
+      var railLinks = rail.querySelectorAll("a[href]");
+      for (var ri = 0; ri < railLinks.length; ri++) {
+        if (railLinks[ri].hash) railLinks[ri].setAttribute("href", location.pathname + railLinks[ri].hash);
+      }
+
+      // The Panel a Rail entry names, or null for an entry that names none yet —
+      // which is the whole of what makes the other two inert. An entry is a route
+      // if it holds a link; nothing here carries a list of which projects have
+      // compositions, because the markup already says it by having an <a> or not.
+      function panelFor(a) {
+        var id = a && a.hash ? a.hash.slice(1) : "";
+        var el = id ? document.getElementById(id) : null;
+        return el && el.classList.contains("panel") ? el : null;
+      }
+
+      // Which entry is drawn and announced as the current one, DERIVED FROM THE
+      // PANEL rather than restated. The markup ships with the answer already in
+      // it, because the section is on screen at first paint and a Rail that
+      // waited for a script would say nothing for a frame — but the markup is not
+      // the authority, this is, so the two cannot drift.
+      function selectRail(id) {
+        var items = rail.querySelectorAll("li");
+        for (var i = 0; i < items.length; i++) {
+          var a = items[i].querySelector("a[href]");
+          var mine = !!a && a.hash === "#" + id;
+          items[i].classList.toggle("is-selected", mine);
+          if (!a) continue;
+          if (mine) a.setAttribute("aria-current", "true");
+          else a.removeAttribute("aria-current");
+        }
+      }
+
+      // The Panel on screen. One Panel, so it is that one, and the selection
+      // never changes — which is why there is no scroll listener here. This is
+      // the seam a second Panel arrives at: what it becomes is "the Panel whose
+      // stop the page is nearest", and selectRail() above already takes an id.
+      function onScreen() {
+        var panels = document.querySelectorAll(".panel");
+        return panels.length === 1 ? panels[0] : null;
+      }
+
+      rail.addEventListener("click", function (e) {
+        var a = e.target && e.target.closest ? e.target.closest("a[href]") : null;
+        if (!a || !rail.contains(a)) return;
+        var dest = panelFor(a);
+        if (!dest) return;                                // an entry with no Panel
+        selectRail(dest.id);
+        // OUTSIDE THE TURN REGIME, AND FOR A READER WHO ASKED FOR NO MOVEMENT,
+        // THE LINK IS THE WHOLE ROUTE. There is no turn to run — the section is
+        // the next block in an ordinary column — so the browser jumps to the
+        // fragment and `scroll-margin-top` puts it where the landing wants it.
+        // #72 asks for the Rail to still navigate when the movement is removed,
+        // and this is that: not a shortened turn, the anchor doing its own job.
+        if (reduce || !inTurn()) return;
+        var target = panelPort();
+        if (turnRaf === null && Math.abs(window.scrollY - target) < 1) return;
+        e.preventDefault();
+        if (turnRaf === null || turnTarget !== target) turnPage(target);
+        // The fragment the anchor would have left, without the history entry it
+        // would have left with it: the turn is not a navigation, and a Back that
+        // only un-set a fragment would move the page without the reader asking.
+        // Reloading on this URL lands on the section already settled, which is
+        // what a deep link to it is meant to do.
+        try { history.replaceState(null, "", a.href); } catch (_) {}
+      });
+
+      var here = onScreen();
+      if (here) selectRail(here.id);
+    }
+
     // drag to scroll (mouse / pen), with a fling on release; touch stays native
     var down = false, lastX = 0, flingV = 0, lastMoveT = 0;
     var FLING = 3.2;                                    // how far a flick carries past the drag

--- a/portfolio/arrival.js
+++ b/portfolio/arrival.js
@@ -1,7 +1,8 @@
-/* The crossing into dark — three numbers off one scroll position, and nothing
- * else. #73 owns the crossing; the landing block at the foot of styles.css is
- * what each of the three reaches, and this file only says where in the turn we
- * are.
+/* The crossing into dark, and the Panel arriving in it — four numbers off one
+ * scroll position, and nothing else. #73 owns the crossing and #72 the arrival;
+ * the landing block at the foot of styles.css is what the first three reach, THE
+ * EXIT TREATMENTS block is what the fourth reaches, and this file only says
+ * where in the turn we are.
  *
  *   --dark    0 to 1 over the whole turn. Every colour on the page is a mix
  *             against it: the ground, the CV's ink, the section's palette and
@@ -15,6 +16,25 @@
  *   --enter   the section's paragraph and its Rail, which are the only two
  *             things standing above the fold at rest. 0 there, 1 by a third of
  *             the way in.
+ *   --exit    where the Panel is in the crossing — #72, and the one of the four
+ *             written on the SECTION rather than on <html>, because that is
+ *             where the sheet declares it and a root declaration would lose to
+ *             `.panel { --exit: 0 }`. -1 at the top of the page, 0 at the port:
+ *             the composition is not drawn and then arrives, which is the
+ *             difference between being carried into the section and being
+ *             dropped into it.
+ *
+ * WHY THE ARRIVAL IS t - 1 AND NOT SOMETHING SHAPED. #74 built the treatments so
+ * that arrival IS departure reflected through zero — a crossing at progress t
+ * puts the Panel being left at --exit t and the Panel being arrived at at t - 1
+ * — and this is that, with the CV in the place of the Panel being left. It is
+ * the RAW turn fraction and not the eased one on purpose: the page's own motion
+ * through the turn is already a quintic in app.js, so easing the composition on
+ * top of it would ease the same journey twice. And because it is a pure function
+ * of scroll position with no state of its own, every one of #72's continuity
+ * criteria comes for free — a reversal mid-turn unwinds exactly, a fast scroll
+ * cannot strand the composition half-arrived, and a touch drag is the same
+ * number as a wheel notch. There is nothing here to interrupt.
  *
  * WHY JAVASCRIPT AND NOT A SCROLL TIMELINE. #73 names the hazard and it is not
  * hypothetical: the author's GitHub profile is an hourly screenshot of this
@@ -27,12 +47,22 @@
  * setting.
  *
  * NOTHING ON THE PAGE DEPENDS ON THIS FILE, the same stance effects.js and
- * cut-morph.js take. All three properties are declared in the sheet at the
- * values they hold at the top of the page — --dark 0, --turn 0, --enter 1 — so
- * a browser that never runs this gets the CV on paper with the section present
- * and nothing to watch, which is also exactly what a reader who has asked for
- * reduced motion gets. #73 asks for the transition removed rather than
- * shortened, and that is what removing it looks like.
+ * cut-morph.js take. All four properties are declared in the sheet at the values
+ * they hold at the top of the page — --dark 0, --turn 0, --enter 1, --exit 0 —
+ * so a browser that never runs this gets the CV on paper with the section
+ * present and nothing to watch, which is also exactly what a reader who has
+ * asked for reduced motion gets. #73 asks for the transition removed rather than
+ * shortened, and that is what removing it looks like. The sheet says the same
+ * thing a second time for --exit, with `!important` inside the reduced-motion
+ * block, so the guarantee does not rest on the early return below.
+ *
+ * NOTE THE ASYMMETRY IN THOSE DEFAULTS, because it is the whole reason this can
+ * be driven from a script at all: --enter is declared 1 and --exit is declared
+ * 0, which are their values at the END of the turn, while --dark and --turn are
+ * declared at their values at the start. Both are the same rule — a browser
+ * running nothing must get the settled composition, present and drawn, on a page
+ * that is not dark — and the two properties happen to reach that from opposite
+ * ends of their own range.
  */
 (function () {
   "use strict";
@@ -44,7 +74,9 @@
   var still = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)");
   if (still && still.matches) return;
 
-  var landing = 0, ready = false, queued = false;
+  var rail = panel.querySelector(".panel-rail");
+  var landing = 0, ready = false, queued = false, wasFaint = null;
+  var pinnedExit = null;             // a number while a tuner is holding --exit
 
   /* Document space, walked up the offsetParent chain rather than taken from a
      client rect. .page spends its first 0.9s translated 8px down by the page-in
@@ -71,9 +103,34 @@
       root.style.removeProperty("--dark");
       root.style.removeProperty("--turn");
       root.style.removeProperty("--enter");
+      /* And the arrival with them: outside the turn regime the section is the
+         next block in an ordinary column, so it is simply there. Removed rather
+         than pinned to 0, so what is left is the sheet's own declaration and
+         there is no inline value to go stale if the window is resized back into
+         the regime. */
+      if (pinnedExit === null) panel.style.removeProperty("--exit");
+      if (rail) rail.removeAttribute("data-faint");
+      wasFaint = null;
       return;
     }
-    landing = Math.max(1, docTop(panel) - (parseFloat(cs.scrollMarginTop) || 0));
+    /* AND NOT PAST THE END OF THE DOCUMENT, which is the second half of "where
+       the page comes to rest" and was invisible until #72 asked a composition to
+       BE somewhere at the far end rather than merely to be a colour. The snap
+       port is a fractional number off layout and the document's scrollable
+       length is a rounded one: on a 1440x900 window the port computes to 782.77
+       and the page cannot scroll past 782, so the turn was arriving at t =
+       0.9990 and staying there. It cost --dark and --turn nothing — 0.999 of a
+       colour is that colour — and it costs --exit a composition that is settled
+       to within a tenth of a per cent and never quite settled, which is exactly
+       what "arrives at rest" is not. The min is the honest definition either
+       way: a landing the page cannot reach is not where it lands.
+       BOTH TERMS COME OFF THE SAME LAYOUT, so this cannot disagree with itself
+       while the page is still loading: sampled every frame with every image and
+       the recording answered four seconds late, the port and the document's
+       length are 782.77 and 782 from the first frame at 130 ms and never move. */
+    landing = Math.max(1, Math.min(
+      docTop(panel) - (parseFloat(cs.scrollMarginTop) || 0),
+      document.documentElement.scrollHeight - window.innerHeight));
     ready = true;
   }
 
@@ -94,6 +151,31 @@
        them faintly drawn over the opening composition for longer rather than
        less. */
     root.style.setProperty("--enter", clamp01(t / 0.34).toFixed(3));
+    /* The Panel arriving — see the header. Written on the section, unclamped:
+       the sheet clamps it once in --exit-c so that no driver has to. Skipped
+       entirely while a tuner is holding the number, rather than written from it,
+       so that the hold does not depend on this function being reached: outside
+       the turn regime there is no landing and nothing above here runs. */
+    if (pinnedExit === null) panel.style.setProperty("--exit", (t - 1).toFixed(4));
+    /* AND THE RAIL IS NOT A POINTER TARGET WHILE IT IS STILL ARRIVING, which is
+       the one thing turning its entries into links costs. The Rail stands above
+       the fold at rest on purpose and --enter fades it in over the first third
+       of the turn — so at the top of the page its first entry is a link that is
+       drawn at nothing, over the bottom-left corner of the CV, and would still
+       take a click. Same threshold as --enter's, so "drawn" and "clickable"
+       start together. The attribute and not `opacity: 0` doing it: an opacity-0
+       element is hit-tested, and the keyboard is unaffected either way, which is
+       what keeps the focus route in #72's criteria open. A browser that never
+       runs this file never gets the attribute, and gets a Rail that is drawn
+       (--enter is declared 1) and clickable — which is the right pair. */
+    if (rail) {
+      var faint = t < 0.34;
+      if (faint !== wasFaint) {
+        if (faint) rail.setAttribute("data-faint", "");
+        else rail.removeAttribute("data-faint");
+        wasFaint = faint;
+      }
+    }
   }
 
   function kick() {
@@ -105,6 +187,38 @@
   /* `load` is for the three corner pictures: they arrive late and settle the
      CV's height, which is what the landing is measured from. */
   window.addEventListener("load", function () { measure(); kick(); });
+
+  /* THE TUNER'S HANDLE ON THIS, and the only reason anything here is exposed —
+     the same arrangement, for the same reason, that cut-morph.js gives its own
+     tuner through window.__cutMorph.
+
+     design/plinth/plinth-tuner.html iframes this page and scrubs --exit to judge
+     an exit treatment by watching. Before #72 nothing on the page wrote --exit,
+     so writing it inline from out there was the whole of the job. Now this file
+     writes it on every scroll and resize — and an iframe both scrolls (the tuner
+     puts the Panel on screen with scrollIntoView) and resizes (its panes are
+     laid out against the window), so a scrub set to 0.62 would silently snap
+     back to wherever the iframe's scroll position said. Pinning is what stops
+     that: a number holds --exit against the scroll, and null hands it back. */
+  window.__arrival = {
+    /* Anything that is not a finite number — null, for one — hands --exit back
+       to the scroll position. Written here on the spot rather than queued
+       through kick(), for the reason cut-morph.js gives for the same choice: it
+       is one discrete change and waiting a frame to see it is the wrong feel,
+       and the tuner reads the page back immediately after asking, so a deferred
+       write would have it measuring the value it was replacing. Written WITHOUT
+       going through frame(), so a hold works at any window size — frame() has a
+       landing to divide by and outside the turn regime there is not one. */
+    setExit: function (v) {
+      pinnedExit = typeof v === "number" && isFinite(v) ? v : null;
+      if (pinnedExit === null) { measure(); kick(); }
+      else panel.style.setProperty("--exit", String(pinnedExit));
+    },
+    /* For a tuner that moves the layout without firing resize — swapping the
+       section's wording or its size, which is what #69's does. */
+    remeasure: function () { measure(); kick(); }
+  };
+
   measure();
   kick();
 })();

--- a/portfolio/index.html
+++ b/portfolio/index.html
@@ -294,7 +294,7 @@
        two things that used to sit at this line, an @font-face at the foot of
        styles.css and a script that attached /fonts/friz-local.css on localhost
        only, are both gone. See the cut title block in styles.css. -->
-  <link rel="stylesheet" href="styles.css?v=36">
+  <link rel="stylesheet" href="styles.css?v=37">
 </head>
 <body>
   <!-- Only ever on screen while a corner picture is genuinely outstanding: it is
@@ -372,35 +372,62 @@
        asked to beat, exactly as it reads the subheading's two text nodes. A
        default nobody has written down is not something a tuner can call shipped.
 
-       NOTHING MOVES BECAUSE OF THEM. --exit is 0 and is declared 0 in the
-       sheet, so all three treatments resolve to the settled composition — the
-       page is byte-identical to one without them, measured, at two widths. What
-       writes --exit is a crossing between Panels, and there is only one Panel:
-       #72 is where these start being driven. -->
+       WHAT DRIVES THEM IS THE SCROLL POSITION, since #72: arrival.js writes
+       --exit as (turn - 1), so this composition ARRIVES as the page crosses into
+       the section rather than standing there waiting to be scrolled to. The
+       settled page is unchanged by that — --exit is 0 at the port and declared 0
+       in the sheet, and the render is byte-identical to one without any of this
+       at four widths in both themes, measured. A crossing between two Panels is
+       the other half of the same number and needs a second Panel to have one. -->
+
   <section class="panel" id="projects" aria-labelledby="panel-masthead"
            data-exit-text="lift" data-exit-frame="recede" data-exit-plinth="sink">
-    <!-- The Rail. Three projects, one Panel: Photo Vault is the selected one and
-         the other two are grey and inert until they have compositions of their
-         own. They are not links yet — there is nowhere to send anyone — and #72
-         is where they start navigating.
+    <!-- The Rail — and as of #72 it navigates. Three projects, one Panel: Photo
+         Vault has a composition and is a link to it; the other two are grey and
+         inert until they have one of their own, which is #58's own out-of-scope
+         note rather than an omission here.
 
-         A PLAIN LABELLED LIST, NOT A <nav>, AND NOT `aria-current`, because
-         neither would be telling the truth yet. A nav landmark announces a set
-         of links to somewhere; this is three words, two of which lead nowhere,
-         and a landmark that offers nothing to navigate is worse than no landmark
-         at all. `aria-current` has the same problem one level down — it is
-         defined against the element a user has moved to, and on a plain <li>
-         screen readers are not obliged to say anything about it, so the
-         selection would be drawn and not announced while looking as though it
-         had been. So the qualifier is words: .visually-hidden, the same device
-         the cut title uses for the word it draws as a picture. #72 turns these
-         into links, and that is the change that earns the <nav> and the
-         `aria-current` back. -->
-    <ul class="panel-rail" aria-label="Projects">
-      <li class="is-selected">Photo Vault<span class="visually-hidden"> — shown below</span></li>
-      <li>Eater Map</li>
-      <li>Record Engine</li>
-    </ul>
+         AN ENTRY IS A ROUTE IF IT HOLDS A LINK, and that is the whole of the
+         machinery — there is no `data-` attribute saying which Panel an entry
+         names, because the link's own fragment already says it. app.js reads the
+         hash, finds the section it names, and eases the page onto that section's
+         snap port; an entry with no link has no Panel and there is nothing to
+         read. So the third and fourth entries are two more <li> with an <a> in
+         them on the day their Panels arrive, and nothing else changes.
+
+         WHICH IS WHAT EARNS THE <nav> AND `aria-current` BACK. #64 argued
+         against both, and the argument was about there being nowhere to go: a
+         landmark announcing a set of links to somewhere, over three words that
+         all led nowhere. One of them leads somewhere now, and `aria-current` is
+         defined against exactly this — the item in a set that the reader is
+         currently on — and it is on an <a>, where it is announced, rather than
+         on a plain <li>, where screen readers are not obliged to say anything
+         about it. That is why the .visually-hidden qualifier has come off this
+         entry and gone onto the two that are still inert: the selection is now
+         announced by the role, and what is not yet announced is why two of the
+         three cannot be followed.
+
+         `role="list"` ON A LIST THAT ALREADY IS ONE, because .panel-rail-items
+         carries `list-style: none` and VoiceOver drops list semantics from a
+         list with no markers. #72 asks for the Rail to be announced as a list of
+         projects; the role is what makes that true in the browser the criterion
+         is most likely to be checked in.
+
+         HREFS ARE REWRITTEN AT RUN TIME, and the reason is the one app.js
+         documents at length for the masthead's link and the cut title's: this
+         document sets <base href="/portfolio/"> while Vercel serves it at
+         /portfolio, so a bare "#projects" resolves to a different path and the
+         browser reloads the page to reach an anchor one frame away. app.js
+         replaces it with location.pathname + the fragment. Left as written it
+         still navigates — it just pays for a reload — which is the right
+         fallback for a browser that runs no script at all. -->
+    <nav class="panel-rail" aria-label="Projects">
+      <ul class="panel-rail-items" role="list">
+        <li class="is-selected"><a href="#projects" aria-current="true">Photo Vault</a></li>
+        <li>Eater Map<span class="visually-hidden"> — no page yet</span></li>
+        <li>Record Engine<span class="visually-hidden"> — no page yet</span></li>
+      </ul>
+    </nav>
     <div class="panel-inner">
       <header class="panel-head">
         <!-- WHAT THE CUT WORD TAKES THE PLACE OF, and in the one-screen band not
@@ -703,7 +730,7 @@
   </svg>
   <noscript><p style="text-align:center;font-family:'Sitka Text',Charter,'Iowan Old Style',Georgia,serif;padding:2rem">This site needs JavaScript enabled.</p></noscript>
   <script src="content.js?v=3"></script>
-  <script src="app.js?v=25"></script>
+  <script src="app.js?v=26"></script>
   <!-- Last, and after app.js rather than beside it: the effect stack is a
        treatment of a finished page, and drawAscii() measures the corner pictures
        against a layout that has to exist first. It is also the one script here
@@ -729,7 +756,7 @@
        It is not last only because the three below touch the Frame and want to
        run in their own order; nothing here depends on any of them, or they on
        this. -->
-  <script src="arrival.js?v=1"></script>
+  <script src="arrival.js?v=2"></script>
   <!-- The Panel's recording, and last for the third time for the third version
        of the same reason: all it does is hand the <video> its sources, and a
        browser that skips it keeps the poster that is already on screen — which

--- a/portfolio/styles.css
+++ b/portfolio/styles.css
@@ -2578,22 +2578,39 @@ body::after {
    rotating each item turns only its own glyphs. Each then measures as a tall
    narrow box in an ordinary column, so `space-between` still means what it says.
    Exactly one is selected, and it is said twice: .is-selected here for anything
-   looking, and a .visually-hidden qualifier in the markup for anything
-   listening — the comment there says why that rather than `aria-current`. */
+   looking, and `aria-current` on that entry's link for anything listening — the
+   comment in index.html says why that is now the honest pair.
+
+   TWO BOXES SINCE #72, AND THE SPLIT IS THE LANDMARK'S. .panel-rail is a <nav>
+   and owns the PLACEMENT — the grid cell it holds here, the page margin it
+   stands in inside the turn regime, the opacity the landing gives it — and
+   .panel-rail-items is the <ul> inside it and owns the LIST. Every rule that
+   placed the Rail before is still on .panel-rail and unmoved; what came off it
+   is the flex column the three names are spread down, which is the list's own
+   business. Doing it the other way round — the landmark on the inner box — would
+   have put a nav inside a list item, and `display: contents` on the <ul> to keep
+   one box is exactly what costs the list its role in a screen reader. */
 .panel-rail {
-  list-style: none;
-  margin: 0;
-  padding: 0;
   display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  align-items: center;
   /* The one thing in the section that answers to the SCREEN and not to the
      composition: it spans the page's whole margin-to-margin height, whatever the
      drawing beside it came out at. `stretch` against the `align-items: center`
      the panel sets for the composition — three names spread over part of the
      window would read as a list that ran out rather than as an edge. */
   align-self: stretch;
+}
+.panel-rail-items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  /* Fills the <nav> in both axes, so `space-between` is spreading the names down
+     the whole of whatever height the placement above arrived at rather than down
+     the height of the three names themselves. */
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  align-items: center;
 }
 .panel-rail li {
   writing-mode: vertical-rl;
@@ -2603,8 +2620,29 @@ body::after {
   letter-spacing: 0.22em;
   color: var(--panel-muted);
 }
-/* The whole of the selection, and the whole of what #72 will have to move. */
+/* The whole of the selection, and it reaches the link because the link takes its
+   colour from the item rather than having one of its own. */
 .panel-rail li.is-selected { color: var(--panel-ink); }
+/* ---- the entries that navigate — #72 ---------------------------------------
+   `a { color: inherit }` is already the page's rule, so the only thing an entry
+   gains by holding a link is the underline, which goes: these are three words in
+   a margin and an underline across a rotated one reads as a strikethrough.
+
+   THE FOCUS RING IS THE PAGE'S OWN, the hairline-and-3px the carousel, the theme
+   toggle and the cut title all use, so a reader tabbing down the page is not
+   handed a different indicator by the last thing on it. It cannot be clipped by
+   .panel's `overflow: clip` even though the Rail stands at `left: 0` inside the
+   turn regime: the item is centred in a --corner-wide column and measures one
+   line of type across, so the ring is tens of pixels clear of the edge. */
+.panel-rail a { text-decoration: none; }
+.panel-rail li:not(.is-selected) a:hover { color: var(--panel-ink); }
+.panel-rail a:focus-visible { outline: 1px solid currentColor; outline-offset: 3px; }
+/* Set by arrival.js for as long as the Rail is still fading in over the top of
+   the CV, and only inside the turn regime — an opacity-0 link is still a click
+   target and the Rail's first entry stands in the bottom-left of the first
+   screen. The file says why an attribute rather than a property; the keyboard is
+   untouched, which is the point. */
+.panel-rail[data-faint] { pointer-events: none; }
 
 /* ---- the composition -------------------------------------------------------
    Twelve columns, two rows, and the placements below are the design render read
@@ -3162,8 +3200,9 @@ body::after {
    INERT, AND SAID TWICE. `pointer-events: none` here, and nothing in the markup
    below is a button or a link — see the comment there. The Frame is not a link
    because the photos site binds to loopback and there is nowhere to send anyone;
-   this is the arrangement that lets #72 or a later ticket switch that on by
-   changing the elements, without moving a single length in this block.
+   this is the arrangement that lets a later ticket switch that on by changing the
+   elements, without moving a single length in this block. #58 puts the chrome
+   being interactive out of scope, so #72 did not take it.
 
    A flex row, not ten absolutely-positioned percentages, and the measured
    centres are still what places everything: each gap below is the distance
@@ -3674,7 +3713,7 @@ body::after {
 
      `baseline` and not the column's `center`: turned across, these are three
      lines of type on one line and they sit on it. */
-  .panel-rail {
+  .panel-rail-items {
     flex-direction: row;
     flex-wrap: wrap;
     justify-content: flex-start;
@@ -4008,10 +4047,12 @@ body::after {
    which is the treatment that makes mixing worth having at all, because it is
    only legible against a Frame and a text that do leave. It is also the one
    whose crossing wants the two Panels to SHARE a plinth rather than to hold one
-   each, and sharing is an arrangement only #72 can make; until it does, two
-   Panels crossing with `hold` both draw their own slab in the same place. Which
-   is exactly right when the two slabs are the same stone, and is worth knowing
-   before a second marble is chosen for a second project. */
+   each, and sharing is an arrangement that needs a SECOND PANEL to be made — #72
+   drove --exit off the scroll position but there is still one composition, so
+   there is nothing to share a slab with. Two Panels crossing with `hold` will
+   each draw their own slab in the same place until then, which is exactly right
+   while the two are the same stone, and is worth knowing before a second marble
+   is chosen for a second project. */
 .panel[data-exit-plinth="hold"] { --exit-plinth-x: 0; --exit-plinth-y: 0;
                                   --exit-plinth-scale: 0; --exit-plinth-fade: 0; }
 
@@ -5231,7 +5272,7 @@ body::after {
      leaves there, and an index in the margin is a thing a printed page does.
      `left`, `top` and `bottom` are against .panel's padding box, which is its
      whole box — absolute insets ignore padding — so `left: 0` is the window's
-     edge and the width IS the margin, with .panel-rail's own `align-items:
+     edge and the width IS the margin, with .panel-rail-items' own `align-items:
      center` putting the type down the middle of it. */
   .panel-rail {
     position: absolute;
@@ -5527,6 +5568,18 @@ body::after {
      block in the section reaches its own factor directly. */
   .panel-copy { opacity: calc(clamp(0, calc(var(--enter) / 0.34), 1) * var(--exit-text-o)); }
   .panel-rail { opacity: clamp(0, calc(var(--enter) / 0.34), 1); }
+  /* AND THE RAIL IS DRAWN WHENEVER IT HOLDS FOCUS — #72 asks for a visible focus
+     state on the Rail's labels, and at the top of the page --enter is 0, so a
+     reader tabbing off the end of the CV would land on a link that is there,
+     announced, and invisible. `:focus-within` and not `:has(:focus-visible)`:
+     the ring itself is still `:focus-visible`'s to draw, so a mouse click does
+     not paint one, but the thing the ring is drawn ON has to be opaque either
+     way — including for the one browser that draws a ring on a click.
+     Not scrolling instead, which was the other answer and is worse: the Rail
+     stands above the fold at rest on purpose, and moving the page because focus
+     arrived would take the reader somewhere they had not asked to go. Following
+     the link is what does that, and that is a keystroke away. */
+  .panel-rail:focus-within { opacity: 1; }
 }
 
 /* ---- print: clean text CV, no photos ------------------------------------- */


### PR DESCRIPTION
The composition ARRIVES rather than standing at the foot of the page waiting
to be scrolled to. arrival.js writes --exit as (turn - 1) on the section, which
is exactly the incoming half of the signed number #74 built the exit treatments
around: the text, the Frame and the plinth come in under whichever mixture is
selected, at the rate it was chosen at.

It is a pure function of the scroll position and holds no state, which is where
every one of #72's continuity criteria comes from rather than from three separate
mechanisms. A reversal mid-turn unwinds exactly because there is nothing to
unwind. A fast scroll cannot strand a half-arrived composition because the
composition is not a thing that travels on its own. A touch drag is the same
number as a wheel notch because neither is read. Measured: --exit tracks the
scroll to 0.00000 over 41 samples, identical scrolling up and down, and welded
to the page frame by frame through a real mid-flight reversal.

The Rail navigates. Its entries are a <nav> of links now, which is what earns
back the landmark and the `aria-current` #64 argued against while all three led
nowhere — an entry is a route if it holds a link, so the other two Panels are two
more <a> on the day they exist and nothing else changes. A route goes through the
same turnPage() the wheel handler calls, so a notch taken during it retargets the
turn instead of fighting a second listener, and the page turn behaves exactly as
it did.

Three things the ticket did not ask for and the change forced:

* THE LANDING WAS NEVER QUITE REACHED. The snap port is fractional off layout and
  the document's scrollable length is rounded, so on a 1440x900 window the turn
  arrived at t = 0.9990 and stayed. It cost --dark nothing and costs a
  composition the difference between settled and nearly settled, so the landing
  is now min(port, what the page can actually scroll).

* AN INVISIBLE LINK OVER THE FOOT OF THE CV. The Rail is above the fold at rest
  and --enter fades it in, and an opacity-0 link still takes a click. arrival.js
  marks it data-faint below the same threshold and the sheet drops its
  pointer-events; the keyboard is untouched, and :focus-within draws the Rail so
  a focus ring is never on something invisible.

* THE VARIANT TUNER'S SCRUB WAS BEING CLOBBERED. Nothing wrote --exit before, so
  the tuner wrote it inline; now the page writes it on every scroll and resize
  and an iframe does both. arrival.js exposes the same kind of pin cut-morph.js
  gives its own tuner, and the tuner asks for a hold instead. Measured through an
  iframe scroll and a window resize.

design/tools/check-panel-nav.mjs is new and asserts the reader's experience
rather than the mechanism: where the page ends up, what the composition was drawn
at on the way, what the browser's own ARIA tree says, and that reduced motion
removes the movement and keeps the navigation. Two of its measurements are
deliberately reported and not asserted, with the reason written down — a per-frame
velocity off a second rAF reads 2x high at random, and headless starves the turn's
own rAF to 10Hz.

The settled page did not move: byte-identical renders against origin/development
at four widths in both themes, with the Rail's boxes identical to the hundredth
of a pixel. #62's check reports 592 / 852 / 80 / 80 and 188.4 / 46.1, unchanged.
