### PR TITLE
Prune design/ of regenerable outputs (#130)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,14 @@ dist/
 # the fetched script has to sit under the install rather than anywhere tidier.
 # Nothing in here is committed — the capture is fetched fresh every run, on
 # purpose, so a vendored copy cannot drift against a repo we do not own.
+#
+# This one rule already covers `runs/`, which grows a directory per --label and
+# is the largest regenerable thing in the repository. Do not add a second rule
+# for it. It is worth deleting by hand when it gets big: `grep -r` and any other
+# tool that does not read .gitignore walks every run directory in it, and a
+# --ref run used to leave a whole extracted copy of the tree behind, so a search
+# came back with two hits for everything. The script now takes that copy down
+# itself; the PNGs under `runs/<label>/out/` are what is meant to survive a run.
 design/tools/.capture-contract/
 
 # the confirmed photographs baked down to a handful of blocks each, by
@@ -44,7 +52,10 @@ design/censor/mosaic/
 design/record/runs/
 design/record/published/
 
-# python bytecode — design/og/build-og.py is the only Python here
+# python bytecode. Most of design/ is Python generators, and any of them that
+# imports a sibling module writes one of these next to it — design/effects/,
+# design/plate/ and design/plinth/ each grow one. Unanchored, so it matches at
+# every depth.
 __pycache__/
 *.pyc
 

--- a/.gitignore
+++ b/.gitignore
@@ -52,10 +52,10 @@ design/censor/mosaic/
 design/record/runs/
 design/record/published/
 
-# python bytecode. Most of design/ is Python generators, and any of them that
-# imports a sibling module writes one of these next to it — design/effects/,
-# design/plate/ and design/plinth/ each grow one. Unanchored, so it matches at
-# every depth.
+# python bytecode. Most of design/ is Python generators — eighteen of them — and
+# every directory holding one grows a __pycache__ as soon as anything imports it,
+# which `python -m compileall design/` alone is enough to do in eight of them. So
+# no list here: unanchored, matching at every depth, deliberately.
 __pycache__/
 *.pyc
 

--- a/design/tools/check-capture-contract.py
+++ b/design/tools/check-capture-contract.py
@@ -169,7 +169,8 @@ def export_ref(root: Path, ref: str, dest: Path) -> None:
 
     A second checkout of the same ref would need a second worktree; an archive
     needs nothing and leaves no branch, no lock and no entry in `git worktree
-    list` behind.
+    list` behind. `main` deletes `dest` once the server is down, so it leaves no
+    directory either — see the note there for why that matters.
     """
     if dest.exists():
         shutil.rmtree(dest)
@@ -373,13 +374,24 @@ def main() -> int:
         served = root
 
     port = args.port or free_port()
-    server = serve(served, port)
     try:
-        report = run_capture(script, out_dir, f"http://127.0.0.1:{port}/portfolio/")
+        server = serve(served, port)
+        try:
+            report = run_capture(script, out_dir, f"http://127.0.0.1:{port}/portfolio/")
+        finally:
+            stop(server)
     finally:
-        stop(server)
+        # The export is scaffolding for the server and is never read again, so it
+        # comes down with the server. Left behind it is a second, complete copy of
+        # the repository inside the repository: `rg` skips it because this staging
+        # directory is gitignored, `grep -r` does not, and one baseline run was
+        # enough to make a search return two hits for everything. The PNGs under
+        # out/ are the part worth keeping. This is the outer `finally` because a
+        # run that fails to serve is the one least likely to be tidied up by hand.
+        if args.ref:
+            shutil.rmtree(served, ignore_errors=True)
 
-    print(f"served     {served}")
+    print(f"served     {args.ref if args.ref else served}")
     print(f"capture    {CAPTURE_REPO}/{CAPTURE_PATH} @ {sha[:12]}")
     print(f"staging    {out_dir}")
     print()

--- a/design/tools/check-capture-contract.py
+++ b/design/tools/check-capture-contract.py
@@ -388,8 +388,18 @@ def main() -> int:
         # enough to make a search return two hits for everything. The PNGs under
         # out/ are the part worth keeping. This is the outer `finally` because a
         # run that fails to serve is the one least likely to be tidied up by hand.
+        #
+        # `ignore_errors` for the same reason `stop` never raises: this runs while
+        # a capture error may be unwinding, and failing to tidy up must not replace
+        # the actual reason the run is ending. But it must not be *silent* either —
+        # a cleanup that quietly failed puts the second copy back with nothing
+        # saying so, which is the whole bug. `stop` kills without waiting after ten
+        # seconds, so a handle outliving it is the way this happens.
         if args.ref:
             shutil.rmtree(served, ignore_errors=True)
+            if served.exists():
+                print(f"WARN  could not remove {served} - delete it by hand; "
+                      "`grep -r` walks it.", file=sys.stderr)
 
     print(f"served     {args.ref if args.ref else served}")
     print(f"capture    {CAPTURE_REPO}/{CAPTURE_PATH} @ {sha[:12]}")

--- a/docs/agents/capture-contract.md
+++ b/docs/agents/capture-contract.md
@@ -80,6 +80,14 @@ two sets of PNGs coexist. **Two runs sharing a label overwrite each other's
 images** — pass `--label` if you are running the same ref twice and want to keep
 both.
 
+The extracted tree is deleted once the server is down, so what a run leaves
+behind is `runs/<label>/out/`: three files, the PNGs and the report. It used to
+leave the tree as well, which meant a complete second copy of the repository
+inside the repository — invisible to `rg`, which reads `.gitignore`, and walked
+by `grep -r`, which does not, so a search came back with two hits for
+everything. `runs/` is still worth emptying by hand when it gets large; nothing
+reads an old run.
+
 ## Traps this script exists to avoid
 
 - **`preview_start` serves the main checkout**, never the worktree the edit is

--- a/docs/agents/capture-contract.md
+++ b/docs/agents/capture-contract.md
@@ -81,7 +81,9 @@ images** — pass `--label` if you are running the same ref twice and want to ke
 both.
 
 The extracted tree is deleted once the server is down, so what a run leaves
-behind is `runs/<label>/out/`: three files, the PNGs and the report. It used to
+behind is `runs/<label>/out/`: the two preview PNGs under `assets/`, and the
+`README.md` the upstream capture writes into its cwd. The JSON report is printed,
+not saved — pass `--json` to see it. It used to
 leave the tree as well, which meant a complete second copy of the repository
 inside the repository — invisible to `rg`, which reads `.gitignore`, and walked
 by `grep -r`, which does not, so a search came back with two hits for


### PR DESCRIPTION
Closes the work in #130.

## What was actually wrong

Both patterns the ticket asks to gitignore were *already* gitignored —
`design/tools/.capture-contract/` at `.gitignore:29` covers `runs/` entirely,
and `__pycache__/` at `:48` covers the rest. Nothing needed a new rule. What was
missing was anything to stop the copy being made again.

`--ref` exports the ref with `git archive` purely so the local `http.server` has
something to serve, never reads it afterwards, and then left it on disk forever.
That is where `runs/origin-development/tree` came from: 199 files, a complete
second copy of the source tree inside the source tree. `rg` never saw it — the
staging directory is gitignored *and* dot-prefixed, so it is skipped twice —
which is why the duplicate hits only showed up under `grep -r` and anything else
that does not read `.gitignore`.

The export now comes down with the server, in an **outer** `finally` so that a
run which fails to serve cleans up too — that is the run least likely to be
tidied up by hand. It stays `ignore_errors=True`, for the reason `stop()` never
raises: it can be unwinding a capture error, and failing to tidy up must not
replace the actual reason the run is ending. But it warns on stderr and names the
path if the directory survives, because a silently failed cleanup puts the bug
back with nothing saying so.

What survives a run is `runs/<label>/out/` — the two preview PNGs and the
`README.md` the capture writes. That is the part worth keeping.

## The two stale comments

Both described a repository that no longer exists, which is the same class of
error as the one this ticket is cleaning up after:

- the `.capture-contract/` note did not mention that `runs/` is the largest
  regenerable thing here, or that one rule already covers it (so nobody adds a
  second);
- the `__pycache__` note claimed `design/og/build-og.py` was "the only Python
  here". There are eighteen generators, and `python -m compileall design/` alone
  produces a `__pycache__` in eight directories.

## Acceptance criteria

- [x] `design/tools/.capture-contract/runs/` deleted and gitignored — 173 MB and
      28 run directories removed from the main checkout; already covered by
      `.gitignore:29`, and the script no longer recreates the tree copy
- [x] All `__pycache__` directories deleted and gitignored — the three on disk
      (`design/effects/`, `design/plate/`, `design/plinth/`) removed; already
      covered by `.gitignore:48`, verified with `git check-ignore -v`
- [x] Every Python generator and every tuner still present and still runs — all
      18 generators parse and import; 12 print their own `--help`; the 6 that do
      not fail for pre-existing reasons unrelated to this change (a Blender-only
      `bpy`, positional-argument CLIs, and gitignored source images). All 11
      tuners present and non-empty
- [x] `design/shots/` untouched — `git diff --stat -- design/shots` empty, all
      37 files present
- [x] A grep for a string that appears once returns exactly one hit
- [x] The live site is unaffected — nothing under `portfolio/` is touched; the
      diff is one ignore file, one tool script and one agent doc

## Not verified, and why

`python design/tools/check-capture-contract.py` could not be run end to end:
`design/tools/node_modules/` is an empty directory, so playwright is not
installed, and the script's own guard refuses before it serves anything. The
capture contract is not in play here — this change touches nothing in
`portfolio/`, so none of `/portfolio`'s markup, layout, spacing or colour moves.
The script's `--help` path and both control-flow branches were exercised
directly instead.

## Review

`/code-review` found three real defects in the first commit; all three are fixed
in `55a3d1e` and each was the same failure as the comment this ticket exists to
correct — a note describing the repository as the writer assumed it was.
