### PR TITLE
Pin the language, and the six decisions the overhaul turns on

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,142 @@
+# Portfolio
+
+`chrisj.uk` — a personal site. This context is `/portfolio`: one document,
+navigated by scrolling, made of Sections. Nothing else on the site shares its
+composition or its vocabulary.
+
+## The page
+
+**Portfolio**:
+The single document at `/portfolio`, and everything in it. Its Sections are
+reached by scrolling, never by clicking.
+_Avoid_: the portfolio page, the CV page, the site
+
+**Section**:
+One self-contained part of the Portfolio's scroll, owning its own markup,
+styles, Tokens, Content, Timeline and assets. A Section may read the Kernel and
+nothing else.
+_Avoid_: page, slice, module, component
+
+**Shell**:
+The thin document carrying the head, the Kernel, and the Sections' mount points.
+It holds no composition of its own.
+_Avoid_: layout, template, index
+
+**Kernel**:
+The small set of things every Section may rely on — faces, theme, the Turn, the
+Effect Stack, the loader. The only thing permitted to cross a Section boundary.
+_Avoid_: globals, shared, common, base
+
+**Showcase**:
+A Section presenting one project in depth, with a composition built for that
+project alone.
+_Avoid_: case study, project page, feature
+
+## The two Sections that exist
+
+**Front Screen**:
+The Section at the top of the Portfolio — masthead, bio, photo carousel, work,
+education, contact, theme toggle — fitted to exactly one screen.
+_Avoid_: front page, home, hero, above the fold
+
+**Projects Panel**:
+The dark Section presenting one project at a time: a Rail, a masthead, copy, and
+the Frame on its Plinth.
+_Avoid_: projects page, photo gallery page, gallery
+
+## What the composition is made of
+
+**Turn**:
+The Portfolio crossing from paper into dark as the reader scrolls. A property of
+the page's ground, belonging to the Kernel, not to any Section.
+_Avoid_: dark mode, the transition, scroll effect
+
+**Cut Title**:
+A word drawn as a picture rather than set as type, standing at a Section's foot.
+_Avoid_: heading, wordmark, the big word
+
+**Frame**:
+The browser window a Showcase's recording is shown inside — chrome, glass
+titlebar, controls — drawn by the page rather than captured.
+_Avoid_: window, mockup, browser chrome
+
+**Plinth**:
+The rendered marble slab a Frame stands on, with the Frame's live reflection
+lying in it.
+_Avoid_: pedestal, base, stand
+
+**Rail**:
+The list down a Section's edge naming what can be shown there, marking which is
+selected and which is not yet built.
+_Avoid_: nav, sidebar, menu, tabs
+
+**Effect Stack**:
+The Kernel's layers over the finished page — paper tooth, halftone, film, grain,
+grille, scan, roll, tube, vignette — each inert until named.
+_Avoid_: filters, overlays, post-processing
+
+**Timeline**:
+A Section's motion as one named, seekable object. Asking a Timeline for a given
+moment is how both the Editor and a Check see motion.
+_Avoid_: animation, transition, sequence
+
+## What is edited, and how
+
+**Token**:
+One of a Section's named numbers or colours, held as a plain CSS custom
+property. Tokens are the only values the Editor may change directly.
+_Avoid_: variable, setting, config, knob
+
+**Content**:
+A Section's words and its list of assets, held as data, apart from the markup
+that presents them.
+_Avoid_: copy, strings, CMS
+
+**Editor**:
+The local surface that opens the real Portfolio and changes its Content and
+Tokens in place, and re-bakes generated assets. It writes Content and Tokens and
+nothing else.
+_Avoid_: dashboard, CMS, tuner, admin, studio
+
+**Annotation**:
+The Editor's output when a wanted change is not expressible as a Token: a
+measured instruction, in words and numbers, for an agent to apply.
+_Avoid_: comment, note, feedback, request
+
+**Override**:
+A value the Editor wrote outside a Section's composition so the page looks right
+now, pending an agent folding it in properly.
+_Avoid_: patch, hack, hotfix
+
+**Variant**:
+One of several complete alternative directions for a Section, all present in the
+source at once, selected by attribute so they can be rendered side by side and
+chosen by eye. The losers stay as the record of what was judged.
+_Avoid_: version, option, theme, experiment
+
+**Check**:
+A headless assertion about a Section that a person would not notice failing.
+Checks never assert whether something looks good.
+_Avoid_: test, spec, lint, validation
+
+**Agent Contract**:
+The document telling an agent what a seam and a test mean in this repository,
+read before any spec or implementation.
+_Avoid_: guidelines, conventions, readme
+
+## Beyond this repository
+
+**Career Record**:
+The private, authoritative source for every word about the author's work and
+study. Only its rendered, publishable fields ever reach the Portfolio.
+_Avoid_: the CV repo, the source of truth
+
+**Record Engine**:
+The author's separate tool that drives a page through a timeline — plain data:
+framerate, a starting state, and segments — and encodes the result as a clip.
+_Avoid_: the recorder, the video tool
+
+**Roll**:
+Every photograph a recording's camera passes over, collected mechanically. Its
+companion is the signed list of which are obscured before capture.
+_Avoid_: the photo list, the manifest

--- a/docs/adr/0001-one-document-navigated-by-scrolling.md
+++ b/docs/adr/0001-one-document-navigated-by-scrolling.md
@@ -1,0 +1,24 @@
+# One document, navigated by scrolling
+
+The Portfolio is a single document whose Sections are reached by scrolling, never
+by clicking, because the reading experience is meant to be continuous. Each
+Section is mounted as it approaches the viewport rather than at load, so a page
+carrying several heavy Showcases still costs one Section's decode work at a time.
+
+## Considered Options
+
+A document per Showcase, stitched together with cross-document View Transitions,
+was the alternative. It keeps payload naturally small and each Section trivially
+isolated, but it makes continuity contingent on a browser feature not everywhere
+yet, and it makes navigation a click.
+
+## Consequences
+
+Deep links are Vercel rewrites onto the same document — `/portfolio/<section>`
+serves the Portfolio anchored at that Section — so a link can still be shared
+without the site becoming several pages.
+
+**One document does not mean one file.** Every Section's markup, styles and
+Content live in that Section's own folder; the Shell holds only mount points.
+This is what keeps a Section inside a single context window, which is the
+constraint every ticket here is sized against.

--- a/docs/adr/0002-astro-and-a-build-step.md
+++ b/docs/adr/0002-astro-and-a-build-step.md
@@ -1,0 +1,30 @@
+# Astro, and therefore a build step
+
+The Portfolio is built with Astro and TypeScript. This reverses the repository's
+previous and loudly stated position that it has no build step and no
+dependencies — `design/tools/package.json` and `design/record/.../scroll-peek.ts`
+both argue for that position in their own comments, so a reader will rightly
+wonder what changed.
+
+What changed is that the site is going from two Sections to seven or eight, and
+two mechanisms are worth a build step at that size: **scoped styles**, which turn
+"no selector may reach outside its Section" from a rule an author can break into
+one the compiler enforces, and **typed Content**, which turns a renamed field
+from a blank space on the page into an error before the page is ever served.
+
+## Considered Options
+
+Vite with plain CSS modules gets scoped styles and a dev server without a
+component model, but not typed Content or a Section's markup and styles in one
+file. Staying dependency-free keeps the property that nothing can break
+invisibly, and gives up all three.
+
+## Consequences
+
+Dependencies rot, and this site is edited occasionally over years. So: **every
+version is pinned exactly, and nothing is updated on a schedule** — only when
+something is actually broken. No CI, no automated dependency updates. A major
+version bump is a decision, not a maintenance chore.
+
+`pnpm` is used so the `node_modules` each worktree needs is a hardlink farm
+rather than a real install.

--- a/docs/adr/0003-a-timeline-is-the-seam-for-motion.md
+++ b/docs/adr/0003-a-timeline-is-the-seam-for-motion.md
@@ -1,0 +1,27 @@
+# A Timeline is the seam for motion
+
+A Section's motion is authored as one named, seekable Timeline — GSAP, with
+ScrollTrigger for scroll-driven choreography — and never as a bare
+`requestAnimationFrame` loop reading wall-clock time.
+
+The reason is not the easing library. It is that a named Timeline can be **asked
+for a given moment**: `seek(0.34)` produces a deterministic frame, which is the
+only way a headless Check can assert choreography, and the only way the Editor
+can scrub. Motion written as a per-frame loop has no such handle, and motion
+written as bare CSS can be seeked but cannot say *which* choreography is being
+looked at.
+
+## Consequences
+
+This is the seam `/to-spec` should nominate for any Section with motion, and it
+is why a Check can assert "this element is at this coordinate at t=340ms" rather
+than asserting nothing about motion at all.
+
+Cheap ambient motion may still be native CSS scroll-driven animation where no
+Check needs to see it. Browser parity is explicitly not required.
+
+Judgement of how motion *feels* stays with the author. Multimodal review of
+motion was measured and rejected: usefully reading a sequence needs upward of
+thirty sampled frames — tens of thousands of tokens — to reach a verdict worse
+than the author's eye, while reading the Timeline's own numbers costs almost
+nothing.

--- a/docs/adr/0004-the-editor-writes-content-and-tokens-only.md
+++ b/docs/adr/0004-the-editor-writes-content-and-tokens-only.md
@@ -1,0 +1,31 @@
+# The Editor writes Content and Tokens, and nothing else
+
+The Editor opens the real Portfolio locally and edits it in place, but it is only
+ever allowed to write two kinds of file: a Section's Content, and a Section's
+Tokens. It never writes markup, styles or scripts.
+
+This is a deliberate limit on reach in exchange for reliability: a tool that
+rewrites the two simplest formats in the repository cannot corrupt a composition,
+and needs no understanding of one.
+
+## Consequences
+
+**A change the Editor cannot express becomes an Annotation** — a measured
+instruction in words and numbers, for an agent to apply — and optionally an
+Override, so the page looks right immediately while the composition is corrected
+later.
+
+**Dragging and resizing is measurement, not authoring.** These compositions are
+held together by relationships, not coordinates; the Frame's left edge is a
+fraction of the stage, and a Section masthead's cap-height *is* another element's.
+A tool that moved boxes freely would destroy the relationship rather than edit it,
+so it reports what the author did and lets an agent decide which constant moved.
+
+**Anything the author will want to adjust must first be promoted to a Token.**
+Choosing which numbers those are is part of building each Section, not an
+afterthought.
+
+The five separate tuners the repository grew — plate, plinth, plinth-studio,
+morph, effects — are absorbed into the Editor and retired to `design/legacy/`.
+Those five drive Python generators rather than styles, so the Editor has two
+speeds: Tokens update live, a baked parameter re-bakes and swaps the asset.

--- a/docs/adr/0005-features-land-on-development-without-review.md
+++ b/docs/adr/0005-features-land-on-development-without-review.md
@@ -1,0 +1,26 @@
+# Features land on development without a pull request
+
+Work is still done in a worktree on its own branch — that is what makes several
+tickets safe to run at once — but it lands on `development` directly, with no
+pull request. `CLAUDE.md` describes the opposite, and this supersedes it.
+
+There is no reviewer. Nobody reads the code before it lands, and nobody will: the
+author validates by pulling `development` and looking at the running site. A pull
+request in that arrangement is a round trip that produces nothing, and here it
+produced worse than nothing — `gh pr merge` is documented in this repository as
+ending in a fatal error on every single change, leaving the branch it was asked
+to delete, and requiring the forge to be asked separately whether the merge it
+just reported actually happened.
+
+## Consequences
+
+The lifecycle collapses to two commands: one that cuts a worktree from the
+fetched `origin/development` and starts a local server on its own port, and one
+that runs the Checks, lands the work, and takes down the worktree, the branch and
+the remote branch together.
+
+Landing is refused if the Checks fail. That is the only gate.
+
+Because Sections own their own folders, two tickets touching different Sections
+have almost no surface to conflict on — which is what makes landing without
+review tolerable rather than reckless.

--- a/docs/adr/0006-prose-leaves-the-source-invariants-become-checks.md
+++ b/docs/adr/0006-prose-leaves-the-source-invariants-become-checks.md
@@ -1,0 +1,30 @@
+# Prose leaves the source; invariants become Checks
+
+The explanatory prose that made up most of this repository's source moves out of
+the source. A Section's files keep one-line pointers; the reasoning lives in that
+Section's `NOTES.md`, read when a change is behavioural and skipped when it is
+not. Anything that was really an **invariant** stops being a comment and becomes
+a Check.
+
+This reverses the repository's most visible convention, so it needs its reason
+stated. It is not about the cost of reading a file — with caching that is close to
+free. It is that `styles.css` was 334 KB, of which 84.6% was prose, and a Section
+must fit in a single context window alongside whatever is being built next to it.
+Prose in the source competes for room with the work.
+
+## Consequences
+
+The load-bearing knowledge gets *more* reliable, not less. A comment saying "do
+not break this" is a wish; a Check that fails is a guarantee. The capture
+geometry, the arc a light must stay inside to read as a highlight, "the stone
+stays" — each becomes an assertion.
+
+Checks **block** a commit rather than reporting. An advisory check inside an agent
+loop is one that gets read and stepped over. The price is that a false positive
+costs the author a prompt, so the suite stays small and asserts only things that
+cannot fire on a legitimate change.
+
+The hourly external capture of the Portfolio is retired. It asserted geometry
+hard and colour not at all, so a theme regression broke it silently; it now runs
+when the author asks for it, and the check that goes with it asserts the ground's
+luminance in both themes so that failure is loud.


### PR DESCRIPTION
The glossary and ADRs from the /grill-with-docs session that scoped the /portfolio overhaul.

CONTEXT.md is the vocabulary for /portfolio as it is about to be built — Section, Shell, Kernel, Token, Content, Editor, Annotation, Override, Variant, Check, Timeline — alongside the terms the current composition already uses.

Six ADRs, each for a decision that is hard to reverse and surprising without the reasoning:

- 0001 one document, navigated by scrolling
- 0002 Astro, and therefore a build step
- 0003 a Timeline is the seam for motion
- 0004 the Editor writes Content and Tokens only
- 0005 features land on development without review
- 0006 prose leaves the source; invariants become Checks

Three of them (0002, 0005, 0006) reverse a position this repository argues for in its own comments, so each states what changed and why.