### PR TITLE
Choose where in the turn the page goes dark, by watching (#58)

### DIFF
--- a/design/README.md
+++ b/design/README.md
@@ -79,6 +79,14 @@ design/
                          the Panel leaving and the Panel arriving are on the
                          screen together; the readout beside the scrub is how
                          thin the two ever get at once, measured off both.
+                         And WHERE IN THE TURN THE PAGE GOES DARK (#73, #58): two
+                         sliders for the crossing's ends and a scrub that holds
+                         the turn, so the middle of a crossing is a thing you can
+                         stand in — the iframe otherwise opens at the far end,
+                         where the crossing is already over. The readout is
+                         measured off the ground rather than off the numbers,
+                         which is how you find out the page is already black a
+                         sixth of a turn before `finishes at` says.
                          Its one approximate half is a WebGL previz of the
                          procedural stone's recipe, for asking what a change
                          would do without paying a minute of Cycles; it is stale
@@ -88,7 +96,9 @@ design/
                          shipping a treatment would take, and a `glass-state v2`
                          blob that imports straight into glass-tuner.html; and
                          for the exit the markup line, the moved numbers as the
-                         declarations they are, and an `exit-state v1` blob.
+                         declarations they are, and an `exit-state v1` blob; and
+                         for the crossing the two declarations and a
+                         `cross-state v1` blob.
     plinth-studio.py     interactive, and the only tool in design/ that is a
     plinth-studio.html   SERVER rather than a page: photograph in, stone on the
                          site out, with no command in between. Drop an image,
@@ -106,6 +116,24 @@ design/
                      does the Panel's recording behave the way #65 asks — it
                      plays, loops, is silent, and under prefers-reduced-motion
                      not one byte of either video file is fetched
+    check-panel-nav.mjs
+                     does scrolling carry the reader into the section and does
+                     the Rail tell the truth (#72). Measures the weld between the
+                     composition and the scroll position frame by frame through a
+                     real mid-flight reversal, and reads the browser's own ARIA
+                     tree rather than the markup
+    check-crossing.mjs
+                     does the page cross into dark where the sheet says, and come
+                     back (#73, tunable per #58). Every number in it is body's own
+                     computed ground rasterised to sRGB through a 1x1 canvas, so
+                     nothing is asserted about a property: light at the top, the
+                     section's own black at rest, monotone and identical in both
+                     directions, and a moved --cross-in/--cross-out honoured on
+                     both sides. Also that a deep link lands settled rather than
+                     mid-crossing, that a reader who chose light still gets light
+                     after scrolling back, and that neither <html> nor body
+                     animates or eases its colour — which is the assertion that
+                     keeps the profile capture from photographing this page dark
     check-panel-exit.mjs
                      do the Panel's exit treatments behave the way #74 asks. It
                      reads one Panel TWICE, at t and at t - 1, because that is
@@ -122,8 +150,8 @@ The **lab** compares finished candidates; the **tuner** is for arriving at one.
 The **plate tuner** does the same job for the three photographs in the page's
 corners, and the **plinth tuner** for the whole of the Projects Panel — the
 stone it stands on, the wording of its subheading, what sits behind its glass,
-what that glass is made of, and how the whole composition comes apart when it is
-left. Every one of the five is the real page driven in
+what that glass is made of, how the whole composition comes apart when it is
+left, and where in the turn the page crosses into dark. Every one of the five is the real page driven in
 an iframe, so what is being looked at is what would ship — the exit twice over,
 because `crossing` puts a second real page on top of the first rather than
 drawing a picture of one. THE STONE is where it

--- a/design/plinth/plinth-tuner.html
+++ b/design/plinth/plinth-tuner.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Panel tuner — the marble, the wording, the glass, the exit</title>
+  <title>Panel tuner — the marble, the wording, the glass, the exit, the crossing</title>
   <style>
     :root { color-scheme: light dark; --ui: #1a1917; --ui-bg: #fcfbf8; --ui-panel: #f5f2ea; --ui-line: #d6d0c4; --ui-mut: #6f6a5d; --ui-hit: #8a5a2b; }
     @media (prefers-color-scheme: dark) {
@@ -126,6 +126,12 @@
     #scrub { flex: 1 1 12rem; min-width: 8rem; accent-color: var(--ui-hit); }
     #presence { font: 11px/1 ui-monospace, Consolas, monospace; color: var(--ui-mut); min-width: 15rem; }
     #presence.thin { color: var(--ui-hit); }
+    /* The turn scrub, on its own strip and shaped like the exit one so the two
+       read as the same kind of control — which they are. */
+    #turn { flex: 1 1 12rem; min-width: 8rem; accent-color: var(--ui-hit); }
+    #turnval { min-width: 7.5rem; }
+    #crossms { font: 11px/1 ui-monospace, Consolas, monospace; color: var(--ui-mut); min-width: 20rem; }
+    #crossms.thin { color: var(--ui-hit); }
 
     /* THE TWO COMPOSITIONS, ONE OVER THE OTHER, which is the only arrangement
        that answers the question the crossing asks: is there ever a moment when
@@ -228,6 +234,37 @@ until asked for.">crossing</button>
     <span class="grow"></span>
     <span id="presence"></span>
   </div>
+  <!-- THE CROSSING INTO DARK, #73, MADE A THING YOU CAN LOOK AT. Like the exit
+       scrub above this is a POSITION IN TIME and not a value, so it is up here on
+       the strip that never scrolls; the two numbers it is for — where the
+       crossing starts and where it finishes — are sliders in the sidebar.
+
+       WHY IT EXISTS AT ALL. This page puts the Panel on screen with
+       scrollIntoView, which lands at the FAR END of the turn, so a page seen
+       through this iframe is always fully crossed and there is nothing about the
+       crossing to judge. Holding the turn is what lets it be looked at at 0.3.
+
+       THE TWO SCRUBS ARE INDEPENDENT ON PURPOSE. `scrub` is where the
+       composition stands and this is where the page's COLOUR is, and holding one
+       still while the other moves is the whole point of having two: an exit
+       treatment is judged against a settled ground, and a ground is judged
+       against a settled composition. -->
+  <div class="top exitrow">
+    <strong>turn</strong>
+    <input type="range" id="turn" min="0" max="1" step="0.005" value="1"
+           aria-label="where in the turn the page is drawn"
+           title="0 is the top of the page and 1 is the section at rest. Dragging this HOLDS the
+turn against the iframe's own scroll position — `release` hands it back.
+It moves the page's colour and nothing about where the composition stands; that
+is `scrub` above.">
+    <span class="ms" id="turnval"></span>
+    <button id="turnrelease" title="Hand the turn back to the iframe's scroll position, which is where
+scrollIntoView left it — the far end.">release</button>
+    <span class="grow"></span>
+    <span id="crossms"></span>
+    <span class="badge" id="crosscount" data-n="0">0 moved</span>
+    <button id="crossreset">reset crossing</button>
+  </div>
   <p class="warn" id="warn"></p>
 
   <div class="wrap">
@@ -252,6 +289,10 @@ until asked for.">crossing</button>
             <h3>the exit treatments <button id="copy-exit">copy</button></h3>
             <textarea id="out-exit" spellcheck="false" readonly style="height:13rem"></textarea>
           </div>
+          <div class="out">
+            <h3>the crossing into dark <button id="copy-cross">copy</button></h3>
+            <textarea id="out-cross" spellcheck="false" readonly style="height:11rem"></textarea>
+          </div>
         </div>
       </div>
     </aside>
@@ -269,16 +310,18 @@ until asked for.">crossing</button>
 
 <script>
 /* ============================================================================
-   Panel tuner — the four things about the Projects Panel that were left to be
-   chosen by eye: which stone the plinth is cut from and what that stone is made
-   of, which of #57's five wordings the subheading carries, what sits behind the
-   titlebar's glass, and what the glass itself is made of.
+   Panel tuner — everything about the Projects Panel that was left to be chosen by
+   eye: which stone the plinth is cut from and what that stone is made of, which
+   of #57's five wordings the subheading carries, what sits behind the titlebar's
+   glass, what the glass itself is made of, how the composition comes apart when
+   it is left, and where in the turn the page crosses into dark.
 
-   ALL FOUR ARE SWITCHED OVER THE REAL COMPOSITION, which is the whole design of
+   ALL OF IT IS SWITCHED OVER THE REAL COMPOSITION, which is the whole design of
    this page and not a convenience. /portfolio is in an iframe, same origin, and
    every control below reaches into it: the stone is a `data-marble` attribute,
-   the wording is two text nodes, and the glass is portfolio/frame-glass.js's own
-   uniforms moved through the seam at the foot of that file. So the Frame is the
+   the wording is two text nodes, the glass is portfolio/frame-glass.js's own
+   uniforms moved through the seam at the foot of that file, and the exit and the
+   crossing are custom properties portfolio/arrival.js reads. So the Frame is the
    real Frame at the real width, the type is the real face with the real amount
    bitten out of its second line by the real window, and the reflection lying in
    the marble is the real reflection. Nothing here draws a picture of the Panel to
@@ -372,6 +415,11 @@ until asked for.">crossing</button>
   var glassCountEl = document.getElementById("glasscount");
   var glassMsEl = document.getElementById("glassms");
   var outExit = document.getElementById("out-exit");
+  var outCross = document.getElementById("out-cross");
+  var turnEl = document.getElementById("turn");
+  var turnValEl = document.getElementById("turnval");
+  var crossMsEl = document.getElementById("crossms");
+  var crossCountEl = document.getElementById("crosscount");
   var ghost = document.getElementById("ghost");
   var scrubEl = document.getElementById("scrub");
   var scrubValEl = document.getElementById("scrubval");
@@ -399,6 +447,7 @@ until asked for.">crossing</button>
   var stoneEl = null;        /* the stone's own controls, rebuilt per stone */
   var glassEl = null;        /* the glass's, built once */
   var exitEl = null;         /* the exit's, rebuilt when a treatment changes */
+  var crossEl = null;        /* the crossing's two ends, built once */
   var clipLoop = 0;          /* the rAF that keeps a MOVING backdrop moving */
   var exitPick = {};         /* group -> treatment name */
   var exitShipped = {};      /* what the page arrived carrying, or null */
@@ -406,6 +455,9 @@ until asked for.">crossing</button>
   var exitVals = {};         /* "text.rate" -> number, sparse, moved off the treatment */
   var exitDefaults = {};     /* the same keys, read off the page under the treatment */
   var exitT = 0;             /* the scrub: where in the crossing this Panel stands */
+  var crossVals = {};        /* "in" / "out" -> number, sparse, moved off the sheet */
+  var crossDefaults = {};    /* the same keys, read off the page */
+  var turnT = null;          /* the turn scrub: a number while it is HELD, null on the scroll */
   var crossing = false;      /* is the second /portfolio loaded and standing on this one */
   var ghostDoc = null, ghostPanel = null;
   var playLoop = 0;          /* the rAF running a crossing, in THIS document */
@@ -746,16 +798,18 @@ until asked for.">crossing</button>
   buildSubPicker();
   buildBehind();
   buildExitChips();
-  /* Three hosts inside one scroller, in this order and made once: the stone's
+  /* Four hosts inside one scroller, in this order and made once: the stone's
      controls are rebuilt every time a stone is picked and the exit's every time
-     a treatment is — the glass's never are — so they cannot share a parent that
-     gets emptied. */
+     a treatment is — the glass's and the crossing's never are — so they cannot
+     share a parent that gets emptied. */
   stoneEl = document.createElement("div");
   glassEl = document.createElement("div");
   exitEl = document.createElement("div");
+  crossEl = document.createElement("div");
   controlsEl.appendChild(stoneEl);
   controlsEl.appendChild(glassEl);
   controlsEl.appendChild(exitEl);
+  controlsEl.appendChild(crossEl);
 
   fetch(SIDECAR, { cache: "no-store" }).then(function (r) {
     if (!r.ok) throw new Error(r.status + " " + r.statusText);
@@ -817,6 +871,9 @@ until asked for.">crossing</button>
        and both ends read the defaults before they build the rows. */
     applyExit();
     buildExitControls();
+    /* And the fifth, on the same terms. */
+    applyCross();
+    buildCrossControls();
     sizeFrame();
     checkShaderCurrent();
   }).catch(function (e) {
@@ -868,6 +925,13 @@ until asked for.">crossing</button>
        have taken focus before someone reaches for ]. Same handler, same origin,
        re-attached on every load because it is a new document each time. */
     doc.addEventListener("keydown", keys);
+    /* AND THE TURN READOUT FOLLOWS THE IFRAME'S OWN SCROLL while nothing is
+       holding it, because "· scroll" has to mean the number beside it is the
+       page's rather than the last one this tuner wrote. Re-attached on every load
+       because it is a new window each time, the same reason `keys` is. */
+    win.addEventListener("scroll", function () {
+      if (turnT === null) win.requestAnimationFrame(markCross);
+    }, { passive: true });
     apply();
     applySub();
     /* The exit's defaults are the shipping page's own under whichever treatment
@@ -878,6 +942,13 @@ until asked for.">crossing</button>
     readExitShipped();
     applyExit();
     buildExitControls();
+    /* The crossing's two ends are the page's own declarations, so like the exit's
+       defaults and the glass's they cannot be read before this. The turn is left
+       on the scroll — scrollIntoView has just put the section on screen, so what
+       the author opens on is the settled composition on its own ground, and the
+       scrub is what takes them back up the turn. */
+    applyCross();
+    buildCrossControls();
     /* Last, and with a redraw asked for: the glass is the only one of the four
        that costs a render, and the page has just drawn itself once with what
        ships. */
@@ -2172,6 +2243,303 @@ until asked for.">crossing</button>
     save();
   });
 
+  /* ---- the crossing into dark ---------------------------------------------
+     #73 built the crossing and measured it over the WHOLE turn; #58's last user
+     story is that the author can find the two points it starts and finishes at
+     by watching rather than by reading a description. That is this: two sliders
+     and a scrub.
+
+     TWO NUMBERS AND NOT A CURVE. The shape is a smoothstep in arrival.js and is
+     not offered here, deliberately — #73 argued the shape (it leaves and arrives
+     at rest, and the drama belongs to the page turn, which is already a quintic)
+     and nothing about the story asks for it back. What was never chosen is WHERE
+     in the turn the crossing sits, and that is exactly two numbers.
+
+     THEY ARE DECLARATIONS IN THE SHEET AND NOT CONSTANTS IN THE DRIVER, which is
+     the whole reason this control can exist: --cross-in and --cross-out are
+     declared in styles.css's crossing block, so writing them inline on the
+     iframe's <html> is a thing an outside document can do, and pasting the pair
+     back into that block is a thing the shipping page can wear. The same
+     arrangement, for the same reason, as the exit treatments' five numbers.
+
+     THE DEFAULTS ARE READ OFF THE PAGE, not restated here. Same reason the glass
+     reads window.panelGlass.defaults and the exit reads the treatment: a pair
+     edited in styles.css has to arrive here as the new default rather than being
+     shadowed by a copy of the old one. So "moved" means moved from what the sheet
+     says today. */
+  var CROSS_ROWS = [
+    { k: "in", prop: "cross-in", label: "starts at", min: 0, max: 1, step: 0.005, dp: 3,
+      tip: "Where in the turn the page begins to leave the paper, as a fraction of it. 0 is the\ntop of the page — the crossing starts the moment the reader does.\nRaising it keeps the CV on paper for longer and then crosses faster, because the\ncrossing always finishes where `finishes at` says." },
+    { k: "out", prop: "cross-out", label: "finishes at", min: 0, max: 1, step: 0.005, dp: 3,
+      tip: "Where the page is fully dark, as a fraction of the turn. 1 is the section at rest.\nWATCH THE READOUT RATHER THAN THIS NUMBER: the ramp is a smoothstep and flattens\nat both ends, so the ground reaches black in 8 bits some way BEFORE this — with the\nshipped 0 and 1 it is black from about 0.85 and the last sixth of the turn is doing\nnothing you can see." }
+  ];
+  /* arrival.js's own floor on the span, restated so the readout can say why a
+     collapsed or inverted pair is being held rather than obeyed. */
+  var CROSS_MIN_SPAN = 0.02;
+  var CROSS_SAMPLES = 40;
+
+  function crossValue(k) {
+    if (crossVals[k] !== undefined) return crossVals[k];
+    if (crossDefaults[k] !== undefined) return crossDefaults[k];
+    return k === "in" ? 0 : 1;
+  }
+
+  /* THE GROUND AS THREE INTEGERS AND NOT AS A STRING, which is the one piece of
+     machinery here worth explaining. `--panel-bg` is a `color-mix` in oklab and
+     Chromium computes body's background to `oklab(0.4999 ...)`, while `--bg` is
+     `#fff`: comparing the two as text compares spellings, and pulling numbers out
+     with a regexp compares 0-to-1 against 0-to-255. Painting each into a 1x1
+     canvas and reading the pixel back is the only comparison that is about the
+     colour, and it is what the eye does anyway. design/tools/check-crossing.mjs
+     measures the same thing the same way. */
+  var crossCtx = null;
+  function groundOf(value) {
+    if (!crossCtx) {
+      var c = document.createElement("canvas");
+      c.width = c.height = 1;
+      crossCtx = c.getContext("2d", { willReadFrequently: true });
+    }
+    crossCtx.clearRect(0, 0, 1, 1);
+    crossCtx.fillStyle = "#000";
+    crossCtx.fillStyle = value;
+    crossCtx.fillRect(0, 0, 1, 1);
+    var d = crossCtx.getImageData(0, 0, 1, 1).data;
+    return [d[0], d[1], d[2]];
+  }
+  function sameGround(a, b) {
+    return Math.abs(a[0] - b[0]) <= 1 && Math.abs(a[1] - b[1]) <= 1 && Math.abs(a[2] - b[2]) <= 1;
+  }
+
+  /* What the sheet says, read in the one moment nothing inline is shadowing it —
+     the same clear-then-read applyExitTo() does for the treatments. */
+  function readCrossDefaults() {
+    if (!win || !doc) return;
+    var cs = win.getComputedStyle(doc.documentElement);
+    CROSS_ROWS.forEach(function (r) {
+      var v = parseFloat(cs.getPropertyValue("--" + r.prop));
+      crossDefaults[r.k] = isNaN(v) ? (r.k === "in" ? 0 : 1) : v;
+    });
+  }
+
+  function applyCross() {
+    if (!doc || !win) { markCross(); writeCross(); return; }
+    var r = doc.documentElement;
+    CROSS_ROWS.forEach(function (x) { r.style.removeProperty("--" + x.prop); });
+    readCrossDefaults();
+    CROSS_ROWS.forEach(function (x) {
+      if (crossVals[x.k] !== undefined) r.style.setProperty("--" + x.prop, String(crossVals[x.k]));
+    });
+    /* AND THE PAGE HAS TO BE ASKED TO RE-READ THEM. arrival.js reads the pair
+       once per measure rather than once per frame — a getComputedStyle in a
+       scroll handler is a forced recalculation sixty times a second — so a pair
+       written inline is invisible to it until something remeasures. This is what
+       that handle is for, and it is why the sliders below could not have been
+       built against a driver that kept the two numbers to itself. */
+    if (win.__arrival && win.__arrival.remeasure) win.__arrival.remeasure();
+    positionTurn();
+    measureCrossing();
+    markCross();
+    writeCross();
+  }
+
+  /* ---- where the crossing actually starts and finishes, MEASURED -----------
+     The two sliders say what was asked for; this says what the page does with
+     it, and the difference is the point. The ramp is a smoothstep, so it
+     flattens at both ends and the GROUND saturates in 8 bits before the number
+     does: with the shipped 0 and 1 the page is already black from about turn 0.85
+     and the last sixth of the turn is doing nothing an eye can see. That is worth
+     knowing while choosing and is invisible from the sliders.
+
+     Swept through the same hold the scrub uses, and the hold is put back
+     afterwards — the same shape as measurePresence(), which sweeps --exit and
+     restores it. Not run while the scrub is being dragged: 41 style
+     recalculations per frame on a page carrying a WebGL Frame is not a thing to
+     do sixty times a second, and nothing it measures can change while only the
+     scrub moves. */
+  function measureCrossing() {
+    if (!win || !doc || !doc.body) { crossMsEl.textContent = ""; crossMsEl.className = ""; return; }
+    var api = win.__arrival;
+    if (!api || !api.setTurn) {
+      crossMsEl.textContent = "no driver — arrival.js returns early under prefers-reduced-motion";
+      crossMsEl.className = "thin";
+      return;
+    }
+    var root = doc.documentElement;
+    var near = groundOf(win.getComputedStyle(root).getPropertyValue("--bg").trim());
+    var far = groundOf(win.getComputedStyle(root).getPropertyValue("--panel-bg-far").trim());
+    var lastNear = -1, firstFar = -1, seen = {};
+    for (var i = 0; i <= CROSS_SAMPLES; i++) {
+      api.setTurn(i / CROSS_SAMPLES);
+      var g = groundOf(win.getComputedStyle(doc.body).backgroundColor);
+      seen[g.join(",")] = 1;
+      if (sameGround(g, near)) lastNear = i;
+      if (firstFar < 0 && sameGround(g, far)) firstFar = i;
+    }
+    api.setTurn(turnT);
+    var span = crossValue("out") - crossValue("in");
+    var held = span < CROSS_MIN_SPAN;
+    /* The one case where the sheet's floor is doing the talking rather than the
+       sliders, said out loud rather than left as a ramp that does not match the
+       numbers beside it. */
+    if (sameGround(near, far)) {
+      crossMsEl.textContent = "this theme's ground and the section's are the same colour — nothing to see";
+      crossMsEl.className = "thin";
+      return;
+    }
+    crossMsEl.textContent =
+      "paper until turn " + (lastNear < 0 ? "—" : (lastNear / CROSS_SAMPLES).toFixed(3)) +
+      " · black from " + (firstFar < 0 ? "never" : (firstFar / CROSS_SAMPLES).toFixed(3)) +
+      " · " + Object.keys(seen).length + " grounds" +
+      (held ? " · SPAN HELD AT " + CROSS_MIN_SPAN : "");
+    crossMsEl.className = held || firstFar < 0 ? "thin" : "";
+  }
+
+  /* ---- the scrub -----------------------------------------------------------
+     WHERE YOU ARE STANDING IS NOT WHAT YOU HAVE CHOSEN, the same split the exit
+     scrub is written around: this writes the one number that moved and does not
+     re-read a default or sweep anything. */
+  function positionTurn() {
+    if (!win || !win.__arrival || !win.__arrival.setTurn) { markCross(); return; }
+    win.__arrival.setTurn(turnT);
+    markCross();
+    /* AND AGAIN ON THE NEXT FRAME, WHEN THE HOLD IS BEING HANDED BACK. A hold is
+       written on the spot, so marking it immediately reads the number that was
+       just set; a RELEASE only queues the driver's own rAF, so --turn still says
+       where the hold was and the readout would keep claiming 0.350 on a page that
+       had gone back to 1.
+       THE IFRAME'S rAF AND NOT THIS DOCUMENT'S, which is the whole of the fix and
+       cost one wrong one first: two documents have two callback queues and nothing
+       orders them against each other, so a frame requested out here can run before
+       the driver's inside there and read the value it was waiting for to change.
+       Requested in the same window as the driver's, after the driver's, it runs
+       after the driver's. */
+    if (turnT === null && win.requestAnimationFrame) win.requestAnimationFrame(markCross);
+  }
+
+  function setTurnHold(t) {
+    turnT = t === null ? null : Math.max(0, Math.min(1, t));
+    positionTurn();
+  }
+
+  /* Where the page is when nothing is holding it, which is where scrollIntoView
+     left it — the far end. Read rather than assumed so the released readout says
+     the truth on a page that has been scrolled by hand inside the iframe. */
+  function turnOnPage() {
+    if (!win || !doc) return null;
+    var v = parseFloat(win.getComputedStyle(doc.documentElement).getPropertyValue("--turn"));
+    return isNaN(v) ? null : v;
+  }
+
+  function markCross() {
+    /* NO DRIVER MEANS NO POSITION TO REPORT, and reporting one anyway was the
+       readout's one lie: under prefers-reduced-motion arrival.js returns before
+       it writes --turn, so the sheet's declared 0 reads back as "the top of the
+       page" on an iframe that is scrolled to the section. The scrub cannot move
+       anything there either, so it says so instead of showing a number. */
+    var driven = !!(win && win.__arrival && win.__arrival.setTurn);
+    var live = turnT === null ? turnOnPage() : turnT;
+    if (live !== null) turnEl.value = String(live);
+    turnEl.disabled = !driven && !!doc;
+    turnValEl.textContent = !driven && doc ? "— · no driver"
+      : (live === null ? "—" : live.toFixed(3)) + (turnT === null ? " · scroll" : " · held");
+    document.getElementById("turnrelease").disabled = turnT === null;
+    var n = Object.keys(crossVals).length;
+    crossCountEl.textContent = n + " moved";
+    crossCountEl.dataset.n = n;
+  }
+
+  turnEl.addEventListener("input", function () { setTurnHold(parseFloat(turnEl.value)); });
+  document.getElementById("turnrelease").addEventListener("click", function () { setTurnHold(null); });
+  document.getElementById("crossreset").addEventListener("click", function () {
+    crossVals = {};
+    turnT = null;
+    applyCross();
+    buildCrossControls();
+    save();
+  });
+
+  /* ---- the sliders -------------------------------------------------------- */
+  function buildCrossControls() {
+    if (!crossEl || !doc) return;
+    crossEl.textContent = "";
+    group(crossEl, "crossing into dark", "cross", function (body) {
+      CROSS_ROWS.forEach(function (r) {
+        row(body, {
+          label: r.label, min: r.min, max: r.max, step: r.step, dp: r.dp, tip: r.tip,
+          onchange: applyCross
+        }, function () { return crossValue(r.k); },
+           function (v) {
+             /* Back to exactly the sheet's own number is having changed your mind
+                rather than an override that happens to match — so it leaves the
+                sparse set, the same rule the exit's rows follow. */
+             if (Math.abs(v - crossDefaults[r.k]) < 1e-9) delete crossVals[r.k];
+             else crossVals[r.k] = v;
+           },
+           crossDefaults[r.k]);
+      });
+    });
+  }
+
+  function writeCross() {
+    if (!outCross) return;
+    var L = [];
+    L.push("panel tuner — the crossing into dark, #73, tunable per #58");
+    L.push("");
+    if (!doc) {
+      L.push("the frame has not loaded yet, so nothing has been read off the page.");
+      outCross.value = L.join("\n") + "\n";
+      return;
+    }
+    var a = crossValue("in"), b = crossValue("out");
+    var moved = Object.keys(crossVals);
+    L.push("THE PAIR — starts at " + fmt(a, 3) + " of the turn, finishes at " + fmt(b, 3) +
+           (moved.length ? ", moved from what the sheet says" : ", which is what the sheet says"));
+    L.push("portfolio/styles.css — in the crossing block's :root, inside the turn regime:");
+    L.push("    --cross-in: " + fmt(a, 3) + ";" +
+           "     /* " + fmt(crossDefaults.in, 3) + " today */");
+    L.push("    --cross-out: " + fmt(b, 3) + ";" +
+           "    /* " + fmt(crossDefaults.out, 3) + " today */");
+    L.push("");
+    if (b - a < CROSS_MIN_SPAN) {
+      L.push("THIS PAIR IS TOO SHORT TO SHIP. arrival.js holds the span at " + CROSS_MIN_SPAN +
+             " rather than");
+      L.push("dividing by nothing, so the page will not do what these two numbers say — a");
+      L.push("crossing that happens inside one wheel notch is the flip #73 says it must not be.");
+      L.push("");
+    }
+    L.push("MEASURED — " + (crossMsEl.textContent || "not measured"));
+    L.push("The ramp is a smoothstep, so it flattens at both ends and the ground reaches");
+    L.push("black in 8 bits BEFORE `finishes at` does. Choose against the measured pair");
+    L.push("rather than the asked-for one: the stretch between them is turn a reader");
+    L.push("spends looking at a page that has stopped changing.");
+    L.push("");
+    L.push("WHAT MOVES AND WHAT DOES NOT. These two carry --dark, and --dark is every");
+    L.push("colour on the page — the ground, the CV's ink, the section's palette and the");
+    L.push("Frame's chrome, all one number. They do NOT carry --turn, which lifts the");
+    L.push("three corner pictures clear of the window as the page comes to rest, or");
+    L.push("--enter, which fades in the two blocks standing above the fold. Those two are");
+    L.push("geometry and are not anybody's taste.");
+    L.push("");
+    L.push("WHAT A SHORTER CROSSING COSTS, since it is the one thing the sliders hide.");
+    L.push("frame-glass.js re-bakes the titlebar when --dark has moved by a sixteenth, so");
+    L.push("a crossing is at most sixteen renders however long it is — a SHORTER one packs");
+    L.push("the same sixteen into less scroll, which is more work per wheel notch on the");
+    L.push("one strip of this page that renders at all. Sixteen is sixteen; watch a phone");
+    L.push("before shipping a crossing much under a third of the turn.");
+    L.push("");
+    L.push("AND NOTHING HERE MAY BECOME AN ANIMATION. The author's profile README is an");
+    L.push("hourly screenshot of /portfolio taken with Playwright's `animations:");
+    L.push('"disabled"`, which fast-forwards finite CSS animations to their end state. Two');
+    L.push("declared numbers read by a scroll handler are safe; the same crossing written");
+    L.push("as a keyframe or a scroll timeline photographs this page fully dark at scroll 0");
+    L.push("while every geometry assertion still passes. See #73, and");
+    L.push("`node design/tools/check-crossing.mjs`, which asserts the pair is honoured and");
+    L.push("that neither <html> nor body is animating or easing its colour.");
+    L.push("");
+    L.push("cross-state v1: " + JSON.stringify({ in: a, out: b, moved: crossVals }));
+    outCross.value = L.join("\n") + "\n";
+  }
+
   /* ======================================================================= */
   /*  the previz                                                             */
   /* ======================================================================= */
@@ -2924,6 +3292,7 @@ until asked for.">crossing</button>
   document.getElementById("copy-css").addEventListener("click", function (e) { e.stopPropagation(); copy(outCss); });
   document.getElementById("copy-panel").addEventListener("click", function (e) { e.stopPropagation(); copy(outPanel); });
   document.getElementById("copy-exit").addEventListener("click", function (e) { e.stopPropagation(); copy(outExit); });
+  document.getElementById("copy-cross").addEventListener("click", function (e) { e.stopPropagation(); copy(outCross); });
   document.getElementById("drawer-head").addEventListener("click", function () {
     var body = document.getElementById("drawer-body");
     var hid = !body.hidden;
@@ -2969,6 +3338,16 @@ until asked for.">crossing</button>
            not what you have chosen, and a tuner that opened at --exit 0.62 would
            open on a composition half gone with no clue why. */
         exitPick: exitPick, exitChosen: exitChosen, exitVals: exitVals,
+        /* The crossing's overrides, sparse, for the reason `glass` and `exitVals`
+           are: a pair edited in styles.css arrives as the new default instead of
+           being shadowed by a stored copy of the old one. There is no `chosen`
+           flag beside it because there is nothing to choose — the two ends are
+           numbers and an unmoved one is simply absent.
+           THE TURN IS DELIBERATELY NOT STORED, the same call the exit scrub's is:
+           it is where you are standing and not what you have chosen, and a tuner
+           that opened holding the turn at 0.3 would open on a half-crossed page
+           with no clue why. */
+        crossVals: crossVals,
         crossing: crossing
       }));
     } catch (_) {}
@@ -3009,6 +3388,17 @@ until asked for.">crossing</button>
           exitChosen = !!s.exitChosen;
         }
         if (s.exitVals && typeof s.exitVals === "object") exitVals = s.exitVals;
+        /* Bounds-checked rather than trusted, for the reason the stored wording
+           is: a pair out of range is a page that either never crosses or is dark
+           from the top, and the second of those is the failure the profile
+           capture cannot see. Each end on its own — a stored `in` is not thrown
+           away because a stored `out` was junk. */
+        if (s.crossVals && typeof s.crossVals === "object") {
+          CROSS_ROWS.forEach(function (r) {
+            var v = s.crossVals[r.k];
+            if (typeof v === "number" && isFinite(v) && v >= 0 && v <= 1) crossVals[r.k] = v;
+          });
+        }
         if (typeof s.crossing === "boolean") crossing = s.crossing;
         /* The stored stone is only put back if it is still the SAME stone —
            a re-render that changed the table should win over a session that
@@ -3028,6 +3418,7 @@ until asked for.">crossing</button>
     markSub();
     markBehind();
     markExit();
+    markCross();
     markCrossing();
     ready = true;
   }

--- a/design/tools/check-crossing.mjs
+++ b/design/tools/check-crossing.mjs
@@ -1,0 +1,588 @@
+/* ============================================================================
+   check-crossing.mjs — does the page cross into dark where the sheet says, and
+   come back? #73's crossing, made tunable by #58's last user story.
+
+     node design/tools/check-crossing.mjs
+
+   Exit 0 if every criterion holds, 1 if any does not, and it names which. It
+   serves the tree it is invoked from, so it answers for the working copy rather
+   than for whatever is deployed — `preview_start` serves the main checkout in
+   this repository and would silently report on `development` while looking like
+   it reported on the branch.
+
+   WHAT IS BEING ASSERTED, AND IT IS A COLOUR AND NOT A PROPERTY. #58's testing
+   note asks for the reader's experience rather than the mechanism, and for the
+   crossing the reader's experience is one thing: what colour the page is. So
+   nothing below reads --dark to decide whether the page is dark. Every number in
+   this file is body's own computed background, rasterised to sRGB through a 1x1
+   canvas so that a `color-mix` in oklab, a `color(srgb ...)` and a plain hex are
+   all the same three integers. --dark is READ in one place — the report — and
+   asserted nowhere.
+
+   WHY THE GROUND AND NOT THE INK. The ground is the only colour on the page that
+   every other one is mixed against, it is painted by ONE element (body — see the
+   crossing block's argument for why there is exactly one), and it is what the
+   silent failure mode looks like: the author's profile preview going black. The
+   two ink remaps are #73's and are measured in that ticket's own terms; what this
+   file asks is whether the page is paper or not, and when.
+
+   THE CROSSING'S TWO ENDS ARE REPORTED AND NOT ASSERTED, deliberately. --cross-in
+   and --cross-out are the author's to choose — that is the whole of the user
+   story — so a test that pinned them to 0 and 1 would fail the moment the choice
+   was made. What is asserted is that whatever pair the sheet declares is the pair
+   the page HONOURS: light before it, dark after it, moving in between, and the
+   same in both directions.
+   ========================================================================== */
+
+import http from "node:http";
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
+import { dirname, extname, join, normalize, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import { chromium } from "playwright";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, "..", "..");
+const PAGE = "/portfolio/";
+
+/* The turn regime is `(min-width: 1100px) and (min-height: 700px)`, and this is
+   the window check-panel-nav.mjs and check-panel-exit.mjs both use, so the three
+   answer about the same drawing. */
+const DESK = { width: 1440, height: 900 };
+
+/* A pair well inside the turn, so both ends have samples on either side of them
+   and neither lands on 0 or 1 where the shipped pair already is. */
+const MOVED = { in: 0.3, out: 0.7 };
+
+const MIME = {
+  ".html": "text/html; charset=utf-8", ".css": "text/css; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8", ".json": "application/json",
+  ".svg": "image/svg+xml", ".png": "image/png", ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg", ".webp": "image/webp", ".woff2": "font/woff2",
+  ".webm": "video/webm", ".mp4": "video/mp4",
+  ".ico": "image/x-icon", ".txt": "text/plain; charset=utf-8",
+};
+
+async function resolveFile(urlPath) {
+  const clean = decodeURIComponent(urlPath.split("?")[0]);
+  const target = resolve(ROOT, "." + normalize(clean).replace(/^([/\\])+/, sep));
+  if (target !== ROOT && !target.startsWith(ROOT + sep)) return null;
+  try {
+    const info = await stat(target);
+    if (info.isDirectory()) {
+      const index = join(target, "index.html");
+      await stat(index);
+      return index;
+    }
+    return target;
+  } catch {
+    return null;
+  }
+}
+
+function serve() {
+  const server = http.createServer(async (req, res) => {
+    const file = await resolveFile(req.url);
+    if (!file) return void res.writeHead(404).end("not found");
+    res.writeHead(200, { "content-type": MIME[extname(file).toLowerCase()] ?? "application/octet-stream" });
+    createReadStream(file).pipe(res);
+  });
+  return new Promise((ok) => server.listen(0, "127.0.0.1", () => ok(server)));
+}
+
+async function open(browser, origin, options = {}, path = PAGE) {
+  const context = await browser.newContext({
+    viewport: DESK,
+    deviceScaleFactor: 1,
+    reducedMotion: "no-preference",
+    colorScheme: "light",
+    ...options,
+  });
+  const page = await context.newPage();
+  await page.goto(origin + path, { waitUntil: "load" });
+  /* The corner pictures settle the CV's height, and the CV's height IS the
+     landing every fraction below is a fraction of. Nothing may be read until
+     they have arrived. */
+  await page.waitForTimeout(2500);
+  await page.evaluate(PROBE);
+  return { context, page };
+}
+
+/* ---------------------------------------------------------------------------
+   the page's own numbers, and one 1x1 canvas
+   ------------------------------------------------------------------------
+   RASTERISED AND NOT PARSED, which is the one piece of machinery in this file
+   worth explaining. `color-mix(in oklab, ...)` computes to a colour Chromium may
+   serialise as `oklab(...)` or `color(srgb ...)` depending on the mix, while
+   `--bg` is `#fff` and a hex — so comparing the strings, or pulling numbers out
+   of them with a regexp, compares different things at different scales. Painting
+   both into a canvas and reading the pixel back is the only comparison that is
+   about the colour rather than about its spelling, and it is what a reader's eye
+   does anyway. */
+const PROBE = () => {
+  const c = document.createElement("canvas");
+  c.width = c.height = 1;
+  const ctx = c.getContext("2d", { willReadFrequently: true });
+  window.__px = (value) => {
+    ctx.clearRect(0, 0, 1, 1);
+    ctx.fillStyle = "#000";
+    ctx.fillStyle = value;
+    ctx.fillRect(0, 0, 1, 1);
+    const d = ctx.getImageData(0, 0, 1, 1).data;
+    return [d[0], d[1], d[2]];
+  };
+  window.__ground = () => window.__px(getComputedStyle(document.body).backgroundColor);
+  window.__token = (name) => window.__px(
+    getComputedStyle(document.documentElement).getPropertyValue(name).trim());
+  /* THREE FRAMES BETWEEN MOVING THE PAGE AND READING IT. The driver is a scroll
+     listener that queues a rAF, so a synchronous read after scrollTo() gets the
+     colour written for wherever the page WAS — the trap check-panel-nav.mjs
+     names, and it costs this file the whole sweep rather than one sample. */
+  window.__settle = () => new Promise((done) => {
+    requestAnimationFrame(() => requestAnimationFrame(() => requestAnimationFrame(done)));
+  });
+};
+
+const GEOMETRY = () => {
+  const panel = document.querySelector(".panel");
+  const cs = getComputedStyle(panel);
+  const docTop = (el) => { let y = 0; for (let n = el; n; n = n.offsetParent) y += n.offsetTop; return y; };
+  const pageMax = document.documentElement.scrollHeight - window.innerHeight;
+  return {
+    regime: cs.scrollSnapAlign !== "none",
+    port: Math.min(pageMax, docTop(panel) - (parseFloat(cs.scrollMarginTop) || 0)),
+    pageMax,
+    theme: document.documentElement.getAttribute("data-theme"),
+    /* What the sheet says, read rather than restated — the pair the page is
+       actually wearing, whatever this file was written against. */
+    crossIn: Number(getComputedStyle(document.documentElement).getPropertyValue("--cross-in")),
+    crossOut: Number(getComputedStyle(document.documentElement).getPropertyValue("--cross-out")),
+    near: window.__token("--bg"),
+    far: window.__token("--panel-bg-far"),
+  };
+};
+
+/* The ground at every fraction of the turn, down and then back up. Both
+   directions in one pass because "it reverses" is a comparison between the two
+   and not a second measurement.
+
+   SNAPPING COMES OFF FOR THE LENGTH OF THE SWEEP, and this is not the test
+   loosening the page to get an answer it likes — it is the page's own lever,
+   pulled the page's own way. `html { scroll-snap-type: y mandatory }` makes the
+   document two ports and nothing between, so a mandatory snap pulls every
+   intermediate scrollTo straight back to the port it started from: the first run
+   of this file sampled 41 positions across the turn and got two colours, because
+   the page had only been at two positions. app.js takes the same property off for
+   exactly the length of the turn's ease and puts it back on landing — its own
+   comment says a turn written as `scrollTo({ behavior: "smooth" })` does not move
+   the page at all otherwise — so the middle of the turn IS a place the reader
+   goes, with snapping off, and this is how to stand there.
+
+   THE FRACTION IS MEASURED AND NOT REQUESTED. Every sample carries the scroll
+   position the page actually reached over the landing, so a snap that came back,
+   a rounded scrollHeight or a fractional port shows up as a moved fraction rather
+   than as a colour attributed to a place the page never was. */
+const SWEEP = async ({ port, samples }) => {
+  const root = document.documentElement;
+  const wasSnap = root.style.scrollSnapType;
+  root.style.scrollSnapType = "none";
+  const at = async (y) => {
+    window.scrollTo(0, y);
+    await window.__settle();
+    return {
+      y: window.scrollY,
+      t: window.scrollY / port,
+      rgb: window.__ground(),
+      dark: Number(getComputedStyle(root).getPropertyValue("--dark")),
+    };
+  };
+  const down = [], up = [];
+  for (let i = 0; i <= samples; i++) down.push(await at((port * i) / samples));
+  for (let i = samples; i >= 0; i--) up.push(await at((port * i) / samples));
+  up.reverse();
+  window.scrollTo(0, 0);
+  await window.__settle();
+  root.style.scrollSnapType = wasSnap;
+  return { down, up };
+};
+
+/* ---------------------------------------------------------------------------
+   the run
+   ------------------------------------------------------------------------ */
+const server = await serve();
+const origin = `http://127.0.0.1:${server.address().port}`;
+const browser = await chromium.launch();
+
+const problems = [];
+const pad = 24;
+const say = (k, v) => console.log(k.padEnd(pad) + " " + v);
+
+const SAMPLES = 40;
+let geo, shipped, moved, restored, collapsed, pinned, released, toggled, still, deep, capture;
+
+try {
+  /* ---- the shipped crossing, and a moved one, in one page ---------------- */
+  {
+    const { context, page } = await open(browser, origin);
+    geo = await page.evaluate(GEOMETRY);
+    if (!geo.regime) throw new Error(`${DESK.width}x${DESK.height} is not in the turn regime`);
+
+    shipped = await page.evaluate(SWEEP, { port: geo.port, samples: SAMPLES });
+
+    /* ---- the pair the sheet declares is the pair the page honours --------
+       Written inline on <html>, which is exactly what the tuner does, and then
+       re-read through the handle arrival.js exposes for it. If the two ends were
+       constants in that file instead of declarations in the sheet, this would be
+       unreachable from out here and so would the tuner. */
+    await page.evaluate(({ a, b }) => {
+      document.documentElement.style.setProperty("--cross-in", String(a));
+      document.documentElement.style.setProperty("--cross-out", String(b));
+      window.__arrival.remeasure();
+    }, { a: MOVED.in, b: MOVED.out });
+    moved = await page.evaluate(SWEEP, { port: geo.port, samples: SAMPLES });
+
+    /* ---- and taking them off puts the shipped ramp back ------------------
+       The one assertion that catches a tuner leaving a page changed: an override
+       removed has to be an override gone, not a value the driver has copied. */
+    await page.evaluate(() => {
+      document.documentElement.style.removeProperty("--cross-in");
+      document.documentElement.style.removeProperty("--cross-out");
+      window.__arrival.remeasure();
+    });
+    restored = await page.evaluate(SWEEP, { port: geo.port, samples: SAMPLES });
+
+    /* ---- and a pair too short to be a crossing still lands dark ----------
+       arrival.js floors the span rather than dividing by nothing, and WHICH END
+       it anchors the floor to is the difference between degrading and breaking:
+       anchored at the near end, a pair like 0.99 / 1 puts the far end of the
+       crossing past the landing and the page comes to REST at --dark 0.5, with
+       the composition on a mid-grey ground. Anchored at the far end the start
+       moves and the finish does not. Asserted rather than argued because the
+       tuner can produce this pair with two drags. */
+    collapsed = await page.evaluate(async ({ port }) => {
+      document.documentElement.style.setProperty("--cross-in", "0.99");
+      document.documentElement.style.setProperty("--cross-out", "1");
+      window.__arrival.remeasure();
+      const root = document.documentElement;
+      const wasSnap = root.style.scrollSnapType;
+      root.style.scrollSnapType = "none";
+      window.scrollTo(0, port);
+      await window.__settle();
+      const rest = window.__ground();
+      window.scrollTo(0, 0);
+      await window.__settle();
+      const top = window.__ground();
+      root.style.scrollSnapType = wasSnap;
+      root.style.removeProperty("--cross-in");
+      root.style.removeProperty("--cross-out");
+      window.__arrival.remeasure();
+      return { rest, top };
+    }, { port: geo.port });
+
+    /* ---- the turn, held ------------------------------------------------- */
+    pinned = await page.evaluate(async () => {
+      const seen = [];
+      for (const t of [0, 0.25, 0.5, 0.75, 1]) {
+        window.__arrival.setTurn(t);
+        await window.__settle();
+        seen.push({ t, y: Math.round(window.scrollY), rgb: window.__ground() });
+      }
+      return seen;
+    });
+    released = await page.evaluate(async () => {
+      window.__arrival.setTurn(null);
+      await window.__settle();
+      return { y: Math.round(window.scrollY), rgb: window.__ground() };
+    });
+
+    await context.close();
+  }
+
+  /* ---- the toggle still chooses what the page crosses FROM ---------------
+     #58's user story 13, and the one that would read as the toggle silently
+     breaking. A reader whose machine is dark, who has chosen light, scrolls into
+     the section and comes back: what they must get at the top is their own
+     choice and not the ground they were just looking at. */
+  {
+    const { context, page } = await open(browser, origin, { colorScheme: "dark" });
+    const before = await page.evaluate(() => document.documentElement.getAttribute("data-theme"));
+    await page.evaluate(() => document.querySelector(".theme-toggle").click());
+    await page.waitForTimeout(600);
+    const g = await page.evaluate(GEOMETRY);
+    const trip = await page.evaluate(async ({ port }) => {
+      const read = () => ({ y: Math.round(window.scrollY), rgb: window.__ground() });
+      window.scrollTo(0, 0); await window.__settle();
+      const top = read();
+      window.scrollTo(0, port); await window.__settle();
+      const rest = read();
+      window.scrollTo(0, 0); await window.__settle();
+      return { top, rest, back: read() };
+    }, { port: g.port });
+    toggled = { before, after: g.theme, near: g.near, far: g.far, ...trip };
+    await context.close();
+  }
+
+  /* ---- reduced motion --------------------------------------------------- */
+  {
+    const { context, page } = await open(browser, origin, { reducedMotion: "reduce" });
+    const g = await page.evaluate(GEOMETRY);
+    const sweep = await page.evaluate(SWEEP, { port: g.port, samples: 20 });
+    /* AND A MOVED PAIR DOES NOT WAKE IT UP, which is the new thing to be sure
+       of: two numbers in the sheet that a reader who asked for no movement can
+       still be crossed by would be #73's criterion undone by #58's feature. The
+       handle is not there to ask — arrival.js returns before it defines one — so
+       the declarations are moved and the page is swept again. */
+    const withMoved = await page.evaluate(async ({ port, a, b }) => {
+      document.documentElement.style.setProperty("--cross-in", String(a));
+      document.documentElement.style.setProperty("--cross-out", String(b));
+      const seen = [];
+      for (let i = 0; i <= 20; i++) {
+        window.scrollTo(0, (port * i) / 20);
+        await window.__settle();
+        seen.push(window.__ground());
+      }
+      window.scrollTo(0, 0);
+      return { handle: !!window.__arrival, seen };
+    }, { port: g.port, a: MOVED.in, b: MOVED.out });
+    still = { port: g.port, near: g.near, far: g.far, sweep, withMoved };
+    await context.close();
+  }
+
+  /* ---- a deep link lands settled, not mid-crossing ---------------------- */
+  {
+    const { context, page } = await open(browser, origin, {}, PAGE + "#projects");
+    const g = await page.evaluate(GEOMETRY);
+    deep = await page.evaluate(() => ({
+      y: Math.round(window.scrollY),
+      rgb: window.__ground(),
+      dark: Number(getComputedStyle(document.documentElement).getPropertyValue("--dark")),
+      exit: Number(getComputedStyle(document.querySelector(".panel")).getPropertyValue("--exit")),
+      hash: location.hash,
+    }));
+    deep.port = g.port;
+    deep.far = g.far;
+
+    /* ---- and there is nothing for the capture to fast-forward -----------
+       The hazard #73 names, asserted rather than argued. The profile capture runs
+       with Playwright's `animations: "disabled"`, which fast-forwards finite CSS
+       animations to their end state — so what must be true of every element
+       carrying the crossing is that no animation and no transition is running on
+       it at all. body's own 0.35s theme fade is switched off inside the turn
+       regime for a different reason (the crossing block says which) and this is
+       the assertion that keeps it off. */
+    capture = await page.evaluate(() => {
+      const of = (el) => {
+        const cs = getComputedStyle(el);
+        return {
+          animation: cs.animationName,
+          transition: cs.transitionProperty + " " + cs.transitionDuration,
+          duration: cs.transitionDuration.split(",").map((s) => parseFloat(s) || 0),
+        };
+      };
+      return { html: of(document.documentElement), body: of(document.body) };
+    });
+    await context.close();
+  }
+} finally {
+  await browser.close();
+  server.close();
+}
+
+/* ===========================================================================
+   the report
+   ======================================================================== */
+const near = geo.near, far = geo.far;
+const same = (a, b) => a && b && Math.abs(a[0] - b[0]) <= 1 && Math.abs(a[1] - b[1]) <= 1 && Math.abs(a[2] - b[2]) <= 1;
+const lum = (c) => 0.2126 * c[0] + 0.7152 * c[1] + 0.0722 * c[2];
+const show = (c) => (c ? `rgb(${c.join(" ")})` : "nothing");
+
+say("serving", ROOT);
+say("page", PAGE);
+say("window", `${DESK.width}x${DESK.height}`);
+say("rest position", `${geo.port}px, document max ${geo.pageMax}px`);
+say("theme", `${geo.theme} — the page's ground is ${show(near)}`);
+say("the section's far ground", show(far));
+console.log("");
+
+if (same(near, far)) {
+  problems.push(`the theme's ground and the section's far ground are both ${show(near)}, ` +
+    "so this run cannot see the crossing at all — measure it in a theme whose ground differs");
+}
+
+/* ---- 1. the shape of a crossing ---------------------------------------- */
+/* Where a sweep leaves the near ground and where it reaches the far one, as
+   fractions of the turn. Reported for the shipped pair and ASSERTED against the
+   declared pair for the moved one: with the two ends at 0 and 1 the first
+   sample past the top is already a shade off white, which is the crossing
+   working and not a boundary to test. */
+function edges(sweep) {
+  const s = sweep.down;
+  let lastNear = -1, firstFar = -1;
+  for (let i = 0; i < s.length; i++) if (same(s[i].rgb, near)) lastNear = i;
+  for (let i = 0; i < s.length; i++) if (same(s[i].rgb, far)) { firstFar = i; break; }
+  return {
+    leaves: lastNear < 0 ? null : s[lastNear].t,
+    arrives: firstFar < 0 ? null : s[firstFar].t,
+    lastNear, firstFar,
+  };
+}
+function monotone(sweep) {
+  return sweep.down.every((s, i) => i === 0 || lum(s.rgb) <= lum(sweep.down[i - 1].rgb) + 1);
+}
+function hysteresis(sweep) {
+  return Math.max(...sweep.down.map((s, i) =>
+    Math.max(...s.rgb.map((v, j) => Math.abs(v - sweep.up[i].rgb[j])))));
+}
+
+const e1 = edges(shipped);
+const ends1 = { top: shipped.down[0], rest: shipped.down[SAMPLES] };
+say("the sheet's crossing", `--cross-in ${geo.crossIn}, --cross-out ${geo.crossOut}`);
+say("measured", `leaves the paper by turn ${e1.leaves === null ? "?" : e1.leaves.toFixed(3)}, ` +
+  `fully dark from turn ${e1.arrives === null ? "NEVER" : e1.arrives.toFixed(3)}`);
+say("ends", `${show(ends1.top.rgb)} at the top, ${show(ends1.rest.rgb)} at rest ` +
+  `(--dark ${ends1.top.dark} to ${ends1.rest.dark})`);
+say("gradual", `${new Set(shipped.down.map((s) => s.rgb.join(","))).size} distinct grounds ` +
+  `over ${SAMPLES + 1} samples of the turn`);
+say("monotone", monotone(shipped) ? "the ground only ever darkens on the way down" : "NO");
+say("reverses", hysteresis(shipped) === 0
+  ? "every sample identical scrolling up and scrolling down"
+  : `DIFFERS by up to ${hysteresis(shipped)} of 255`);
+
+if (!Number.isFinite(geo.crossIn) || !Number.isFinite(geo.crossOut)) {
+  problems.push(`the sheet declares --cross-in ${geo.crossIn} and --cross-out ${geo.crossOut}, ` +
+    "and a crossing cannot be driven from a value that is not a number");
+} else if (geo.crossIn < 0 || geo.crossOut > 1 || geo.crossOut - geo.crossIn < 0.02) {
+  problems.push(`the declared crossing runs from ${geo.crossIn} to ${geo.crossOut} of the turn, ` +
+    "which is either outside it or too short to be gradual");
+}
+if (!same(ends1.top.rgb, near)) {
+  problems.push(`at the top of the page the ground is ${show(ends1.top.rgb)} and the theme's is ` +
+    `${show(near)} — the page is already partly crossed at scroll 0, which is what the profile capture photographs`);
+}
+if (!same(ends1.rest.rgb, far)) {
+  problems.push(`at rest the ground is ${show(ends1.rest.rgb)} rather than the section's ${show(far)}, ` +
+    "so the composition is not sitting on its own ground");
+}
+if (!monotone(shipped)) problems.push("the ground does not darken monotonically through the turn — it comes back before it has finished");
+if (hysteresis(shipped) !== 0) {
+  problems.push(`the ground depends on which way the page was scrolled (by up to ${hysteresis(shipped)} of 255), ` +
+    "so the crossing does not reverse — a reader who scrolls back does not get the page they had");
+}
+if (new Set(shipped.down.map((s) => s.rgb.join(","))).size < 8) {
+  problems.push("the ground takes fewer than 8 distinct values across the turn, which is a flip rather than a crossing");
+}
+
+/* ---- 2. a moved pair is honoured --------------------------------------- */
+console.log("");
+const e2 = edges(moved);
+const beforeIn = moved.down.filter((s) => s.t <= MOVED.in && !same(s.rgb, near));
+const afterOut = moved.down.filter((s) => s.t >= MOVED.out && !same(s.rgb, far));
+const between = moved.down.filter((s) => s.t > MOVED.in && s.t < MOVED.out);
+const betweenMoving = new Set(between.map((s) => s.rgb.join(","))).size;
+say("moved to", `--cross-in ${MOVED.in}, --cross-out ${MOVED.out}`);
+say("measured", `leaves the paper by turn ${e2.leaves === null ? "?" : e2.leaves.toFixed(3)}, ` +
+  `fully dark from turn ${e2.arrives === null ? "NEVER" : e2.arrives.toFixed(3)}`);
+say("still paper before it", beforeIn.length === 0
+  ? `every sample up to turn ${MOVED.in} is exactly ${show(near)}`
+  : `NO — ${beforeIn.length} sample(s) had left it, the first at ${show(beforeIn[0].rgb)}`);
+say("still dark after it", afterOut.length === 0
+  ? `every sample from turn ${MOVED.out} is exactly ${show(far)}`
+  : `NO — ${afterOut.length} sample(s) had not arrived, the first at ${show(afterOut[0].rgb)}`);
+say("and moving between", `${betweenMoving} distinct grounds over ${between.length} samples`);
+say("reverses", hysteresis(moved) === 0 ? "yes" : `DIFFERS by up to ${hysteresis(moved)} of 255`);
+if (beforeIn.length) problems.push(`with the crossing declared to start at turn ${MOVED.in} the ground had already left the paper before it — the declared start is not honoured`);
+if (afterOut.length) problems.push(`with the crossing declared to finish at turn ${MOVED.out} the ground had not arrived by it — the declared finish is not honoured`);
+if (betweenMoving < 8) problems.push(`between the two declared ends the ground takes only ${betweenMoving} values, so a shortened crossing is a flip`);
+if (!monotone(moved)) problems.push("a moved crossing is not monotone in the scroll position");
+if (hysteresis(moved) !== 0) problems.push("a moved crossing does not reverse identically");
+
+/* ---- 3. and removing the override puts the page back ------------------- */
+const drift = Math.max(...restored.down.map((s, i) =>
+  Math.max(...s.rgb.map((v, j) => Math.abs(v - shipped.down[i].rgb[j])))));
+say("override removed", drift === 0
+  ? "the sheet's own crossing again, identical at all 41 samples"
+  : `the page did NOT go back — up to ${drift} of 255 different`);
+if (drift !== 0) problems.push(`taking the inline pair off left the page ${drift} of 255 from the sheet's own crossing, so a tuner cannot be closed without changing the page`);
+say("a collapsed pair", `0.99 / 1 lands on ${show(collapsed.rest)} at rest, ${show(collapsed.top)} at the top`);
+if (!same(collapsed.rest, far)) {
+  problems.push(`with a crossing too short to run (0.99 to 1 of the turn) the page comes to rest on ${show(collapsed.rest)} ` +
+    `rather than ${show(far)} — the span floor is anchored at the near end, so the crossing finishes past the landing ` +
+    "and the composition sits on a half-crossed ground");
+}
+if (!same(collapsed.top, near)) problems.push(`a collapsed pair left the top of the page at ${show(collapsed.top)} rather than ${show(near)}`);
+
+/* ---- 4. the turn, held -------------------------------------------------- */
+console.log("");
+const heldUnscrolled = pinned.every((p) => p.y === 0);
+const heldMatches = pinned.map((p) => {
+  const i = Math.round(p.t * SAMPLES);
+  return { t: p.t, held: p.rgb, scrolled: shipped.down[i].rgb, ok: same(p.rgb, shipped.down[i].rgb) };
+});
+say("held turn", pinned.map((p) => `${p.t}:${show(p.rgb)}`).join("  "));
+say("without scrolling", heldUnscrolled ? "the page never moved" : "NO — the hold scrolled the page");
+say("and it agrees", heldMatches.every((m) => m.ok)
+  ? "every held fraction is the colour that scrolling to it gives"
+  : heldMatches.filter((m) => !m.ok).map((m) => `${m.t}: ${show(m.held)} vs ${show(m.scrolled)}`).join(", "));
+say("released", `${show(released.rgb)} at ${released.y}px`);
+if (!heldUnscrolled) problems.push("holding the turn scrolled the page, so a tuner cannot look at the middle of the crossing without moving what it is looking at");
+if (!heldMatches.every((m) => m.ok)) problems.push("a held turn draws a different colour from scrolling to the same fraction, so the tuner is not showing the page a reader would get");
+if (!same(released.rgb, near)) problems.push(`releasing the hold left the ground at ${show(released.rgb)} rather than the theme's ${show(near)} at scroll 0`);
+
+/* ---- 5. the toggle ----------------------------------------------------- */
+console.log("");
+say("machine dark, chose", `${toggled.before} -> ${toggled.after}, whose ground is ${show(toggled.near)}`);
+say("at the top", show(toggled.top.rgb));
+say("in the section", show(toggled.rest.rgb));
+say("and back at the top", show(toggled.back.rgb));
+if (toggled.after !== "light") {
+  problems.push(`the toggle did not reach light (data-theme is "${toggled.after}"), so nothing about the reader's choice was measured`);
+} else {
+  if (!same(toggled.top.rgb, toggled.near)) problems.push(`with light chosen on a dark machine the top of the page is ${show(toggled.top.rgb)} rather than ${show(toggled.near)}`);
+  if (!same(toggled.rest.rgb, toggled.far)) problems.push(`with light chosen the section is ${show(toggled.rest.rgb)} rather than ${show(toggled.far)} — the crossing does not happen`);
+  if (!same(toggled.back.rgb, toggled.near)) problems.push(`after scrolling into the section and back, a reader who chose light gets ${show(toggled.back.rgb)} — the toggle has silently stopped working`);
+}
+
+/* ---- 6. reduced motion ------------------------------------------------- */
+console.log("");
+const stillMoved = still.sweep.down.filter((s) => !same(s.rgb, still.near));
+const stillMovedPair = still.withMoved.seen.filter((c) => !same(c, still.near));
+say("reduced motion", stillMoved.length
+  ? `CROSSES — ${stillMoved.length} of 21 samples left the paper`
+  : `the ground is ${show(still.near)} at all 21 scroll positions across the turn`);
+say("with a moved pair", stillMovedPair.length
+  ? `CROSSES — ${stillMovedPair.length} of 21 samples moved`
+  : "still nothing, so the two ends cannot be used to reintroduce the movement");
+say("and no handle", still.withMoved.handle ? "window.__arrival is defined" : "window.__arrival is absent, as the file's early return says");
+if (stillMoved.length) problems.push("under prefers-reduced-motion the page still crosses into dark; #73 asks for the transition removed rather than shortened");
+if (stillMovedPair.length) problems.push("under prefers-reduced-motion a declared crossing window reintroduces the movement");
+
+/* ---- 7. the deep link ------------------------------------------------- */
+console.log("");
+say("/portfolio/#projects", `landed at ${deep.y}px against a port of ${deep.port}px, url "${deep.hash}"`);
+say("and settled", `ground ${show(deep.rgb)}, --dark ${deep.dark}, --exit ${deep.exit}`);
+if (deep.y !== deep.port) problems.push(`a deep link to the section landed at ${deep.y}px rather than on the port at ${deep.port}px`);
+if (!same(deep.rgb, deep.far)) problems.push(`a deep link to the section lands on a ground of ${show(deep.rgb)} rather than ${show(deep.far)} — the reader arrives mid-crossing`);
+if (deep.exit !== 0) problems.push(`a deep link to the section lands with --exit ${deep.exit}, so the composition is mid-arrival`);
+
+/* ---- 8. nothing to fast-forward -------------------------------------- */
+const running = ["html", "body"].filter((k) => capture[k].animation !== "none");
+const easing = ["html", "body"].filter((k) => capture[k].duration.some((d) => d > 0));
+say("no animation", running.length ? `${running.join(" and ")} carries ${running.map((k) => capture[k].animation).join(", ")}` : "neither <html> nor body");
+say("no transition", easing.length ? `${easing.map((k) => k + ": " + capture[k].transition).join("; ")}` : "neither <html> nor body");
+if (running.length) {
+  problems.push(`${running.join(" and ")} carries a CSS animation in the turn regime — the profile capture runs with ` +
+    "animations disabled, which fast-forwards it to its end state and photographs this page dark at scroll 0");
+}
+if (easing.length) {
+  problems.push(`${easing.join(" and ")} eases its colour (${easing.map((k) => capture[k].transition).join("; ")}), ` +
+    "so the ground lags the rest of the crossing — one ground means one timing, and a scroll-driven crossing wants none");
+}
+
+/* ---- and the verdict -------------------------------------------------- */
+console.log("");
+if (problems.length) {
+  console.log(`${problems.length} problem${problems.length === 1 ? "" : "s"}:`);
+  for (const p of problems) console.log("  - " + p);
+  process.exit(1);
+}
+console.log("the page crosses into dark where the sheet says, and comes back — #73, tunable per #58");

--- a/portfolio/arrival.js
+++ b/portfolio/arrival.js
@@ -4,10 +4,11 @@
  * EXIT TREATMENTS block is what the fourth reaches, and this file only says
  * where in the turn we are.
  *
- *   --dark    0 to 1 over the whole turn. Every colour on the page is a mix
- *             against it: the ground, the CV's ink, the section's palette and
- *             the Frame's chrome. The two screens go dark together, which is
- *             the point — they are one sheet of paper.
+ *   --dark    0 to 1 over the STRETCH OF THE TURN the sheet asks for, which is
+ *             --cross-in to --cross-out and by default the whole of it. Every
+ *             colour on the page is a mix against it: the ground, the CV's ink,
+ *             the section's palette and the Frame's chrome. The two screens go
+ *             dark together, which is the point — they are one sheet of paper.
  *   --turn    the same ramp UNEASED, which is what the three corner pictures
  *             are lifted by. They have to clear the window exactly as the page
  *             comes to rest, and a picture that eased out of the way while the
@@ -46,6 +47,17 @@
  * Read off scroll position in script, --dark is 0 at scroll 0 under any capture
  * setting.
  *
+ * WHERE THE CROSSING STARTS AND STOPS IS THE SHEET'S TO SAY, and #58's last
+ * user story is that the author can find those two points by watching rather
+ * than by reading a description. --cross-in and --cross-out are declared in the
+ * crossing block, read here on every measure, and scrubbed live by
+ * design/plinth/plinth-tuner.html — so a pair arrived at by dragging is the
+ * same pair that can be pasted back into the sheet. THEY MOVE --dark AND
+ * NOTHING ELSE: --turn is what lifts the three corner pictures out of the way
+ * and they have to clear the window as the page comes to rest whatever the
+ * colour is doing, and --enter is two blocks above the fold at rest. Only the
+ * COLOUR is a matter of taste; the other two are geometry.
+ *
  * NOTHING ON THE PAGE DEPENDS ON THIS FILE, the same stance effects.js and
  * cut-morph.js take. All four properties are declared in the sheet at the values
  * they hold at the top of the page — --dark 0, --turn 0, --enter 1, --exit 0 —
@@ -77,6 +89,17 @@
   var rail = panel.querySelector(".panel-rail");
   var landing = 0, ready = false, queued = false, wasFaint = null;
   var pinnedExit = null;             // a number while a tuner is holding --exit
+  var pinnedTurn = null;             // a number while a tuner is holding the turn
+  /* The crossing's two ends, as fractions of the turn. Read off the sheet in
+     measure() rather than restated here — see the header. These are what the
+     sheet declares, so a file that never re-measures still crosses the whole
+     turn the way #73 shipped it. */
+  var crossIn = 0, crossOut = 1;
+  /* The narrowest crossing that is still a crossing. Below this a stretch of
+     scroll is one frame of a wheel notch and the ramp is a flip, which is the one
+     thing #73 says the crossing must not be — so an inverted or collapsed pair
+     out of a tuner is held here rather than dividing by nothing. */
+  var MIN_SPAN = 0.02;
 
   /* Document space, walked up the offsetParent chain rather than taken from a
      client rect. .page spends its first 0.9s translated 8px down by the page-in
@@ -95,14 +118,37 @@
      with the section's own edge on the window's — see the landing block. */
   function measure() {
     ready = false;
+    /* THE CROSSING'S TWO ENDS, READ AND NOT REMEMBERED, off <html> because that
+       is where the sheet declares them and where a tuner writes them. Here
+       rather than in frame() because frame() runs on every scrolled frame and a
+       getComputedStyle in it is a forced style recalculation sixty times a
+       second for two numbers that only a resize or a tuner can change; a tuner
+       that moves them asks for the remeasure that re-reads them. Read off the
+       ROOT and not off the panel: a custom property inherits, so .panel would
+       answer the same today and would quietly follow a per-section override
+       tomorrow, and the crossing is the whole page's.
+       ABOVE THE REGIME CHECK and not below it, because a held turn is drawn at
+       every window size — including the ones with no turn to measure — and it
+       has to be drawn against the pair the sheet says NOW rather than against
+       whatever was read the last time the window was wide. */
+    var rs = window.getComputedStyle(root);
+    var a = parseFloat(rs.getPropertyValue("--cross-in"));
+    var b = parseFloat(rs.getPropertyValue("--cross-out"));
+    crossIn = clamp01(isFinite(a) ? a : 0);
+    crossOut = clamp01(isFinite(b) ? b : 1);
     /* The turn regime, read off the cascade rather than restated here: .panel
        takes `scroll-snap-align` inside the one-screen media query and nowhere
        else. Outside it the page is an ordinary column with no turn to cross. */
     var cs = window.getComputedStyle(panel);
     if (cs.scrollSnapAlign === "none") {
-      root.style.removeProperty("--dark");
-      root.style.removeProperty("--turn");
-      root.style.removeProperty("--enter");
+      /* Left alone while a tuner is holding the turn, for the reason --exit is
+         below: the hold is a deliberate value and a resize of the tuner's own
+         panes is not a reason to lose it. */
+      if (pinnedTurn === null) {
+        root.style.removeProperty("--dark");
+        root.style.removeProperty("--turn");
+        root.style.removeProperty("--enter");
+      }
       /* And the arrival with them: outside the turn regime the section is the
          next block in an ordinary column, so it is simply there. Removed rather
          than pinned to 0, so what is left is the sheet's own declaration and
@@ -140,12 +186,31 @@
      belongs to the page turn, and the turn is already a quintic. */
   function smooth(t) { return t * t * (3 - 2 * t); }
 
-  function frame() {
-    queued = false;
-    if (!ready) return;
-    var t = clamp01((window.pageYOffset || root.scrollTop || 0) / landing);
+  /* The turn fraction the CROSSING is at, which is the turn fraction remapped
+     onto the stretch the sheet asked for. Nothing but --dark goes through this —
+     see the header — and with the shipped 0 and 1 it is the identity, so #73's
+     measurements hold unless somebody moves the pair. */
+  function crossed(t) {
+    var span = crossOut - crossIn;
+    if (span >= MIN_SPAN) return clamp01((t - crossIn) / span);
+    /* HELD AGAINST THE FAR END AND NOT THE NEAR ONE, which is the difference
+       between degrading and breaking. Floored the other way — start where
+       --cross-in says and run MIN_SPAN from there — a pair like 0.99 / 1 puts the
+       crossing's far end past the landing, and the page comes to REST at --dark
+       0.5: the composition on a mid-grey ground, which is the one thing the whole
+       section is arranged not to be. Anchored at --cross-out the page always
+       finishes where it was told to finish, and what a collapsed pair costs is
+       the start moving rather than the end never arriving. */
+    return clamp01((t - (crossOut - MIN_SPAN)) / MIN_SPAN);
+  }
+
+  /* WHERE IN THE TURN THE PAGE IS DRAWN, given the fraction. Split out of
+     frame() so that a tuner holding the turn does not need a landing to divide
+     by — the same reason setExit() writes --exit without going through frame(),
+     and the reason a hold works at a window size where there is no turn at all. */
+  function draw(t) {
     root.style.setProperty("--turn", t.toFixed(4));
-    root.style.setProperty("--dark", smooth(t).toFixed(3));
+    root.style.setProperty("--dark", smooth(crossed(t)).toFixed(3));
     /* The first third of the turn, and not eased: what it drives is an opacity
        on two blocks that are only just above the fold, and easing it would keep
        them faintly drawn over the opening composition for longer rather than
@@ -178,6 +243,17 @@
     }
   }
 
+  function frame() {
+    queued = false;
+    /* A HELD TURN IS DRAWN WHETHER OR NOT THERE IS A LANDING, which is what puts
+       this before the ready check rather than after it: a tuner holds the turn at
+       window sizes outside the turn regime as well, and there the landing does
+       not exist. */
+    if (pinnedTurn !== null) return void draw(pinnedTurn);
+    if (!ready) return;
+    draw(clamp01((window.pageYOffset || root.scrollTop || 0) / landing));
+  }
+
   function kick() {
     if (!queued) { queued = true; window.requestAnimationFrame(frame); }
   }
@@ -199,7 +275,16 @@
      puts the Panel on screen with scrollIntoView) and resizes (its panes are
      laid out against the window), so a scrub set to 0.62 would silently snap
      back to wherever the iframe's scroll position said. Pinning is what stops
-     that: a number holds --exit against the scroll, and null hands it back. */
+     that: a number holds --exit against the scroll, and null hands it back.
+
+     SINCE #58 IT ALSO HOLDS THE TURN, for the crossing into dark — the same
+     problem one property along. The tuner puts the Panel on screen with
+     scrollIntoView, which lands at the far end of the turn, so a page seen
+     through that iframe is ALWAYS fully crossed and there is nothing about the
+     crossing to judge. Holding the turn is what lets it be looked at at 0.3.
+     THE TWO PINS ARE INDEPENDENT ON PURPOSE: --exit is where the composition
+     stands and the turn is where the page's colour is, and the whole point of
+     scrubbing one is to hold the other still. */
   window.__arrival = {
     /* Anything that is not a finite number — null, for one — hands --exit back
        to the scroll position. Written here on the spot rather than queued
@@ -214,8 +299,24 @@
       if (pinnedExit === null) { measure(); kick(); }
       else panel.style.setProperty("--exit", String(pinnedExit));
     },
+    /* Where in the turn to draw the page, 0 to 1 — the crossing's own scrub, and
+       #58's "the theme crossing tunable" is this plus the two ends the sheet
+       declares. Anything that is not a finite number hands the turn back to the
+       scroll position, and then measure() re-reads the two ends, so a tuner that
+       has just written a new pair inline gets it applied by releasing.
+       Drawn on the spot, for setExit's reasons: the tuner reads the page's
+       colour back immediately after asking, and a deferred write would have it
+       measuring the frame it was replacing. */
+    setTurn: function (v) {
+      pinnedTurn = typeof v === "number" && isFinite(v) ? clamp01(v) : null;
+      if (pinnedTurn === null) { measure(); kick(); }
+      else draw(pinnedTurn);
+    },
     /* For a tuner that moves the layout without firing resize — swapping the
-       section's wording or its size, which is what #69's does. */
+       section's wording or its size, which is what #69's does — and for one that
+       has just written --cross-in or --cross-out inline and needs them re-read.
+       The redraw goes through kick() rather than draw(), so a held turn is
+       redrawn at its held value by frame(). */
     remeasure: function () { measure(); kick(); }
   };
 

--- a/portfolio/styles.css
+++ b/portfolio/styles.css
@@ -5318,6 +5318,32 @@ body::after {
     --turn: 0;
     --enter: 1;
 
+    /* ---- WHERE IN THE TURN THE CROSSING HAPPENS, #58's last user story -------
+       0 and 1 are the whole turn, which is what shipped with #73 and is what
+       these two say out loud rather than leave implicit. They are the two ends of
+       the crossing as fractions of the turn: --dark leaves 0 at --cross-in and
+       reaches 1 at --cross-out, and outside that stretch the page is simply the
+       page it was, or simply dark.
+
+       THEY ARE READ BY arrival.js AND WRITTEN NOWHERE, which is the whole reason
+       they are declared here rather than kept as two constants in that file: the
+       tuner sets them inline on <html> and asks for a remeasure, so a pair
+       arrived at by scrubbing can be pasted back into this block and BE the
+       shipping page. Same arrangement as the exit treatments' five numbers.
+
+       0 AND 1 ARE A DEFAULT AND NOT A CHOICE, said here for the reason #122 says
+       it about the subheading and the backdrop: nobody has yet looked at the
+       crossing over a shorter stretch and preferred the whole turn. The tuner is
+       where that is decided, and until it is this is what #73 measured.
+
+       NOTHING ANIMATES THEM, and that is the same discipline the rest of this
+       block is written under: a keyframe or a scroll timeline on either would
+       hand `animations: "disabled"` something to fast-forward, and the author's
+       profile preview would photograph this page dark at scroll 0. They are two
+       declared numbers, read once per measure. */
+    --cross-in: 0;
+    --cross-out: 1;
+
     /* ---- THE INK DOES NOT CROSS WHEN THE GROUND DOES -------------------------
        A page that starts as dark type on paper and ends as light type on black
        has to take its type THROUGH its own ground, and there is no palette that


### PR DESCRIPTION
Closes #58 — the last of its user stories, the other three parts having shipped as #72, #73 and #74.

## What was missing

#58's user story 27 — *"As the author, I want the theme crossing tunable, so that I can find the point at which it starts and finishes by eye"* — had no control anywhere. `--dark` was a smoothstep over the whole turn with nothing to move, and the tuner could not show the middle of a crossing at all: it puts the Panel on screen with `scrollIntoView`, which lands at the far end, where the crossing is already over.

Story 23 (a deep link to `#projects` lands settled rather than mid-animation) held but was asserted nowhere. It is now.

## The change

**Two declarations, not two constants.** `--cross-in` and `--cross-out` are declared in the crossing block at `0` and `1` — the whole turn, which is what #73 shipped and measured — and read by `arrival.js` on every measure. That is what lets the tuner write them inline and a pair arrived at by dragging be pasted back into the sheet: the same arrangement as the exit treatments' five numbers.

They move `--dark` and nothing else. `--turn` lifts the three corner pictures clear of the window as the page comes to rest, and `--enter` fades in the two blocks above the fold; both are geometry, and only the colour is a matter of taste.

**Nothing became an animation.** This is #73's hazard, not a style preference: a keyframe or a scroll timeline on either number would hand `animations: "disabled"` something to fast-forward and photograph `/portfolio` dark at scroll 0 on the author's profile, while every geometry assertion still passed. Two declared numbers read by a scroll handler are safe, and `check-crossing.mjs` now asserts that neither `<html>` nor `body` animates or eases its colour.

**`window.__arrival.setTurn`** holds the turn the way `setExit` holds the composition. The two pins are independent on purpose — an exit treatment is judged against a settled ground and a ground against a settled composition.

**The tuner** grows a `turn` strip and a `crossing into dark` group, exporting the two declarations and a `cross-state v1` blob. Its readout is measured off the **ground** rather than off the numbers, which is how you learn that with 0 and 1 the page is already black from turn 0.85 and the last sixth of the turn is doing nothing an eye can see.

`0` and `1` remain a **default and not a choice** — nobody has yet looked at a shorter crossing and preferred the whole turn. That is the author's, the way #122 is.

## Two things the review caught

- **The span floor is anchored at the far end.** A pair too short to be a crossing is held at `0.02` rather than dividing by nothing — but anchored at `--cross-in`, a pair like `0.99 / 1` put the far end past the landing and the page came to **rest** at `--dark 0.5`, with the composition on a mid-grey ground. Anchored at `--cross-out` the start moves and the finish does not. Asserted, because the tuner can produce that pair with two drags.
- **The turn readout no longer claims a position it cannot know.** Under `prefers-reduced-motion` `arrival.js` returns before writing `--turn`, so the sheet's declared `0` read back as "the top of the page" on an iframe scrolled to the section. It says `— · no driver` and disables the scrub.

## `design/tools/check-crossing.mjs`

New, and it asserts a **colour rather than a property**: every number in it is `body`'s own computed ground rasterised to sRGB through a 1×1 canvas, so a `color-mix` in oklab and a plain hex are the same three integers.

```
the sheet's crossing     --cross-in 0, --cross-out 1
measured                 leaves the paper by turn 0.026, fully dark from turn 0.850
ends                     rgb(255 255 255) at the top, rgb(0 0 0) at rest
gradual                  36 distinct grounds over 41 samples of the turn
monotone                 the ground only ever darkens on the way down
reverses                 every sample identical scrolling up and scrolling down

moved to                 --cross-in 0.3, --cross-out 0.7
still paper before it    every sample up to turn 0.3 is exactly rgb(255 255 255)
still dark after it      every sample from turn 0.7 is exactly rgb(0 0 0)
override removed         the sheet's own crossing again, identical at all 41 samples
a collapsed pair         0.99 / 1 lands on rgb(0 0 0) at rest

held turn                every held fraction is the colour scrolling to it gives
machine dark, chose      light — white at the top, black in the section, white again
reduced motion           the ground is white at all 21 scroll positions
/portfolio/#projects     landed at 782px, --dark 1, --exit 0
no animation             neither <html> nor body
```

**The sweep takes snapping off**, and that is the page's own lever rather than the test loosening it. `html { scroll-snap-type: y mandatory }` makes the document two ports and nothing between, so a mandatory snap pulls every intermediate `scrollTo` straight back — the first run of this check sampled 41 positions and got **two** colours, because the page had only been at two positions. `app.js` takes the same property off for exactly the length of the turn's ease, so the middle of the turn is a place the reader goes.

## Verification

| check | result |
| --- | --- |
| `check-crossing.mjs` | pass |
| `check-panel-nav.mjs` (#72) | pass |
| `check-panel-exit.mjs` (#74) | pass |
| `check-panel-clip.mjs` (#65) | pass |
| `check-capture-contract.py` | 592 / 852 / 80 / 80, light **188.4**, dark **46.1**, separation **142.3** |

The capture numbers are the same ones #73 and #74 measured — the settled page did not move.

## One thing beyond the ticket

`design/README.md` gains an entry for `check-panel-nav.mjs`, which #125 added without listing, alongside the new one. Same list, same epic, one line.
