### PR TITLE
Stand up the Shell, the Kernel and the Section convention at /next (#133)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,10 +15,14 @@
 Thumbs.db
 *.log
 
-# node / vercel local artifacts (not used, kept out just in case)
+# the build's inputs and outputs. dist/ is what the deployment serves and is
+# assembled from scratch on every build — Astro's output plus the static tree
+# copied in beside it — so a committed copy could only ever be stale. .astro/ is
+# the types Astro generates for `astro check` and is regenerated the same way.
 node_modules/
 .vercel/
 dist/
+.astro/
 
 # where design/tools/check-capture-contract.py stages the profile repo's capture
 # script and the screenshots it takes. It lives beside design/tools/node_modules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,56 @@ is line endings — and leaves a `settings.json.*.bak` to delete.
 a file if git puts it there, so anything ignored is missing from every tree the
 work is actually done in.
 
+## The build, and /next
+
+This repository is two sites in one tree, and which one you are looking at
+decides everything else about how to work in it.
+
+`/portfolio` is the live document, and it is still plain files with no build step:
+`portfolio/index.html`, `portfolio/styles.css` and the scripts beside them. It is
+served exactly as it sits. Nothing below applies to it.
+
+`/next` is the Portfolio's new foundation — an Astro and TypeScript tree under
+`src/`, built to a temporary route so `/portfolio` keeps working through every
+porting ticket. A later ticket flips the route. ADRs 0001–0006 in `docs/adr/` are
+binding on it, and `CONTEXT.md` is the vocabulary: **Shell**, **Kernel**,
+**Section**, **Turn**, **Timeline**, **Token**, **Content**, **Variant**,
+**Check**. Where a name in `portfolio/` disagrees, the glossary wins.
+
+```bash
+pnpm install --frozen-lockfile
+```
+
+```bash
+pnpm build
+```
+
+`pnpm dev` runs Astro's dev server and serves the existing static site beside it,
+so `/portfolio` and `/next` both answer on one origin. `pnpm build` runs the
+source checks, typechecks, builds, and assembles `dist/` — Astro's output plus
+`index.html`, `portfolio/`, `projects/` and `fonts/` copied in. `pnpm preview`
+serves that `dist/`, **of the tree it is run from**, which is why it exists rather
+than `preview_start`: the in-app preview serves the main checkout and would report
+on `development` while looking like it reported on your branch.
+
+Every dependency version is pinned exactly and nothing is updated on a schedule
+(ADR 0002). pnpm's settings live in `pnpm-workspace.yaml`, not `.npmrc` — pnpm 11
+ignores `.npmrc` for `saveExact`, and the failure mode is a caret quietly
+reappearing in `package.json`.
+
+**Read `src/kernel/NOTES.md` before touching the Kernel, and
+`src/sections/stub/NOTES.md` before adding a Section.** Between them they carry
+the folder convention, what the build actually enforces about it, and the two
+things that have already cost a wrong diagnosis: `hold()` before you seek a
+Timeline, and one mount point per Section. `scripts/check-source.mjs` is what
+turns those rules into build failures rather than hopes — it runs first in
+`pnpm build`, and on its own as `pnpm check:sections`.
+
+`IntersectionObserver` never delivers in the in-app browser pane, for the same
+reason `requestAnimationFrame` never ticks there: the pane does not run the
+rendering steps. Lazy mounting and motion have to be verified in a real headless
+browser, never in the preview.
+
 ## Verifying a change to /portfolio
 
 `/portfolio` has a consumer outside this repository: the author's GitHub profile

--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 # chrisj.uk
 
 Personal site and photo portfolio — hand-written HTML, CSS and vanilla
-JavaScript. No framework, no build step, no dependencies.
+JavaScript.
+
+The live pages are still exactly that: no framework, no build step, no
+dependencies. Beside them, at `/next`, is the foundation the Portfolio is being
+rebuilt on — Astro and TypeScript, every version pinned exactly, nothing updated
+on a schedule. It replaces nothing yet. See
+[The build, and /next](#the-build-and-next).
 
 **Live:** [chrisj.uk](https://chrisj.uk)
 
@@ -230,10 +236,41 @@ kept out of deploys by `.vercelignore`. `fonts/README.md` records why Computer
 Modern lost, measured rather than asserted. Neither folder affects a visitor; see
 [`design/README.md`](design/README.md) and [`fonts/README.md`](fonts/README.md).
 
+## The build, and /next
+
+Everything above is served exactly as it sits in the tree. `/next` is not:
+
+```bash
+pnpm install --frozen-lockfile
+pnpm build       # checks, typechecks, builds, assembles dist/
+pnpm preview     # serves that dist/ — of the tree it is run from
+pnpm dev         # Astro's dev server, with the static site beside it
+```
+
+`/next` is one document made of Sections. A **Section** owns its markup, styles,
+Tokens, Content, Timeline and assets in one folder and may read the **Kernel** and
+nothing else; the **Shell** carries the head, the Kernel and the Sections' mount
+points and no composition of its own. Two of those boundaries are the build's
+rather than a convention: a Section's styles are scoped by the compiler, and its
+Content is typed, so renaming a field stops the build instead of blanking the
+page. `pnpm check:sections` is the rest of it.
+
+Nothing at `/next` is live yet — it carries a stub Section, and `/portfolio` goes
+on being the document until the ticket that flips the route.
+
+Reading order for the detail: `CONTEXT.md` for the vocabulary, `docs/adr/` for the
+decisions, then `src/kernel/NOTES.md` and `src/sections/stub/NOTES.md`.
+
 ## Deployment
 
-The site deploys to Vercel as a plain static site — no framework preset,
-no build command. `vercel.json` enables clean URLs, 308s `/projects` to
+The live pages deploy to Vercel as a plain static site. The build adds one step
+rather than replacing that: `pnpm build` writes Astro's output to `dist/` and
+copies `index.html`, `portfolio/`, `projects/` and `fonts/` in beside it, byte for
+byte, and `dist/` is what gets served. A collision between the two halves fails
+the build rather than being merged, which is what keeps `/next` from ever landing
+on a path `/portfolio` answers on.
+
+`vercel.json` enables clean URLs, 308s `/projects` to
 `/portfolio#projects`, and sets a
 day-long `Cache-Control` (with a week of `stale-while-revalidate`) on the
 image directory, plus a year-long `immutable` one on `/fonts` and another on

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,0 +1,50 @@
+import { createReadStream, statSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'astro/config';
+import { contentType, isStaticPath, resolveFile } from './scripts/static-tree.mjs';
+
+const repoRoot = fileURLToPath(new URL('.', import.meta.url)).replace(/[\\/]+$/, '');
+
+/**
+ * Serve the site that already exists beside /next while `astro dev` is running.
+ *
+ * The Kernel's corner pictures and the Effect Stack's textures are baked files
+ * under /portfolio/img/, and a built /next reaches them because the assemble
+ * step puts both trees in one dist/. Without this the dev server is the only
+ * place those URLs 404, which makes the dev server the one surface that cannot
+ * be trusted. Registered after Astro's own middleware, so a real route always
+ * wins and this only ever answers what Astro did not.
+ */
+function servesTheExistingSite() {
+  return {
+    name: 'portfolio:existing-site',
+    configureServer(server) {
+      return () => {
+        server.middlewares.use((req, res, next) => {
+          const pathname = (req.url ?? '/').split('?')[0];
+          if (!isStaticPath(pathname)) return next();
+          const file = resolveFile(repoRoot, pathname, { statSync });
+          if (!file) return next();
+          res.setHeader('content-type', contentType(file));
+          // A read that fails after the stat would otherwise take the dev
+          // server down on an unhandled 'error'.
+          createReadStream(file)
+            .on('error', () => res.destroy())
+            .pipe(res);
+        });
+      };
+    },
+  };
+}
+
+export default defineConfig({
+  site: 'https://chrisj.uk',
+  // dist/ is where the deployment's output directory points, and where the
+  // assemble step lays the existing site down beside what Astro wrote.
+  outDir: './dist',
+  // /next, not /next/index.html — vercel.json's cleanUrls serves the directory
+  // form at the bare path.
+  build: { format: 'directory' },
+  devToolbar: { enabled: false },
+  vite: { plugins: [servesTheExistingSite()] },
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "portfolio",
+  "private": true,
+  "type": "module",
+  "packageManager": "pnpm@11.9.0",
+  "scripts": {
+    "dev": "astro dev",
+    "build": "node scripts/check-source.mjs && astro check && astro build && node scripts/assemble-dist.mjs",
+    "preview": "node scripts/serve-dist.mjs",
+    "check:sections": "node scripts/check-source.mjs",
+    "check:types": "astro check"
+  },
+  "engines": {
+    "node": "22.x"
+  },
+  "devDependencies": {
+    "@astrojs/check": "0.9.10",
+    "astro": "7.2.4",
+    "typescript": "6.0.3"
+  },
+  "dependencies": {
+    "gsap": "3.15.0"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,3319 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      gsap:
+        specifier: 3.15.0
+        version: 3.15.0
+    devDependencies:
+      '@astrojs/check':
+        specifier: 0.9.10
+        version: 0.9.10(prettier@3.9.6)(typescript@6.0.3)
+      astro:
+        specifier: 7.2.4
+        version: 7.2.4(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(yaml@2.9.0)
+      typescript:
+        specifier: 6.0.3
+        version: 6.0.3
+
+packages:
+
+  '@astrojs/check@0.9.10':
+    resolution: {integrity: sha512-zgx/UQMozdjOa3bOxjgeCFdtpE3c9rRX6xHwa+2QXvy8z8Akifu2AtubHyv/zzC2znO8dl8fFWL4K+Ba9kS8HQ==}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0 || ^6.0.0
+
+  '@astrojs/compiler-binding-darwin-arm64@0.3.2':
+    resolution: {integrity: sha512-MM8tn8CSimcfytaOla4b6acN8mKWiL/rlAA1fpT3/Wl7dNGSE4y8FjTN/zJVNnb63CsLWG5zZwCt01TXtDKh9g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@astrojs/compiler-binding-darwin-x64@0.3.2':
+    resolution: {integrity: sha512-2lXOlzf8xb7jLomRsf/aswh61/NnGusynB2OwFkK6k4pmOtpfXMYnG0PLfXrEvxXYj69NdCnmUYXtHDd+JOOag==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@astrojs/compiler-binding-linux-arm64-gnu@0.3.2':
+    resolution: {integrity: sha512-BmU3kWj7qnLrd4vzm49zFEPJ5oFnn1tCT4Vt9hZbqdU5Cmb8GZl7fn6VFsnNfe7B18a2gIFtVzbLINtYl5kBjQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@astrojs/compiler-binding-linux-arm64-musl@0.3.2':
+    resolution: {integrity: sha512-f0heT9ZZEseSu5bHCeb80eL2DH07ArE6U9xi1WT/PEusNjzPmEr3GJsjG1tRLo5VYUUYX7h3ScaqGmGrMOVGmw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@astrojs/compiler-binding-linux-x64-gnu@0.3.2':
+    resolution: {integrity: sha512-M8fOUt0itRpqiGyoEA/ij184s8O+hqbCz3+YozRusOOM3osgGljpDThhbKAJjqh82wOo6FioQ4w8PBvU1XMD5Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@astrojs/compiler-binding-linux-x64-musl@0.3.2':
+    resolution: {integrity: sha512-/Kebk8sO6HnLeSd691JkaAPfN7CqR9/KEXmWvyNPkaKNGmj8rTZ/lf2uXtnPu92Lan84UrKdIKVPy1fSo2encQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@astrojs/compiler-binding-wasm32-wasi@0.3.2':
+    resolution: {integrity: sha512-pUA6xbcOSB7DhfzIArB8BCAkFfAIqriiR7zl5zOStd6oU2G0kIKj+GUdGnyXyhfiv881Hffyk5tC0mR18sDjDw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@astrojs/compiler-binding-win32-arm64-msvc@0.3.2':
+    resolution: {integrity: sha512-ESruf+6Qkl1trHUFxI6GSf6t52j8yN2kCNSzMWdzt7V/T09tFHrYzrVaJQohb2C9bJUH76pNvX6Zb51+xCQc9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@astrojs/compiler-binding-win32-x64-msvc@0.3.2':
+    resolution: {integrity: sha512-wzzVrEbOwbsLWOdEbocskjMRx2aZPxJ7ZbmL+jnpBamFwmigm+2M/wzuM6JWncocgYwLic1csSpalBh96kQKXA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@astrojs/compiler-binding@0.3.2':
+    resolution: {integrity: sha512-8w/9CWmYrAJJ8N0SY3O43ws2BgxoW6u3QsD8u2mE140lMYAlwh+tlNoUeSBq22wVheFuiBbR212l6ixZ2IIgCQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  '@astrojs/compiler-rs@0.3.2':
+    resolution: {integrity: sha512-xlx/T7JovIKduu4ucbTQUxQ5+Q8wxkHxhLjnZk3VlJbhbQ9RLvvuDk1p2YYFYFQ5y14dVm3FGGO4isQXa4F+Tg==}
+    engines: {node: '>=22.12.0'}
+
+  '@astrojs/compiler@2.13.1':
+    resolution: {integrity: sha512-f3FN83d2G/v32ipNClRKgYv30onQlMZX1vCeZMjPsMMPl1mDpmbl0+N5BYo4S/ofzqJyS5hvwacEo0CCVDn/Qg==}
+
+  '@astrojs/internal-helpers@0.10.4':
+    resolution: {integrity: sha512-nozZSy/mKYLqe4YrqbKtdOszedAfXYCtw3wZ0d+CAjz4GqQ4L9rl1ltIL5BlgwmYVinJg/RZ0MgGuWOdlyRZlA==}
+
+  '@astrojs/language-server@2.16.14':
+    resolution: {integrity: sha512-YPXkBu6N4d1sT09pvBmIDGZay+1MemV551FSgdEM3aZRDzbkxd2H7Cvf8MsVJLVB1mIEyTf1XbMN/30gp7s46w==}
+    hasBin: true
+    peerDependencies:
+      prettier: ^3.0.0
+      prettier-plugin-astro: '>=0.11.0'
+    peerDependenciesMeta:
+      prettier:
+        optional: true
+      prettier-plugin-astro:
+        optional: true
+
+  '@astrojs/markdown-satteri@0.3.7':
+    resolution: {integrity: sha512-NHcHbrKW/opbZnTZQ5nH293BdcK2VV0tjuzI88CLnvy2njiEJVwUQ5KFnYd4NoWgHJCY/I1CyjGWCR4Vv3khXQ==}
+
+  '@astrojs/prism@4.0.2':
+    resolution: {integrity: sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA==}
+    engines: {node: '>=22.12.0'}
+
+  '@astrojs/telemetry@3.3.3':
+    resolution: {integrity: sha512-C1TLn5sPJr0x4vk56piHWKbnqlEB8BKyte5Y45V02U+D7BGO5eMqZDH5aPjnkXQWJggvmsTXxH03QMZ9NgWLzQ==}
+    engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
+
+  '@astrojs/yaml2ts@0.2.4':
+    resolution: {integrity: sha512-8oddpOae35pJsXPQXhTkM0ypfKPskVsh2bCxRtbf7e+/Epw2nReakFYpLKjZMEr75CsoF203PMnCocpfz0s69A==}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.8':
+    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.8':
+    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@bruits/satteri-darwin-arm64@0.10.5':
+    resolution: {integrity: sha512-27KTVl4TJkVahMy/ohyA7qd4938G5UNneFUz/PsScYfpIhj0IVAS23mpcJXdPF44sa6nva198lmV/cKIb2YPyA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@bruits/satteri-darwin-x64@0.10.5':
+    resolution: {integrity: sha512-IjnLe3nKspq6qaeqGgjT7MT8VrTV74yWRlaag7ZdNsI8TDAYZ0iPxMCo+9KQZHUk5EyVB+reBI/PFWL5KuFw9Q==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@bruits/satteri-linux-arm64-gnu@0.10.5':
+    resolution: {integrity: sha512-glkYXZCJywjP13v67eAyAMSJdF+ncvEbYvgi/wOtffL9tQ27lr/zsyzUfgs+ovjJ9d8JNQKiXeiArJcX8PJL9w==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@bruits/satteri-linux-arm64-musl@0.10.5':
+    resolution: {integrity: sha512-yWdgG1g17Nh2QyGVlFUxGRa3FEFwiMcpZEyMNWkbM3deC94cmVc+/i9OuyFpdKuWo3GkgoCtYVOoxk1uCnCZIA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@bruits/satteri-linux-x64-gnu@0.10.5':
+    resolution: {integrity: sha512-FVaLoPT1fBgGl0J+AYebyyXJYBachGl8Oyyrf1lye4RTqCB4S0Gwkj1uM9RJyThUOvx5VUmAT1CnNh1SFHA+kw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@bruits/satteri-linux-x64-musl@0.10.5':
+    resolution: {integrity: sha512-EHpVAx2bqW3GINHTKkljtxVfQmVDGWIuwOYOP5YghTj+0PkBa2o8oKPRtQ9Kbsr1Fye8jtUcDjhwj2jMNugZKg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@bruits/satteri-wasm32-wasi@0.10.5':
+    resolution: {integrity: sha512-ypz8c/Zmipxp4IoeDa228Gstv6TLzVmNs3yC6wKCoNSOjx1iwpgzu87Y3hTkXFdwChVGU85qeUDuOIarGUZQLw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@bruits/satteri-win32-arm64-msvc@0.10.5':
+    resolution: {integrity: sha512-siTV88nb0LRqNpkL2gXboqCwVdq95sLtzMHS1/3eONV2gLbB3NAK46wmSMvCO/yquBvI2lvaFIfd8P12ecsxBw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@bruits/satteri-win32-x64-msvc@0.10.5':
+    resolution: {integrity: sha512-C3IfPvfvMXmlzBxaMPKFS1XiuV9pu2mC7YqkPk7PSvTgPZ8gbdASIpHpztDLvTTQjqZ0z1Ol8tK5X+V6XXC0wQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@capsizecss/unpack@4.0.1':
+    resolution: {integrity: sha512-CuNiSqg7+e1cO/GjffyMOm5Tt2jUF9CWHHnvQ/UkqvtkGfHdgwEC0wpmq7fkN3gxwpRnrAN0WzO3vREKmNolMQ==}
+    engines: {node: '>=18'}
+
+  '@clack/core@1.4.3':
+    resolution: {integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==}
+    engines: {node: '>= 20.12.0'}
+
+  '@clack/prompts@1.7.0':
+    resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
+    engines: {node: '>= 20.12.0'}
+
+  '@emmetio/abbreviation@2.3.3':
+    resolution: {integrity: sha512-mgv58UrU3rh4YgbE/TzgLQwJ3pFsHHhCLqY20aJq+9comytTXUDNGG/SMtSeMJdkpxgXSXunBGLD8Boka3JyVA==}
+
+  '@emmetio/css-abbreviation@2.1.8':
+    resolution: {integrity: sha512-s9yjhJ6saOO/uk1V74eifykk2CBYi01STTK3WlXWGOepyKa23ymJ053+DNQjpFcy1ingpaO7AxCcwLvHFY9tuw==}
+
+  '@emmetio/css-parser@0.4.1':
+    resolution: {integrity: sha512-2bC6m0MV/voF4CTZiAbG5MWKbq5EBmDPKu9Sb7s7nVcEzNQlrZP6mFFFlIaISM8X6514H9shWMme1fCm8cWAfQ==}
+
+  '@emmetio/html-matcher@1.3.0':
+    resolution: {integrity: sha512-NTbsvppE5eVyBMuyGfVu2CRrLvo7J4YHb6t9sBFLyY03WYhXET37qA4zOYUjBWFCRHO7pS1B9khERtY0f5JXPQ==}
+
+  '@emmetio/scanner@1.0.4':
+    resolution: {integrity: sha512-IqRuJtQff7YHHBk4G8YZ45uB9BaAGcwQeVzgj/zj8/UdOhtQpEIupUhSk8dys6spFIWVZVeK20CzGEnqR5SbqA==}
+
+  '@emmetio/stream-reader-utils@0.1.0':
+    resolution: {integrity: sha512-ZsZ2I9Vzso3Ho/pjZFsmmZ++FWeEd/txqybHTm4OgaZzdS8V9V/YYWQwg5TC38Z7uLWUV1vavpLLbjJtKubR1A==}
+
+  '@emmetio/stream-reader@2.2.0':
+    resolution: {integrity: sha512-fXVXEyFA5Yv3M3n8sUGT7+fvecGrZP4k6FnWWMSZVQf69kAq0LLpaBQLGcPR30m3zMmKYhECP4k/ZkzvhEW5kw==}
+
+  '@emnapi/core@1.11.1':
+    resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
+
+  '@emnapi/runtime@1.11.1':
+    resolution: {integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==}
+
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
+
+  '@emnapi/wasi-threads@1.2.2':
+    resolution: {integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==}
+
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.35.3':
+    resolution: {integrity: sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.35.3':
+    resolution: {integrity: sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-freebsd-wasm32@0.35.3':
+    resolution: {integrity: sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==}
+    engines: {node: '>=20.9.0'}
+    os: [freebsd]
+
+  '@img/sharp-libvips-darwin-arm64@1.3.2':
+    resolution: {integrity: sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.3.2':
+    resolution: {integrity: sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.3.2':
+    resolution: {integrity: sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.3.2':
+    resolution: {integrity: sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.3.2':
+    resolution: {integrity: sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.3.2':
+    resolution: {integrity: sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.3.2':
+    resolution: {integrity: sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.3.2':
+    resolution: {integrity: sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
+    resolution: {integrity: sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
+    resolution: {integrity: sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.35.3':
+    resolution: {integrity: sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.35.3':
+    resolution: {integrity: sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.35.3':
+    resolution: {integrity: sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.35.3':
+    resolution: {integrity: sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.35.3':
+    resolution: {integrity: sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==}
+    engines: {node: '>=20.9.0'}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.35.3':
+    resolution: {integrity: sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.35.3':
+    resolution: {integrity: sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.35.3':
+    resolution: {integrity: sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.35.3':
+    resolution: {integrity: sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==}
+    engines: {node: '>=20.9.0'}
+
+  '@img/sharp-webcontainers-wasm32@0.35.3':
+    resolution: {integrity: sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==}
+    engines: {node: '>=20.9.0'}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.35.3':
+    resolution: {integrity: sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.35.3':
+    resolution: {integrity: sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==}
+    engines: {node: ^20.9.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.35.3':
+    resolution: {integrity: sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@napi-rs/wasm-runtime@1.2.3':
+    resolution: {integrity: sha512-UMduMbqO5s5zF2NkNacMT/yK5Y5QiKvWr2+50bzIIxFDwVJ2h49b+oyjaCGPhJxd2/gC2x39EHv/gHVuu36x2Q==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=23.5.0}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1 || ^2.0.0-alpha.4
+      '@emnapi/runtime': ^1.7.1 || ^2.0.0-alpha.4
+
+  '@oslojs/encoding@1.1.0':
+    resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
+
+  '@oxc-project/types@0.146.0':
+    resolution: {integrity: sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA==}
+
+  '@rolldown/binding-android-arm-eabi@1.2.5':
+    resolution: {integrity: sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@rolldown/binding-android-arm64@1.2.5':
+    resolution: {integrity: sha512-zXcwKlQApYAOELHd8PwKDFkagYF9Wy4e0RJ+0qnzl9Pjnpj75TEG8ufv40p2J7kCEfwZAsNiuzRIyNNMWT38ig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.2.5':
+    resolution: {integrity: sha512-dK4QakI42nzWgJT5sm4y4y/O//D4OxM75/cH28RLV+nzIN9AY+YsbuUVrUTjlLjXR6vpyxFbSsbmNuJ6BP9sww==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.2.5':
+    resolution: {integrity: sha512-fqSALaUu1Wjd1nK2uW2kJDWdLCc8lx1IcY+MTY26Aurfdx19anlzhqXOgCFbBFQnlFDTn4TC1/7Nz4Bl2mLP3A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.2.5':
+    resolution: {integrity: sha512-/vCnNxlkxs9tKxNDcyWUePpJ/PgTzxIaVhoM5SmG8UV+GR/IcPam4VYxi7GIMo7PSDuNqlJqvprqii9NqqVCMw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.5':
+    resolution: {integrity: sha512-abk0NLA519LxRCszmbE0jYKuQ9YPocOXTiOXOo6Yr+YAT95VH+PtqYAjOJvGKt3viEd/x4qzabAlwd5bHOOARg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.5':
+    resolution: {integrity: sha512-Y7eALiJ8lr0M2HH103Js+g7V34wf6snlpZLAsHI90uLhr3PVlNsbFVAXJC9d/V6BnPyKtpSwI+NcB/RLxsQxuA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.2.5':
+    resolution: {integrity: sha512-xMvZgnbZg4YVnR/AX2b3oOPDTFYJvUVaJg5FedA/LuvexAtXibZQej4cnTkw3rjsJ/ggUROB64TdtETiim+FYA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.5':
+    resolution: {integrity: sha512-GRjeqTUDHTo5GwntsLaAMcBahG3nlpjftXWZLN73HiYQlhwEowvarFgQnRnQZtIp4keXX7quXFbG38uPZBa2EA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.5':
+    resolution: {integrity: sha512-vLNTR45F2Uwc8AufkNXPmB4VliaXs+FvcheEogIzOXzO4l+LzieXF5A/TWxLy5HtqpsRCHUfd0lPVrrdgXdLHQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.2.5':
+    resolution: {integrity: sha512-Mgj59/HTuYeK9Gz2MA+mBWKnHsAgkBSec15ZMb1st3oIfFbX7gCjOae7GydHhzcyQi9Z/7M1QuN9bR3oFqF0jQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.2.5':
+    resolution: {integrity: sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.2.5':
+    resolution: {integrity: sha512-8SLssA2oweAxyRgDp789ACfRb/3P+zNRJpzZxSizxF9m8NUDQ4+3xjo8ttjhVGGw6Qxb70oZiEtIjaKikCO7Yw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.5':
+    resolution: {integrity: sha512-vGbruD5zquhoc8D9SViXgN2FBJtNdTyQ4DtG+SWiEGlJiAzoKcZ2xp+xuXCffhubVdt0NJlTZqkeRuERy7g8Cw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.2.5':
+    resolution: {integrity: sha512-e/SXpgISz+IoqVcSSI0rx/d/he8zqLex+/rCWpnHpmVfmPIUjag9H6P7zotf0gJHwPUhQxZ/mF8tr6acebT9yw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
+  '@shikijs/core@4.4.3':
+    resolution: {integrity: sha512-QCR4q2ZO/ILJEuwiBMel4wdcTDb1JGwfjKTxPDF6x8ixOaluPrVqIn06C99AcRPhmYlBR56d/Fb+GN58GzExpg==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-javascript@4.4.3':
+    resolution: {integrity: sha512-FbOjFJp9VLdo1Wevs10BBtVxiTWwNLqZh5Gkhjgda/ioL15YOgeSl9n+6XMa3qRlPQzfhFNe641SrynFHYG0nQ==}
+    engines: {node: '>=20'}
+
+  '@shikijs/engine-oniguruma@4.4.3':
+    resolution: {integrity: sha512-EcOQkxdxGQrc1Row/cC2c96/v1dbZqGnEVu1qTuT/MJmp6+cXCvQussowVmCv5Tqr3KuY3c7IbM6HTW3LJ1k9w==}
+    engines: {node: '>=20'}
+
+  '@shikijs/langs@4.4.3':
+    resolution: {integrity: sha512-ePic0yfAJGOF83D5wBHK/00EjK65oahBYxFk5epgq33WRv7X9UuxLEV8PtR0szC0z8dl7INIpIodB99JRFlR+A==}
+    engines: {node: '>=20'}
+
+  '@shikijs/primitive@4.4.3':
+    resolution: {integrity: sha512-m0wBeLDQDeIxRdUmrCPdQqfuUamDwRL5isCfYbguKD6NiaKpVbsv+3J81DyIKgNW5h4WAIIr8T4EkgQrBBxvaQ==}
+    engines: {node: '>=20'}
+
+  '@shikijs/themes@4.4.3':
+    resolution: {integrity: sha512-w8UHjeUnIR965KMWJHUPXOc2mNJUnK3vpVLYLvw5IYU2mnTTJ89E24OrJDBNiJDQ0qzb0tc4l7mrIXx5cFeIyw==}
+    engines: {node: '>=20'}
+
+  '@shikijs/types@4.4.3':
+    resolution: {integrity: sha512-UEJxmRR++MAGR6hugn0vgVS2W/6lWAts84FFSrnlH9sP0LNol7E5+NQ792pH8liWUhyMyjhTgSUH3k7iD7tc5g==}
+    engines: {node: '>=20'}
+
+  '@shikijs/vscode-textmate@10.0.2':
+    resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
+
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/hast@3.0.5':
+    resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/nlcst@2.0.3':
+    resolution: {integrity: sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@ungap/structured-clone@1.3.3':
+    resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
+
+  '@volar/kit@2.4.28':
+    resolution: {integrity: sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==}
+    peerDependencies:
+      typescript: '*'
+
+  '@volar/language-core@2.4.28':
+    resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
+
+  '@volar/language-server@2.4.28':
+    resolution: {integrity: sha512-NqcLnE5gERKuS4PUFwlhMxf6vqYo7hXtbMFbViXcbVkbZ905AIVWhnSo0ZNBC2V127H1/2zP7RvVOVnyITFfBw==}
+
+  '@volar/language-service@2.4.28':
+    resolution: {integrity: sha512-Rh/wYCZJrI5vCwMk9xyw/Z+MsWxlJY1rmMZPsxUoJKfzIRjS/NF1NmnuEcrMbEVGja00aVpCsInJfixQTMdvLw==}
+
+  '@volar/source-map@2.4.28':
+    resolution: {integrity: sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==}
+
+  '@volar/typescript@2.4.28':
+    resolution: {integrity: sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==}
+
+  '@vscode/emmet-helper@2.11.0':
+    resolution: {integrity: sha512-QLxjQR3imPZPQltfbWRnHU6JecWTF1QSWhx3GAKQpslx7y3Dp6sIIXhKjiUJ/BR9FX8PVthjr9PD6pNwOJfAzw==}
+
+  '@vscode/l10n@0.0.18':
+    resolution: {integrity: sha512-KYSIHVmslkaCDyw013pphY+d7x1qV8IZupYfeIfzNA+nsaWHbn5uPuQRvdRFsa9zFzGeudPuoGoZ1Op4jrJXIQ==}
+
+  ajv-draft-04@1.0.0:
+    resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
+    peerDependencies:
+      ajv: ^8.5.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv-i18n@4.2.0:
+    resolution: {integrity: sha512-v/ei2UkCEeuKNXh8RToiFsUclmU+G57LO1Oo22OagNMENIw+Yb8eMwvHu7Vn9fmkjJyv6XclhJ8TbuigSglPkg==}
+    peerDependencies:
+      ajv: ^8.0.0-beta.0
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
+  am-i-vibing@0.4.0:
+    resolution: {integrity: sha512-MxT4XZL7pzLHpuvhDKdMaQHMGGkJDLluKBLsbstn+8wv9sWcFT6h+0ve9qkml95amVTZtZV83gQe2hY+ojgHLg==}
+    hasBin: true
+
+  ansi-regex@6.3.0:
+    resolution: {integrity: sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==}
+    engines: {node: '>=12'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
+  anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
+
+  astro@7.2.4:
+    resolution: {integrity: sha512-+cuLsBns2wwUHI9a10xZMbjrF91m7+QNwqTVeljTx0B8Lf+8h0LgVGjdVIL2FALDKD2I565lczeeS3BFC+KdZg==}
+    engines: {node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0'}
+    hasBin: true
+    peerDependencies:
+      '@astrojs/markdown-remark': 7.2.4
+    peerDependenciesMeta:
+      '@astrojs/markdown-remark':
+        optional: true
+
+  axobject-query@4.1.0:
+    resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
+    engines: {node: '>= 0.4'}
+
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
+  chalk@4.1.2:
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
+    engines: {node: '>=10'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  chokidar@5.0.0:
+    resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
+    engines: {node: '>= 20.19.0'}
+
+  ci-info@4.4.0:
+    resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
+    engines: {node: '>=8'}
+
+  cliui@9.0.1:
+    resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
+    engines: {node: '>=20'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  commander@11.1.0:
+    resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
+    engines: {node: '>=16'}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
+
+  common-ancestor-path@2.0.0:
+    resolution: {integrity: sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==}
+    engines: {node: '>= 18'}
+
+  cookie-es@1.2.3:
+    resolution: {integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==}
+
+  cookie@2.0.1:
+    resolution: {integrity: sha512-yuToqVvRrj6pfDXREyQAAv8SkAEk/8GS3jQRTiUMm66TVtBYmqQeoEjL2Lmq8Rpo6271vH76InTChTitEAm65w==}
+    engines: {node: '>=22'}
+
+  crossws@0.3.5:
+    resolution: {integrity: sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==}
+
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
+  css-tree@2.2.1:
+    resolution: {integrity: sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
+
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
+
+  csso@5.0.5:
+    resolution: {integrity: sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
+
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  destr@2.0.5:
+    resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  devalue@5.9.1:
+    resolution: {integrity: sha512-+17vil3EVQRzvtDJSFuTWEb8XJRvXqAiV3qZyQWD398QeXUa6CxsUyMdD1fxzEhUrd4FojitFz7lhIHBTlV4fw==}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
+
+  diff@8.0.4:
+    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+    engines: {node: '>=0.3.1'}
+
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  dset@3.1.4:
+    resolution: {integrity: sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==}
+    engines: {node: '>=4'}
+
+  emmet@2.4.11:
+    resolution: {integrity: sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ==}
+
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  es-module-lexer@2.3.2:
+    resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
+
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+
+  fast-wrap-ansi@0.2.2:
+    resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  find-process@2.1.1:
+    resolution: {integrity: sha512-SrQDx3QhlmHM90iqn9rdjCQcw/T+WlpOkHFsjoRgB+zTpDfltNA1VSNYeYELwhUTJy12UFxqjWhmhOrJc+o4sA==}
+    hasBin: true
+
+  flattie@1.1.1:
+    resolution: {integrity: sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==}
+    engines: {node: '>=8'}
+
+  fontace@0.4.1:
+    resolution: {integrity: sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==}
+
+  fontkitten@1.0.3:
+    resolution: {integrity: sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==}
+    engines: {node: '>=20'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  get-east-asian-width@1.6.0:
+    resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
+    engines: {node: '>=18'}
+
+  get-tsconfig@5.0.0-beta.4:
+    resolution: {integrity: sha512-7nF7C9fIPFEMHgEMEfgIlO9wDdZ8CyHw27rWciFZfHvHDReIiPhsYuzPRXsfvBCqFy1l8RRyyWV7QLM+ZhUJsQ==}
+    engines: {node: '>=20.20.0'}
+
+  github-slugger@2.0.0:
+    resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
+
+  gsap@3.15.0:
+    resolution: {integrity: sha512-dMW4CWBTUK1AEEDeZc1g4xpPGIrSf9fJF960qbTZmN/QwZIWY5wgliS6JWl9/25fpTGJrMRtSjGtOmPnfjZB+A==}
+
+  h3@1.15.11:
+    resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
+
+  has-flag@4.0.0:
+    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
+    engines: {node: '>=8'}
+
+  hast-util-to-html@9.0.5:
+    resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  html-escaper@3.0.3:
+    resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
+
+  http-cache-semantics@4.2.0:
+    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
+  iron-webcrypto@1.2.1:
+    resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
+
+  is-docker@4.0.0:
+    resolution: {integrity: sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
+
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
+    hasBin: true
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  jsonc-parser@2.3.1:
+    resolution: {integrity: sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==}
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
+  kleur@4.1.5:
+    resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
+    engines: {node: '>=6'}
+
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
+    engines: {node: '>= 12.0.0'}
+
+  loglevel@1.9.2:
+    resolution: {integrity: sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==}
+    engines: {node: '>= 0.6.0'}
+
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
+  magic-string@1.2.2:
+    resolution: {integrity: sha512-veT/+7iXrXzT39XnEN4lOxtNl72dMgJ8Lp+5Bd6YcMSWpb0n0MjBM8Uuooi6jgJr8dhUW2swQgBmoZVMni5SVg==}
+
+  magicast@0.5.4:
+    resolution: {integrity: sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdn-data@2.0.28:
+    resolution: {integrity: sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  mrmime@2.0.1:
+    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
+    engines: {node: '>=10'}
+
+  muggle-string@0.4.1:
+    resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
+
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  neotraverse@1.0.1:
+    resolution: {integrity: sha512-WmmLty1YWwJl9yZi77v2dVIV6X2kuYV8YYBI/G3LWGKdGHmHUvL1z7FW0iDvEvGAwNEoc5x1tOOOyDnf5jJw/w==}
+    engines: {node: '>= 10'}
+
+  nlcst-to-string@4.0.0:
+    resolution: {integrity: sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==}
+
+  node-fetch-native@1.6.7:
+    resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
+  node-mock-http@1.0.5:
+    resolution: {integrity: sha512-KQyt/wLjG3TAc7DOUhpqWzgd4ERxR80JOlTK5VE5R1S12IaPVN5qkj4klBce9HPG1Njuup4Sb5bljaT34lIyjw==}
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
+  ofetch@1.5.1:
+    resolution: {integrity: sha512-2W4oUZlVaqAPAil6FUg/difl6YhqhUR7x2eZY4bQCko22UXg3hptq9KLQdqFClV+Wu85UX7hNtdGTngi/1BxcA==}
+
+  ohash@2.0.12:
+    resolution: {integrity: sha512-65S/5gk9YSsaRjcyf7Nfa6h/d3E8/1gslpXfI4W7Dxn/oap8IKRuNT5VXkLQ1YFKIEg4apRY4Pj6aiwFzrDdmw==}
+
+  oniguruma-parser@0.12.2:
+    resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
+
+  oniguruma-to-es@4.3.6:
+    resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
+
+  p-limit@7.3.1:
+    resolution: {integrity: sha512-0trZaiG7Y7kN/Egy9a8j47t9osC0Tch4PaIWd9yGF6bvmlk7muExRvGNYb8sXBwEKMoNKsbNN9P8EefuQekE4Q==}
+    engines: {node: '>=20'}
+
+  p-queue@9.3.3:
+    resolution: {integrity: sha512-NXAOdnEe5FsZJfT4oK84lE1Y5cFFdWlRuOo5tww8DyNMxyRXwn39fIkUtNLKppcPC+UYU/bXujNCUGDv01y7CA==}
+    engines: {node: '>=20'}
+
+  p-timeout@7.0.1:
+    resolution: {integrity: sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==}
+    engines: {node: '>=20'}
+
+  package-manager-detector@1.8.0:
+    resolution: {integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==}
+
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
+  piccolore@0.1.3:
+    resolution: {integrity: sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  prettier@3.9.6:
+    resolution: {integrity: sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  prismjs@1.30.0:
+    resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
+    engines: {node: '>=6'}
+
+  process-ancestry@0.1.0:
+    resolution: {integrity: sha512-tGqJW/UnclpYASFcM6Xh8D8l/BMtaQ9+CSG0vlJSJTcdMM4lDRv4c6H0Pdcsfted+bVczdYSfk2fdukg2gQkZg==}
+    engines: {node: '>=18.0.0'}
+
+  property-information@7.2.0:
+    resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
+  radix3@1.1.2:
+    resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  readdirp@5.1.1:
+    resolution: {integrity: sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==}
+    engines: {node: '>= 20.19.0'}
+
+  regex-recursion@6.0.2:
+    resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
+
+  regex-utilities@2.3.0:
+    resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
+
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
+  request-light@0.5.8:
+    resolution: {integrity: sha512-3Zjgh+8b5fhRJBQZoy+zbVKpAQGLyka0MPgW3zruTF4dFFJ8Fqcfu9YsAvi/rvdcaTeWG3MkbZv4WKxAn/84Lg==}
+
+  request-light@0.7.0:
+    resolution: {integrity: sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q==}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  retext-smartypants@6.2.0:
+    resolution: {integrity: sha512-kk0jOU7+zGv//kfjXEBjdIryL1Acl4i9XNkHxtM7Tm5lFiCog576fjNC9hjoR7LTKQ0DsPWy09JummSsH1uqfQ==}
+
+  rolldown@1.2.5:
+    resolution: {integrity: sha512-VD2IE5PUG4Oj8zz2VGykiYd5wbnjdIiSsNQb8Qu5B+noEp+A78mu2iVvpp27g8es14Tk9rofNs5Tku9iQCS4fA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
+  satteri@0.10.5:
+    resolution: {integrity: sha512-Ao1LKpAEa9Wdg0otgbVKViZHEq9ebdXe4DMrp3s9vQAU0HNIuHnFEuMuOcm0ZIXyV0Yzxj91NvhLpvXZJO/5ZQ==}
+
+  sax@1.6.1:
+    resolution: {integrity: sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==}
+    engines: {node: '>=11.0.0'}
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  sharp@0.35.3:
+    resolution: {integrity: sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  shiki@4.4.3:
+    resolution: {integrity: sha512-Mb/GvXPHBAXdgGIcnfU5L3ldpn1XcxrGkPHwqgRx17/I2XRfqlFKk2vGkHWINn1kdXvzJZeuO3is6I9KLPFm0g==}
+    engines: {node: '>=20'}
+
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  smol-toml@1.8.0:
+    resolution: {integrity: sha512-kCZr2V3ch9i00x8zXRhjUNVcjG9ijES5dDudkXvUVCT5QlJNQWElSJdZqyPemffHoLNUYwOcou0Fy+ojN0uHSQ==}
+    engines: {node: '>= 18'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
+  string-width@8.2.2:
+    resolution: {integrity: sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==}
+    engines: {node: '>=20'}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
+
+  supports-color@7.2.0:
+    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
+    engines: {node: '>=8'}
+
+  svgo@4.0.2:
+    resolution: {integrity: sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  tiny-inflate@1.0.3:
+    resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
+
+  tinyclip@0.1.15:
+    resolution: {integrity: sha512-uo33abH+Ays0xYaDysoBt494Hb3hsEczMpcC0MwFl773pazORx4fmvKhclhR1wonUbB6vvpRsvVMwnhfqeMc+A==}
+    engines: {node: ^16.14.0 || >= 17.3.0}
+
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typesafe-path@0.2.2:
+    resolution: {integrity: sha512-OJabfkAg1WLZSqJAJ0Z6Sdt3utnbzr/jh+NAHoyWHJe8CMSy79Gm085094M9nvTPy22KzTVn5Zq5mbapCI/hPA==}
+
+  typescript-auto-import-cache@0.3.6:
+    resolution: {integrity: sha512-RpuHXrknHdVdK7wv/8ug3Fr0WNsNi5l5aB8MYYuXhq2UH5lnEB1htJ1smhtD5VeCsGr2p8mUDtd83LCQDFVgjQ==}
+
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
+  ultrahtml@1.7.0:
+    resolution: {integrity: sha512-2xRd0VHoAQE4M+vF/DvFFB7pUV0ZxTW1TLi7lHQWnF/Sb5TPeEUV/l+hxcNnGO00ZXGnR0voCMmYRKQf+rvJ2g==}
+
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+    engines: {node: '>=22.19.0'}
+
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unifont@0.7.5:
+    resolution: {integrity: sha512-ULe/Cs+ZIsq+dcFofNkhqielCrUJnb5mr+Yc4EBM2VlL+6OZR6+cjtI2mT1bJvRBrVncqHAbLURxmPLcCXzWMg==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
+  unstorage@1.17.5:
+    resolution: {integrity: sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==}
+    peerDependencies:
+      '@azure/app-configuration': ^1.8.0
+      '@azure/cosmos': ^4.2.0
+      '@azure/data-tables': ^13.3.0
+      '@azure/identity': ^4.6.0
+      '@azure/keyvault-secrets': ^4.9.0
+      '@azure/storage-blob': ^12.26.0
+      '@capacitor/preferences': ^6 || ^7 || ^8
+      '@deno/kv': '>=0.9.0'
+      '@netlify/blobs': ^6.5.0 || ^7.0.0 || ^8.1.0 || ^9.0.0 || ^10.0.0
+      '@planetscale/database': ^1.19.0
+      '@upstash/redis': ^1.34.3
+      '@vercel/blob': '>=0.27.1'
+      '@vercel/functions': ^2.2.12 || ^3.0.0
+      '@vercel/kv': ^1 || ^2 || ^3
+      aws4fetch: ^1.0.20
+      db0: '>=0.2.1'
+      idb-keyval: ^6.2.1
+      ioredis: ^5.4.2
+      uploadthing: ^7.4.4
+    peerDependenciesMeta:
+      '@azure/app-configuration':
+        optional: true
+      '@azure/cosmos':
+        optional: true
+      '@azure/data-tables':
+        optional: true
+      '@azure/identity':
+        optional: true
+      '@azure/keyvault-secrets':
+        optional: true
+      '@azure/storage-blob':
+        optional: true
+      '@capacitor/preferences':
+        optional: true
+      '@deno/kv':
+        optional: true
+      '@netlify/blobs':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/blob':
+        optional: true
+      '@vercel/functions':
+        optional: true
+      '@vercel/kv':
+        optional: true
+      aws4fetch:
+        optional: true
+      db0:
+        optional: true
+      idb-keyval:
+        optional: true
+      ioredis:
+        optional: true
+      uploadthing:
+        optional: true
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  vite@8.2.2:
+    resolution: {integrity: sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.4.0 || ^0.5.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitefu@1.1.3:
+    resolution: {integrity: sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==}
+    peerDependencies:
+      vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      vite:
+        optional: true
+
+  volar-service-css@0.0.71:
+    resolution: {integrity: sha512-wRRFt9BpjMKCazcgOh67MSjUjiWUCAh99DyYSDIOTuxaRjEtDC7PpB0k1Y1wbJIW/pVtMUSVbpPo3UGSm0Byxw==}
+    peerDependencies:
+      '@volar/language-service': ~2.4.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+
+  volar-service-emmet@0.0.71:
+    resolution: {integrity: sha512-zqjzt6bN95e3CUstBm0PBFAJnrfz0ZAARka87fart46/gNCLLuP3Vujy8V/J8HEziTFLnfkgIASLFYPUhonJcA==}
+    peerDependencies:
+      '@volar/language-service': ~2.4.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+
+  volar-service-html@0.0.71:
+    resolution: {integrity: sha512-e8tHPhgQ7ooLfudAEIku+kgd9pWkq3SSz8RbnQDI1+Eb8wbenkLGHqoirLqz5ORLV6wIMr2Iv08RWBG5eOcgpw==}
+    peerDependencies:
+      '@volar/language-service': ~2.4.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+
+  volar-service-prettier@0.0.71:
+    resolution: {integrity: sha512-Rz7JVH3qD108UCdmIEiZvOBNljMt2nLFdbN8AXcDfn7xD9F5I2aCIsDVqBbXw21PsnxG0b7MfwtNF+zPS/NKUg==}
+    peerDependencies:
+      '@volar/language-service': ~2.4.0
+      prettier: ^2.2 || ^3.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+      prettier:
+        optional: true
+
+  volar-service-typescript-twoslash-queries@0.0.71:
+    resolution: {integrity: sha512-9K2k72s4n7rV9s4bX0MyjbX9iBribvKZbBJKuEmTCZfeWJXs6Yh7bGpY4eoc7UufAjvpheBqwyZCOIPBvxCv0A==}
+    peerDependencies:
+      '@volar/language-service': ~2.4.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+
+  volar-service-typescript@0.0.71:
+    resolution: {integrity: sha512-yTtM/BVT6hoyEYnDtaCyAtNhdNeS/mhTTABlBOdw3NNiRBUin3IznFJpgfjer4c6RYopiPjjQjc9VFhxVl1mLw==}
+    peerDependencies:
+      '@volar/language-service': ~2.4.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+
+  volar-service-yaml@0.0.71:
+    resolution: {integrity: sha512-qYGWGuVpUTnZGu5P/CR4KLK4aIR8RrcVnmfZ2eRcj9q/I8VZCoC5yy9FtEvfNvnDp4MU17yhdJcvpQPIqhJS2Q==}
+    peerDependencies:
+      '@volar/language-service': ~2.4.0
+    peerDependenciesMeta:
+      '@volar/language-service':
+        optional: true
+
+  vscode-css-languageservice@6.3.10:
+    resolution: {integrity: sha512-eq5N9Er3fC4vA9zd9EFhyBG90wtCCuXgRSpAndaOgXMh1Wgep5lBgRIeDgjZBW9pa+332yC9+49cZMW8jcL3MA==}
+
+  vscode-html-languageservice@5.6.2:
+    resolution: {integrity: sha512-ulCrSnFnfQ16YzvwnYUgEbUEl/ZG7u2eV27YhvLObSHKkb8fw1Z9cgsnUwjTEeDIdJDoTDTDpxuhQwoenoLNMg==}
+
+  vscode-json-languageservice@4.1.8:
+    resolution: {integrity: sha512-0vSpg6Xd9hfV+eZAaYN63xVVMOTmJ4GgHxXnkLCh+9RsQBkWKIghzLhW2B9ebfG+LQQg8uLtsQ2aUKjTgE+QOg==}
+    engines: {npm: '>=7.0.0'}
+
+  vscode-jsonrpc@8.2.0:
+    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
+    engines: {node: '>=14.0.0'}
+
+  vscode-jsonrpc@9.0.1:
+    resolution: {integrity: sha512-rfuA6T75H6m5EkbhtEPzre9pT0HPcDI2MMy4+nPFIBks5J8JBAUHD4tRYSgaBOijIEC7SRkC1kKyXTLqbmh9jw==}
+    engines: {node: '>=14.0.0'}
+
+  vscode-languageserver-protocol@3.17.5:
+    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
+
+  vscode-languageserver-protocol@3.18.2:
+    resolution: {integrity: sha512-XRyDbT0Pp3sSNti3JmxVEUMySWCSi1hhM+/KUlCy1hV1zmrqpM1OwO12EAki8blhmLuIMpaJrYbo0OzGVfK2Qg==}
+
+  vscode-languageserver-textdocument@1.0.12:
+    resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
+
+  vscode-languageserver-types@3.17.5:
+    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
+
+  vscode-languageserver-types@3.18.0:
+    resolution: {integrity: sha512-8TsGPNMIMiiBdkORgRSvLjuiEIiAFtO+KssmYWxQ+uSVvlf7RjK8YKCOjPzZ+YA04jXEV7+7LvkSmHkhpNS99g==}
+
+  vscode-languageserver@9.0.1:
+    resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
+    hasBin: true
+
+  vscode-nls@5.2.0:
+    resolution: {integrity: sha512-RAaHx7B14ZU04EU31pT+rKz2/zSl7xMsfIZuo8pd+KZO6PXtQmpevpq3vxvWNcrGbdmhM/rr5Uw5Mz+NBfhVng==}
+
+  vscode-uri@3.1.0:
+    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
+
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
+
+  xxhash-wasm@1.1.0:
+    resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
+  yaml-language-server@1.23.0:
+    resolution: {integrity: sha512-3qVyCOexLCWw06PQa5kRPwvMWMZ/eZeCRWUvgD6a0OkqL/4iCnxy2WumbWifa937Uo5xhyWJ0uxlU39ljhNh7A==}
+    hasBin: true
+
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yargs-parser@22.0.0:
+    resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yargs@18.1.0:
+    resolution: {integrity: sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yocto-queue@1.2.2:
+    resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
+    engines: {node: '>=12.20'}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
+
+snapshots:
+
+  '@astrojs/check@0.9.10(prettier@3.9.6)(typescript@6.0.3)':
+    dependencies:
+      '@astrojs/language-server': 2.16.14(prettier@3.9.6)(typescript@6.0.3)
+      chokidar: 4.0.3
+      kleur: 4.1.5
+      typescript: 6.0.3
+      yargs: 18.1.0
+    transitivePeerDependencies:
+      - prettier
+      - prettier-plugin-astro
+
+  '@astrojs/compiler-binding-darwin-arm64@0.3.2':
+    optional: true
+
+  '@astrojs/compiler-binding-darwin-x64@0.3.2':
+    optional: true
+
+  '@astrojs/compiler-binding-linux-arm64-gnu@0.3.2':
+    optional: true
+
+  '@astrojs/compiler-binding-linux-arm64-musl@0.3.2':
+    optional: true
+
+  '@astrojs/compiler-binding-linux-x64-gnu@0.3.2':
+    optional: true
+
+  '@astrojs/compiler-binding-linux-x64-musl@0.3.2':
+    optional: true
+
+  '@astrojs/compiler-binding-wasm32-wasi@0.3.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
+  '@astrojs/compiler-binding-win32-arm64-msvc@0.3.2':
+    optional: true
+
+  '@astrojs/compiler-binding-win32-x64-msvc@0.3.2':
+    optional: true
+
+  '@astrojs/compiler-binding@0.3.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)':
+    optionalDependencies:
+      '@astrojs/compiler-binding-darwin-arm64': 0.3.2
+      '@astrojs/compiler-binding-darwin-x64': 0.3.2
+      '@astrojs/compiler-binding-linux-arm64-gnu': 0.3.2
+      '@astrojs/compiler-binding-linux-arm64-musl': 0.3.2
+      '@astrojs/compiler-binding-linux-x64-gnu': 0.3.2
+      '@astrojs/compiler-binding-linux-x64-musl': 0.3.2
+      '@astrojs/compiler-binding-wasm32-wasi': 0.3.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)
+      '@astrojs/compiler-binding-win32-arm64-msvc': 0.3.2
+      '@astrojs/compiler-binding-win32-x64-msvc': 0.3.2
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
+  '@astrojs/compiler-rs@0.3.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)':
+    dependencies:
+      '@astrojs/compiler-binding': 0.3.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
+  '@astrojs/compiler@2.13.1': {}
+
+  '@astrojs/internal-helpers@0.10.4':
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      js-yaml: 4.3.1
+      picomatch: 4.0.5
+      retext-smartypants: 6.2.0
+      shiki: 4.4.3
+      smol-toml: 1.8.0
+      unified: 11.0.5
+
+  '@astrojs/language-server@2.16.14(prettier@3.9.6)(typescript@6.0.3)':
+    dependencies:
+      '@astrojs/compiler': 2.13.1
+      '@astrojs/yaml2ts': 0.2.4
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@volar/kit': 2.4.28(typescript@6.0.3)
+      '@volar/language-core': 2.4.28
+      '@volar/language-server': 2.4.28
+      '@volar/language-service': 2.4.28
+      muggle-string: 0.4.1
+      tinyglobby: 0.2.17
+      volar-service-css: 0.0.71(@volar/language-service@2.4.28)
+      volar-service-emmet: 0.0.71(@volar/language-service@2.4.28)
+      volar-service-html: 0.0.71(@volar/language-service@2.4.28)
+      volar-service-prettier: 0.0.71(@volar/language-service@2.4.28)(prettier@3.9.6)
+      volar-service-typescript: 0.0.71(@volar/language-service@2.4.28)
+      volar-service-typescript-twoslash-queries: 0.0.71(@volar/language-service@2.4.28)
+      volar-service-yaml: 0.0.71(@volar/language-service@2.4.28)
+      vscode-html-languageservice: 5.6.2
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      prettier: 3.9.6
+    transitivePeerDependencies:
+      - typescript
+
+  '@astrojs/markdown-satteri@0.3.7':
+    dependencies:
+      '@astrojs/internal-helpers': 0.10.4
+      '@astrojs/prism': 4.0.2
+      github-slugger: 2.0.0
+      satteri: 0.10.5
+
+  '@astrojs/prism@4.0.2':
+    dependencies:
+      prismjs: 1.30.0
+
+  '@astrojs/telemetry@3.3.3':
+    dependencies:
+      ci-info: 4.4.0
+      dset: 3.1.4
+      is-docker: 4.0.0
+      package-manager-detector: 1.8.0
+
+  '@astrojs/yaml2ts@0.2.4':
+    dependencies:
+      yaml: 2.9.0
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/parser@7.29.8':
+    dependencies:
+      '@babel/types': 7.29.8
+
+  '@babel/types@7.29.8':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@bruits/satteri-darwin-arm64@0.10.5':
+    optional: true
+
+  '@bruits/satteri-darwin-x64@0.10.5':
+    optional: true
+
+  '@bruits/satteri-linux-arm64-gnu@0.10.5':
+    optional: true
+
+  '@bruits/satteri-linux-arm64-musl@0.10.5':
+    optional: true
+
+  '@bruits/satteri-linux-x64-gnu@0.10.5':
+    optional: true
+
+  '@bruits/satteri-linux-x64-musl@0.10.5':
+    optional: true
+
+  '@bruits/satteri-wasm32-wasi@0.10.5':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@napi-rs/wasm-runtime': 1.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+    optional: true
+
+  '@bruits/satteri-win32-arm64-msvc@0.10.5':
+    optional: true
+
+  '@bruits/satteri-win32-x64-msvc@0.10.5':
+    optional: true
+
+  '@capsizecss/unpack@4.0.1':
+    dependencies:
+      fontkitten: 1.0.3
+
+  '@clack/core@1.4.3':
+    dependencies:
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.7.0':
+    dependencies:
+      '@clack/core': 1.4.3
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.2
+      sisteransi: 1.0.5
+
+  '@emmetio/abbreviation@2.3.3':
+    dependencies:
+      '@emmetio/scanner': 1.0.4
+
+  '@emmetio/css-abbreviation@2.1.8':
+    dependencies:
+      '@emmetio/scanner': 1.0.4
+
+  '@emmetio/css-parser@0.4.1':
+    dependencies:
+      '@emmetio/stream-reader': 2.2.0
+      '@emmetio/stream-reader-utils': 0.1.0
+
+  '@emmetio/html-matcher@1.3.0':
+    dependencies:
+      '@emmetio/scanner': 1.0.4
+
+  '@emmetio/scanner@1.0.4': {}
+
+  '@emmetio/stream-reader-utils@0.1.0': {}
+
+  '@emmetio/stream-reader@2.2.0': {}
+
+  '@emnapi/core@1.11.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.2
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.11.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.2':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/android-arm@0.28.2':
+    optional: true
+
+  '@esbuild/android-x64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.2':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.2':
+    optional: true
+
+  '@img/colour@1.1.0':
+    optional: true
+
+  '@img/sharp-darwin-arm64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.3.2
+    optional: true
+
+  '@img/sharp-darwin-x64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.3.2
+    optional: true
+
+  '@img/sharp-freebsd-wasm32@0.35.3':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.3
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-arm@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-s390x@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.3.2
+    optional: true
+
+  '@img/sharp-linux-x64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.3.2
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.35.3':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
+    optional: true
+
+  '@img/sharp-wasm32@0.35.3':
+    dependencies:
+      '@emnapi/runtime': 1.11.3
+    optional: true
+
+  '@img/sharp-webcontainers-wasm32@0.35.3':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.3
+    optional: true
+
+  '@img/sharp-win32-arm64@0.35.3':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.35.3':
+    optional: true
+
+  '@img/sharp-win32-x64@0.35.3':
+    optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.1
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.2.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)':
+    dependencies:
+      '@emnapi/core': 1.11.1
+      '@emnapi/runtime': 1.11.3
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@oslojs/encoding@1.1.0': {}
+
+  '@oxc-project/types@0.146.0': {}
+
+  '@rolldown/binding-android-arm-eabi@1.2.5':
+    optional: true
+
+  '@rolldown/binding-android-arm64@1.2.5':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.2.5':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.2.5':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.2.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.5':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.2.5':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.5':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.2.5':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.2.5':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.2.5':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.5':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.2.5':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
+
+  '@shikijs/core@4.4.3':
+    dependencies:
+      '@shikijs/primitive': 4.4.3
+      '@shikijs/types': 4.4.3
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+      hast-util-to-html: 9.0.5
+
+  '@shikijs/engine-javascript@4.4.3':
+    dependencies:
+      '@shikijs/types': 4.4.3
+      '@shikijs/vscode-textmate': 10.0.2
+      oniguruma-to-es: 4.3.6
+
+  '@shikijs/engine-oniguruma@4.4.3':
+    dependencies:
+      '@shikijs/types': 4.4.3
+      '@shikijs/vscode-textmate': 10.0.2
+
+  '@shikijs/langs@4.4.3':
+    dependencies:
+      '@shikijs/types': 4.4.3
+
+  '@shikijs/primitive@4.4.3':
+    dependencies:
+      '@shikijs/types': 4.4.3
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+
+  '@shikijs/themes@4.4.3':
+    dependencies:
+      '@shikijs/types': 4.4.3
+
+  '@shikijs/types@4.4.3':
+    dependencies:
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+
+  '@shikijs/vscode-textmate@10.0.2': {}
+
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.9
+
+  '@types/estree@1.0.9': {}
+
+  '@types/hast@3.0.5':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/nlcst@2.0.3':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/unist@3.0.3': {}
+
+  '@ungap/structured-clone@1.3.3': {}
+
+  '@volar/kit@2.4.28(typescript@6.0.3)':
+    dependencies:
+      '@volar/language-service': 2.4.28
+      '@volar/typescript': 2.4.28
+      typesafe-path: 0.2.2
+      typescript: 6.0.3
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+
+  '@volar/language-core@2.4.28':
+    dependencies:
+      '@volar/source-map': 2.4.28
+
+  '@volar/language-server@2.4.28':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      '@volar/language-service': 2.4.28
+      '@volar/typescript': 2.4.28
+      path-browserify: 1.0.1
+      request-light: 0.7.0
+      vscode-languageserver: 9.0.1
+      vscode-languageserver-protocol: 3.18.2
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+
+  '@volar/language-service@2.4.28':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      vscode-languageserver-protocol: 3.18.2
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+
+  '@volar/source-map@2.4.28': {}
+
+  '@volar/typescript@2.4.28':
+    dependencies:
+      '@volar/language-core': 2.4.28
+      path-browserify: 1.0.1
+      vscode-uri: 3.1.0
+
+  '@vscode/emmet-helper@2.11.0':
+    dependencies:
+      emmet: 2.4.11
+      jsonc-parser: 2.3.1
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-types: 3.18.0
+      vscode-uri: 3.1.0
+
+  '@vscode/l10n@0.0.18': {}
+
+  ajv-draft-04@1.0.0(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv-i18n@4.2.0(ajv@8.20.0):
+    dependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.5
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  am-i-vibing@0.4.0:
+    dependencies:
+      process-ancestry: 0.1.0
+
+  ansi-regex@6.3.0: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
+
+  anymatch@3.1.3:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.2
+
+  argparse@2.0.1: {}
+
+  aria-query@5.3.2: {}
+
+  astro@7.2.4(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(yaml@2.9.0):
+    dependencies:
+      '@astrojs/compiler-rs': 0.3.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)
+      '@astrojs/internal-helpers': 0.10.4
+      '@astrojs/markdown-satteri': 0.3.7
+      '@astrojs/telemetry': 3.3.3
+      '@capsizecss/unpack': 4.0.1
+      '@clack/prompts': 1.7.0
+      '@oslojs/encoding': 1.1.0
+      am-i-vibing: 0.4.0
+      aria-query: 5.3.2
+      axobject-query: 4.1.0
+      ci-info: 4.4.0
+      clsx: 2.1.1
+      common-ancestor-path: 2.0.0
+      cookie: 2.0.1
+      devalue: 5.9.1
+      diff: 8.0.4
+      dset: 3.1.4
+      es-module-lexer: 2.3.2
+      esbuild: 0.28.2
+      find-process: 2.1.1
+      flattie: 1.1.1
+      fontace: 0.4.1
+      get-tsconfig: 5.0.0-beta.4
+      github-slugger: 2.0.0
+      html-escaper: 3.0.3
+      http-cache-semantics: 4.2.0
+      js-yaml: 4.3.1
+      jsonc-parser: 3.3.1
+      magic-string: 1.2.2
+      magicast: 0.5.4
+      mrmime: 2.0.1
+      neotraverse: 1.0.1
+      obug: 2.1.4
+      p-limit: 7.3.1
+      p-queue: 9.3.3
+      package-manager-detector: 1.8.0
+      piccolore: 0.1.3
+      picomatch: 4.0.5
+      semver: 7.8.5
+      shiki: 4.4.3
+      smol-toml: 1.8.0
+      svgo: 4.0.2
+      tinyclip: 0.1.15
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      ultrahtml: 1.7.0
+      unifont: 0.7.5
+      unstorage: 1.17.5
+      vite: 8.2.2(esbuild@0.28.2)(yaml@2.9.0)
+      vitefu: 1.1.3(vite@8.2.2(esbuild@0.28.2)(yaml@2.9.0))
+      xxhash-wasm: 1.1.0
+      yargs-parser: 22.0.0
+      zod: 4.4.3
+    optionalDependencies:
+      sharp: 0.35.3
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@types/node'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vitejs/devtools'
+      - aws4fetch
+      - db0
+      - idb-keyval
+      - ioredis
+      - jiti
+      - less
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - uploadthing
+      - yaml
+
+  axobject-query@4.1.0: {}
+
+  bail@2.0.2: {}
+
+  boolbase@1.0.0: {}
+
+  ccount@2.0.1: {}
+
+  chalk@4.1.2:
+    dependencies:
+      ansi-styles: 4.3.0
+      supports-color: 7.2.0
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  chokidar@5.0.0:
+    dependencies:
+      readdirp: 5.1.1
+
+  ci-info@4.4.0: {}
+
+  cliui@9.0.1:
+    dependencies:
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
+
+  clsx@2.1.1: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  comma-separated-tokens@2.0.3: {}
+
+  commander@11.1.0: {}
+
+  commander@14.0.3: {}
+
+  common-ancestor-path@2.0.0: {}
+
+  cookie-es@1.2.3: {}
+
+  cookie@2.0.1: {}
+
+  crossws@0.3.5:
+    dependencies:
+      uncrypto: 0.1.3
+
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
+
+  css-tree@2.2.1:
+    dependencies:
+      mdn-data: 2.0.28
+      source-map-js: 1.2.1
+
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  css-what@6.2.2: {}
+
+  csso@5.0.5:
+    dependencies:
+      css-tree: 2.2.1
+
+  defu@6.1.7: {}
+
+  dequal@2.0.3: {}
+
+  destr@2.0.5: {}
+
+  detect-libc@2.1.2: {}
+
+  devalue@5.9.1: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
+
+  diff@8.0.4: {}
+
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
+  dset@3.1.4: {}
+
+  emmet@2.4.11:
+    dependencies:
+      '@emmetio/abbreviation': 2.3.3
+      '@emmetio/css-abbreviation': 2.1.8
+
+  emoji-regex@10.6.0: {}
+
+  entities@4.5.0: {}
+
+  es-module-lexer@2.3.2: {}
+
+  esbuild@0.28.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
+
+  escalade@3.2.0: {}
+
+  eventemitter3@5.0.4: {}
+
+  extend@3.0.2: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
+  fast-uri@3.1.5: {}
+
+  fast-wrap-ansi@0.2.2:
+    dependencies:
+      fast-string-width: 3.0.2
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  find-process@2.1.1:
+    dependencies:
+      chalk: 4.1.2
+      commander: 14.0.3
+      loglevel: 1.9.2
+
+  flattie@1.1.1: {}
+
+  fontace@0.4.1:
+    dependencies:
+      fontkitten: 1.0.3
+
+  fontkitten@1.0.3:
+    dependencies:
+      tiny-inflate: 1.0.3
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-caller-file@2.0.5: {}
+
+  get-east-asian-width@1.6.0: {}
+
+  get-tsconfig@5.0.0-beta.4:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  github-slugger@2.0.0: {}
+
+  gsap@3.15.0: {}
+
+  h3@1.15.11:
+    dependencies:
+      cookie-es: 1.2.3
+      crossws: 0.3.5
+      defu: 6.1.7
+      destr: 2.0.5
+      iron-webcrypto: 1.2.1
+      node-mock-http: 1.0.5
+      radix3: 1.1.2
+      ufo: 1.6.4
+      uncrypto: 0.1.3
+
+  has-flag@4.0.0: {}
+
+  hast-util-to-html@9.0.5:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      comma-separated-tokens: 2.0.3
+      hast-util-whitespace: 3.0.0
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      stringify-entities: 4.0.4
+      zwitch: 2.0.4
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.5
+
+  html-escaper@3.0.3: {}
+
+  html-void-elements@3.0.0: {}
+
+  http-cache-semantics@4.2.0: {}
+
+  iron-webcrypto@1.2.1: {}
+
+  is-docker@4.0.0: {}
+
+  is-plain-obj@4.1.0: {}
+
+  js-yaml@4.3.1:
+    dependencies:
+      argparse: 2.0.1
+
+  json-schema-traverse@1.0.0: {}
+
+  jsonc-parser@2.3.1: {}
+
+  jsonc-parser@3.3.1: {}
+
+  kleur@4.1.5: {}
+
+  lightningcss-android-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.33.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.33.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    optional: true
+
+  lightningcss@1.33.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
+
+  loglevel@1.9.2: {}
+
+  lru-cache@11.5.2: {}
+
+  magic-string@1.2.2:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.5.4:
+    dependencies:
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      source-map-js: 1.2.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.3
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdn-data@2.0.28: {}
+
+  mdn-data@2.27.1: {}
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  mrmime@2.0.1: {}
+
+  muggle-string@0.4.1: {}
+
+  nanoid@3.3.18: {}
+
+  neotraverse@1.0.1: {}
+
+  nlcst-to-string@4.0.0:
+    dependencies:
+      '@types/nlcst': 2.0.3
+
+  node-fetch-native@1.6.7: {}
+
+  node-mock-http@1.0.5: {}
+
+  normalize-path@3.0.0: {}
+
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
+
+  obug@2.1.4: {}
+
+  ofetch@1.5.1:
+    dependencies:
+      destr: 2.0.5
+      node-fetch-native: 1.6.7
+      ufo: 1.6.4
+
+  ohash@2.0.12: {}
+
+  oniguruma-parser@0.12.2: {}
+
+  oniguruma-to-es@4.3.6:
+    dependencies:
+      oniguruma-parser: 0.12.2
+      regex: 6.1.0
+      regex-recursion: 6.0.2
+
+  p-limit@7.3.1:
+    dependencies:
+      yocto-queue: 1.2.2
+
+  p-queue@9.3.3:
+    dependencies:
+      eventemitter3: 5.0.4
+      p-timeout: 7.0.1
+
+  p-timeout@7.0.1: {}
+
+  package-manager-detector@1.8.0: {}
+
+  path-browserify@1.0.1: {}
+
+  piccolore@0.1.3: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@2.3.2: {}
+
+  picomatch@4.0.5: {}
+
+  postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  prettier@3.9.6: {}
+
+  prismjs@1.30.0: {}
+
+  process-ancestry@0.1.0: {}
+
+  property-information@7.2.0: {}
+
+  radix3@1.1.2: {}
+
+  readdirp@4.1.2: {}
+
+  readdirp@5.1.1: {}
+
+  regex-recursion@6.0.2:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  regex-utilities@2.3.0: {}
+
+  regex@6.1.0:
+    dependencies:
+      regex-utilities: 2.3.0
+
+  request-light@0.5.8: {}
+
+  request-light@0.7.0: {}
+
+  require-from-string@2.0.2: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  retext-smartypants@6.2.0:
+    dependencies:
+      '@types/nlcst': 2.0.3
+      nlcst-to-string: 4.0.0
+      unist-util-visit: 5.1.0
+
+  rolldown@1.2.5:
+    dependencies:
+      '@oxc-project/types': 0.146.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm-eabi': 1.2.5
+      '@rolldown/binding-android-arm64': 1.2.5
+      '@rolldown/binding-darwin-arm64': 1.2.5
+      '@rolldown/binding-darwin-x64': 1.2.5
+      '@rolldown/binding-freebsd-x64': 1.2.5
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.5
+      '@rolldown/binding-linux-arm64-gnu': 1.2.5
+      '@rolldown/binding-linux-arm64-musl': 1.2.5
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.5
+      '@rolldown/binding-linux-s390x-gnu': 1.2.5
+      '@rolldown/binding-linux-x64-gnu': 1.2.5
+      '@rolldown/binding-linux-x64-musl': 1.2.5
+      '@rolldown/binding-openharmony-arm64': 1.2.5
+      '@rolldown/binding-win32-arm64-msvc': 1.2.5
+      '@rolldown/binding-win32-x64-msvc': 1.2.5
+
+  satteri@0.10.5:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+    optionalDependencies:
+      '@bruits/satteri-darwin-arm64': 0.10.5
+      '@bruits/satteri-darwin-x64': 0.10.5
+      '@bruits/satteri-linux-arm64-gnu': 0.10.5
+      '@bruits/satteri-linux-arm64-musl': 0.10.5
+      '@bruits/satteri-linux-x64-gnu': 0.10.5
+      '@bruits/satteri-linux-x64-musl': 0.10.5
+      '@bruits/satteri-wasm32-wasi': 0.10.5
+      '@bruits/satteri-win32-arm64-msvc': 0.10.5
+      '@bruits/satteri-win32-x64-msvc': 0.10.5
+
+  sax@1.6.1: {}
+
+  semver@7.8.5: {}
+
+  sharp@0.35.3:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.35.3
+      '@img/sharp-darwin-x64': 0.35.3
+      '@img/sharp-freebsd-wasm32': 0.35.3
+      '@img/sharp-libvips-darwin-arm64': 1.3.2
+      '@img/sharp-libvips-darwin-x64': 1.3.2
+      '@img/sharp-libvips-linux-arm': 1.3.2
+      '@img/sharp-libvips-linux-arm64': 1.3.2
+      '@img/sharp-libvips-linux-ppc64': 1.3.2
+      '@img/sharp-libvips-linux-riscv64': 1.3.2
+      '@img/sharp-libvips-linux-s390x': 1.3.2
+      '@img/sharp-libvips-linux-x64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
+      '@img/sharp-linux-arm': 0.35.3
+      '@img/sharp-linux-arm64': 0.35.3
+      '@img/sharp-linux-ppc64': 0.35.3
+      '@img/sharp-linux-riscv64': 0.35.3
+      '@img/sharp-linux-s390x': 0.35.3
+      '@img/sharp-linux-x64': 0.35.3
+      '@img/sharp-linuxmusl-arm64': 0.35.3
+      '@img/sharp-linuxmusl-x64': 0.35.3
+      '@img/sharp-webcontainers-wasm32': 0.35.3
+      '@img/sharp-win32-arm64': 0.35.3
+      '@img/sharp-win32-ia32': 0.35.3
+      '@img/sharp-win32-x64': 0.35.3
+    optional: true
+
+  shiki@4.4.3:
+    dependencies:
+      '@shikijs/core': 4.4.3
+      '@shikijs/engine-javascript': 4.4.3
+      '@shikijs/engine-oniguruma': 4.4.3
+      '@shikijs/langs': 4.4.3
+      '@shikijs/themes': 4.4.3
+      '@shikijs/types': 4.4.3
+      '@shikijs/vscode-textmate': 10.0.2
+      '@types/hast': 3.0.5
+
+  sisteransi@1.0.5: {}
+
+  smol-toml@1.8.0: {}
+
+  source-map-js@1.2.1: {}
+
+  space-separated-tokens@2.0.2: {}
+
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
+  string-width@8.2.2:
+    dependencies:
+      get-east-asian-width: 1.6.0
+      strip-ansi: 7.2.0
+
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.3.0
+
+  supports-color@7.2.0:
+    dependencies:
+      has-flag: 4.0.0
+
+  svgo@4.0.2:
+    dependencies:
+      commander: 11.1.0
+      css-select: 5.2.2
+      css-tree: 3.2.1
+      css-what: 6.2.2
+      csso: 5.0.5
+      picocolors: 1.1.1
+      sax: 1.6.1
+
+  tiny-inflate@1.0.3: {}
+
+  tinyclip@0.1.15: {}
+
+  tinyexec@1.3.0: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
+
+  tslib@2.8.1:
+    optional: true
+
+  typesafe-path@0.2.2: {}
+
+  typescript-auto-import-cache@0.3.6:
+    dependencies:
+      semver: 7.8.5
+
+  typescript@6.0.3: {}
+
+  ufo@1.6.4: {}
+
+  ultrahtml@1.7.0: {}
+
+  uncrypto@0.1.3: {}
+
+  undici@8.10.0: {}
+
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unifont@0.7.5:
+    dependencies:
+      css-tree: 3.2.1
+      ohash: 2.0.12
+      undici: 8.10.0
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  unstorage@1.17.5:
+    dependencies:
+      anymatch: 3.1.3
+      chokidar: 5.0.0
+      destr: 2.0.5
+      h3: 1.15.11
+      lru-cache: 11.5.2
+      node-fetch-native: 1.6.7
+      ofetch: 1.5.1
+      ufo: 1.6.4
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
+
+  vite@8.2.2(esbuild@0.28.2)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rolldown: 1.2.5
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      esbuild: 0.28.2
+      fsevents: 2.3.3
+      yaml: 2.9.0
+
+  vitefu@1.1.3(vite@8.2.2(esbuild@0.28.2)(yaml@2.9.0)):
+    optionalDependencies:
+      vite: 8.2.2(esbuild@0.28.2)(yaml@2.9.0)
+
+  volar-service-css@0.0.71(@volar/language-service@2.4.28):
+    dependencies:
+      vscode-css-languageservice: 6.3.10
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      '@volar/language-service': 2.4.28
+
+  volar-service-emmet@0.0.71(@volar/language-service@2.4.28):
+    dependencies:
+      '@emmetio/css-parser': 0.4.1
+      '@emmetio/html-matcher': 1.3.0
+      '@vscode/emmet-helper': 2.11.0
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      '@volar/language-service': 2.4.28
+
+  volar-service-html@0.0.71(@volar/language-service@2.4.28):
+    dependencies:
+      vscode-html-languageservice: 5.6.2
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      '@volar/language-service': 2.4.28
+
+  volar-service-prettier@0.0.71(@volar/language-service@2.4.28)(prettier@3.9.6):
+    dependencies:
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      '@volar/language-service': 2.4.28
+      prettier: 3.9.6
+
+  volar-service-typescript-twoslash-queries@0.0.71(@volar/language-service@2.4.28):
+    dependencies:
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      '@volar/language-service': 2.4.28
+
+  volar-service-typescript@0.0.71(@volar/language-service@2.4.28):
+    dependencies:
+      path-browserify: 1.0.1
+      semver: 7.8.5
+      typescript-auto-import-cache: 0.3.6
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-nls: 5.2.0
+      vscode-uri: 3.1.0
+    optionalDependencies:
+      '@volar/language-service': 2.4.28
+
+  volar-service-yaml@0.0.71(@volar/language-service@2.4.28):
+    dependencies:
+      vscode-uri: 3.1.0
+      yaml-language-server: 1.23.0
+    optionalDependencies:
+      '@volar/language-service': 2.4.28
+
+  vscode-css-languageservice@6.3.10:
+    dependencies:
+      '@vscode/l10n': 0.0.18
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-types: 3.17.5
+      vscode-uri: 3.1.0
+
+  vscode-html-languageservice@5.6.2:
+    dependencies:
+      '@vscode/l10n': 0.0.18
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-types: 3.18.0
+      vscode-uri: 3.1.0
+
+  vscode-json-languageservice@4.1.8:
+    dependencies:
+      jsonc-parser: 3.3.1
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-types: 3.18.0
+      vscode-nls: 5.2.0
+      vscode-uri: 3.1.0
+
+  vscode-jsonrpc@8.2.0: {}
+
+  vscode-jsonrpc@9.0.1: {}
+
+  vscode-languageserver-protocol@3.17.5:
+    dependencies:
+      vscode-jsonrpc: 8.2.0
+      vscode-languageserver-types: 3.17.5
+
+  vscode-languageserver-protocol@3.18.2:
+    dependencies:
+      vscode-jsonrpc: 9.0.1
+      vscode-languageserver-types: 3.18.0
+
+  vscode-languageserver-textdocument@1.0.12: {}
+
+  vscode-languageserver-types@3.17.5: {}
+
+  vscode-languageserver-types@3.18.0: {}
+
+  vscode-languageserver@9.0.1:
+    dependencies:
+      vscode-languageserver-protocol: 3.17.5
+
+  vscode-nls@5.2.0: {}
+
+  vscode-uri@3.1.0: {}
+
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
+
+  xxhash-wasm@1.1.0: {}
+
+  y18n@5.0.8: {}
+
+  yaml-language-server@1.23.0:
+    dependencies:
+      '@vscode/l10n': 0.0.18
+      ajv: 8.20.0
+      ajv-draft-04: 1.0.0(ajv@8.20.0)
+      ajv-i18n: 4.2.0(ajv@8.20.0)
+      prettier: 3.9.6
+      request-light: 0.5.8
+      vscode-json-languageservice: 4.1.8
+      vscode-languageserver: 9.0.1
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-languageserver-types: 3.18.0
+      vscode-uri: 3.1.0
+      yaml: 2.8.3
+
+  yaml@2.8.3: {}
+
+  yaml@2.9.0: {}
+
+  yargs-parser@22.0.0: {}
+
+  yargs@18.1.0:
+    dependencies:
+      cliui: 9.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      string-width: 8.2.2
+      y18n: 5.0.8
+      yargs-parser: 22.0.0
+
+  yocto-queue@1.2.2: {}
+
+  zod@4.4.3: {}
+
+  zwitch@2.0.4: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,14 @@
+# pnpm's own settings live here rather than in .npmrc: pnpm 11 reads its
+# configuration from this file, and a `save-exact=true` written into .npmrc is
+# silently ignored — which is worth saying out loud, because the failure mode is
+# a caret quietly reappearing in package.json.
+#
+# saveExact is ADR 0002's rule made mechanical: `pnpm add x` writes `1.2.3`, not
+# `^1.2.3`, so an install two years from now resolves to the same bytes.
+saveExact: true
+
+# esbuild ships a platform binary it fetches in a postinstall script. pnpm blocks
+# build scripts by default and asks; naming it here answers once. Nothing else in
+# the tree is allowed to run one.
+onlyBuiltDependencies:
+  - esbuild

--- a/scripts/assemble-dist.mjs
+++ b/scripts/assemble-dist.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+/**
+ * Lay the site that already exists down beside what Astro just built.
+ *
+ * The deployment serves one directory, and this repository is two things: a
+ * plain static tree that is the live site, and an Astro build that is `/next`.
+ * Astro writes dist/ and empties it first, so this runs after it and copies the
+ * static tree in.
+ *
+ * A collision is a failure and not a merge. That is the guard that `/next`
+ * cannot quietly land on top of a path `/portfolio` already answers on — and it
+ * is the whole reason this ticket's route is `/next` and not `/portfolio`.
+ */
+
+import { cp, readdir, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { STATIC_ROOTS } from './static-tree.mjs';
+
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+const dist = join(repoRoot, 'dist');
+
+async function present(path) {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+if (!(await present(dist))) {
+  console.error('assemble-dist: dist/ does not exist — run `astro build` first.');
+  process.exit(1);
+}
+
+const built = new Set(await readdir(dist));
+let copied = 0;
+
+for (const root of STATIC_ROOTS) {
+  const from = join(repoRoot, root);
+  if (!(await present(from))) {
+    console.error(`assemble-dist: ${root} is missing from the repository.`);
+    process.exit(1);
+  }
+  if (built.has(root)) {
+    console.error(
+      `assemble-dist: the build wrote dist/${root}, which the existing site also owns.\n` +
+        '  Nothing has been copied. Rename the route, or land the ticket that replaces that path.',
+    );
+    process.exit(1);
+  }
+  await cp(from, join(dist, root), { recursive: true });
+  copied += 1;
+}
+
+console.log(`assemble-dist: ${copied} static path(s) laid down beside ${built.size} built one(s).`);

--- a/scripts/check-source.mjs
+++ b/scripts/check-source.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+/**
+ * The two boundaries the build enforces, checked before Astro is asked to
+ * compile anything.
+ *
+ * ADR 0006: an invariant stops being a comment and becomes a Check, and a Check
+ * blocks rather than reports. Both groups below are things a legitimate change
+ * cannot trip, which is the price of being allowed to block.
+ *
+ *   pnpm check:sections     — run it on its own
+ *   pnpm build              — runs it first, and stops on a failure
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = fileURLToPath(new URL('..', import.meta.url));
+const sectionsDir = join(repoRoot, 'src', 'sections');
+const kernelDir = join(repoRoot, 'src', 'kernel');
+
+/** @type {string[]} */
+const failures = [];
+
+function fail(file, message) {
+  failures.push(`${relative(repoRoot, file).replace(/\\/g, '/')}: ${message}`);
+}
+
+function exists(path) {
+  try {
+    statSync(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function filesUnder(dir) {
+  /** @type {string[]} */
+  const found = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) found.push(...filesUnder(path));
+    else found.push(path);
+  }
+  return found;
+}
+
+/** Comments carry examples of the things being banned, so they come out first. */
+function withoutComments(source) {
+  return source.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/^\s*\/\/.*$/gm, ' ');
+}
+
+// ---------------------------------------------------------------------------
+// A Section is a folder, and the folder shape is the same every time.
+// ---------------------------------------------------------------------------
+
+const REQUIRED = ['content.ts', 'tokens.css', 'timeline.ts', 'variants.css', 'NOTES.md', 'assets'];
+
+/** Source only. NOTES.md is prose ABOUT these rules and quotes the things being
+ *  banned, so scanning it would fail the build for saying `is:global` out loud. */
+const SOURCE = /\.(astro|ts|css)$/;
+
+/** A Section may read its own folder and the Kernel. Nothing else. */
+const ALLOWED_IMPORT = /^(?:\.\/|gsap(?:\/|$)|astro(?:\/|$)|\.\.\/\.\.\/kernel\/)/;
+
+/** `is:global` and `:global(` are the escape hatches out of Astro's scoping. */
+const SCOPE_ESCAPES = [
+  [/\bis:global\b/, 'is:global — a Section may not write a global rule'],
+  [/:global\s*\(/, ':global() — a Section may not write a global rule'],
+  [/<style[^>]*\bis:inline\b/, '<style is:inline> — an inline style block is not scoped'],
+];
+
+const sections = exists(sectionsDir)
+  ? readdirSync(sectionsDir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+  : [];
+
+if (sections.length === 0) failures.push('src/sections: no Sections found');
+
+for (const section of sections) {
+  const dir = join(sectionsDir, section);
+
+  for (const required of REQUIRED) {
+    if (!exists(join(dir, required))) fail(join(dir, required), 'missing — every Section holds one');
+  }
+  const component = readdirSync(dir).filter((name) => name.endsWith('.astro'));
+  if (component.length !== 1) {
+    fail(dir, `expected exactly one .astro component, found ${component.length}`);
+  }
+
+  for (const file of filesUnder(dir).filter((path) => SOURCE.test(path))) {
+    const source = readFileSync(file, 'utf8');
+    const code = withoutComments(source);
+
+    for (const [pattern, why] of SCOPE_ESCAPES) {
+      if (pattern.test(code)) fail(file, why);
+    }
+
+    // Reaching another Section, whether by relative path or by alias.
+    for (const [, specifier] of code.matchAll(/\bfrom\s+['"]([^'"]+)['"]/g)) {
+      if (!ALLOWED_IMPORT.test(specifier)) {
+        fail(file, `imports "${specifier}" — a Section may read its own folder and src/kernel/ only`);
+      }
+    }
+    for (const [, specifier] of code.matchAll(/\bimport\s+['"]([^'"]+)['"]/g)) {
+      if (!ALLOWED_IMPORT.test(specifier)) {
+        fail(file, `imports "${specifier}" — a Section may read its own folder and src/kernel/ only`);
+      }
+    }
+  }
+
+  // tokens.css and variants.css are not scoped by the compiler — Astro never
+  // looks inside a plain stylesheet — so what they may contain is what makes
+  // them safe, and it is checked rather than trusted. Custom properties only,
+  // every one prefixed with the Section's name, on a selector ending in the
+  // Section's own root class.
+  for (const name of ['tokens.css', 'variants.css']) {
+    const file = join(dir, name);
+    if (!exists(file)) continue;
+    const css = withoutComments(readFileSync(file, 'utf8'));
+
+    for (const [, selector, body] of css.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+      const trimmed = selector.trim().replace(/\s+/g, ' ');
+      for (const one of trimmed.split(',')) {
+        if (!new RegExp(`\\.${section}$`).test(one.trim())) {
+          fail(file, `selector "${one.trim()}" does not end in .${section}`);
+        }
+      }
+      for (const declaration of body.split(';')) {
+        const property = declaration.split(':')[0]?.trim();
+        if (!property) continue;
+        if (!property.startsWith(`--${section}-`)) {
+          fail(file, `"${property}" is not a Token — expected a custom property named --${section}-…`);
+        }
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The Kernel's one invariant that a comment cannot hold.
+// ---------------------------------------------------------------------------
+
+// A z-index, `isolation` or a mask on .fx makes it an isolated group, and an
+// isolated group hands every blending layer a transparent backdrop instead of
+// the page. The stack then stops blending and starts painting, which looks
+// exactly like the strengths being too high — so the failure is a day of tuning
+// the wrong numbers rather than a broken page. effect-stack.css says the rest.
+const effectStack = join(kernelDir, 'effect-stack', 'effect-stack.css');
+if (exists(effectStack)) {
+  const css = withoutComments(readFileSync(effectStack, 'utf8'));
+  const container = /(^|\})\s*\.fx\s*\{([^}]*)\}/.exec(css);
+  if (!container) fail(effectStack, 'no .fx container rule found');
+  else {
+    for (const banned of ['z-index', 'isolation', 'mask', 'mask-image', 'filter', 'opacity']) {
+      if (new RegExp(`(^|;)\\s*${banned}\\s*:`).test(container[2])) {
+        fail(effectStack, `.fx declares ${banned} — that isolates the stack and stops it blending`);
+      }
+    }
+  }
+}
+
+if (failures.length > 0) {
+  console.error('check-source: the source boundaries are broken.\n');
+  for (const failure of failures) console.error(`  ${failure}`);
+  console.error(`\n${failures.length} failure${failures.length === 1 ? '' : 's'}.`);
+  process.exit(1);
+}
+
+console.log(`check-source: ${sections.length} Section(s) and the Kernel pass.`);

--- a/scripts/serve-dist.mjs
+++ b/scripts/serve-dist.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**
+ * Serve the assembled dist/ OF THE TREE THIS IS RUN FROM.
+ *
+ * That last part is the reason this exists rather than any off-the-shelf static
+ * server: the in-app browser preview serves the main checkout, so in a worktree
+ * it reports on `development` while appearing to report on the branch. Every
+ * check in design/tools/ serves its own tree for the same reason.
+ *
+ * `cleanUrls`, as the deployment does, so a path that works here works there.
+ *
+ *   pnpm preview            — port 4321
+ *   pnpm preview -- 4400    — or wherever
+ */
+
+import { createReadStream, statSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { fileURLToPath } from 'node:url';
+import { contentType, resolveFile } from './static-tree.mjs';
+
+const dist = fileURLToPath(new URL('../dist', import.meta.url));
+const port = Number(process.argv[2] ?? process.env.PORT ?? 4321);
+
+try {
+  statSync(dist);
+} catch {
+  console.error('serve-dist: dist/ does not exist — run `pnpm build` first.');
+  process.exit(1);
+}
+
+createServer((request, response) => {
+  const file = resolveFile(dist, request.url ?? '/', { statSync });
+  if (!file) {
+    response.statusCode = 404;
+    response.end('not found\n');
+    return;
+  }
+  response.setHeader('content-type', contentType(file));
+  // A read that fails after the stat — the file removed by a rebuild mid-request
+  // — would otherwise take the whole server down on an unhandled 'error'.
+  createReadStream(file)
+    .on('error', () => response.destroy())
+    .pipe(response);
+}).listen(port, () => {
+  console.log(`serve-dist: ${dist}\nserve-dist: http://localhost:${port}/next`);
+});

--- a/scripts/static-tree.mjs
+++ b/scripts/static-tree.mjs
@@ -1,0 +1,92 @@
+// The part of the repository that is already a served site, named once.
+//
+// `/next` is built by Astro into dist/; everything the site serves today is
+// plain files at the repository root and is not built by anything. Two things
+// need to agree about which those are — the dev server, which serves them
+// alongside /next, and the assemble step, which copies them into dist/ after a
+// build — so the list lives here rather than in both.
+//
+// Deliberately a whitelist of the four served paths and not "everything that is
+// not source". README.md, CONTEXT.md, docs/ and run.bat are uploaded to the
+// deployment today and nothing links them.
+
+export const STATIC_ROOTS = ['index.html', 'portfolio', 'projects', 'fonts'];
+
+const MIME = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.mjs': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.webp': 'image/webp',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.png': 'image/png',
+  '.ico': 'image/x-icon',
+  '.woff2': 'font/woff2',
+  '.mp4': 'video/mp4',
+  '.webm': 'video/webm',
+  '.txt': 'text/plain; charset=utf-8',
+  '.md': 'text/markdown; charset=utf-8',
+};
+
+export function contentType(file) {
+  const dot = file.lastIndexOf('.');
+  return (dot === -1 ? null : MIME[file.slice(dot).toLowerCase()]) ?? 'application/octet-stream';
+}
+
+/**
+ * The file a request resolves to under `baseDir`, or null.
+ *
+ * Follows vercel.json's `cleanUrls: true` so a path served locally is the path
+ * served in production: a directory resolves to its index.html, and an
+ * extensionless path that is not a directory gets `.html` tried.
+ *
+ * @param {string} baseDir
+ * @param {string} pathname  request path, still URL-encoded
+ * @param {{ statSync: (p: string) => { isDirectory(): boolean, isFile(): boolean } }} fs
+ * @returns {string | null}
+ */
+export function resolveFile(baseDir, pathname, fs) {
+  let decoded;
+  try {
+    decoded = decodeURIComponent(pathname.split('?')[0].split('#')[0]);
+  } catch {
+    return null;
+  }
+  // Path traversal. Both separators, because this runs on Windows and a request
+  // for `/%5C..%5C..%5C.env` decodes to backslashes that only Node's own path
+  // handling would treat as separators — splitting on '/' alone lets it through
+  // and the join below then climbs out of baseDir.
+  const rel = decoded.replace(/^[/\\]+/, '');
+  if (rel.split(/[/\\]/).includes('..')) return null;
+  // Windows drive letters and UNC paths, for the same reason: `C:/…` joined onto
+  // baseDir is still an absolute path to Node.
+  if (/^[a-z]:/i.test(rel)) return null;
+
+  const candidates = [];
+  const base = rel === '' ? 'index.html' : rel;
+  candidates.push(base);
+  candidates.push(`${base}/index.html`.replace(/\/+/g, '/'));
+  if (!/\.[a-z0-9]+$/i.test(base)) candidates.push(`${base}.html`);
+
+  for (const candidate of candidates) {
+    const full = `${baseDir}/${candidate}`;
+    let stat;
+    try {
+      stat = fs.statSync(full);
+    } catch {
+      continue;
+    }
+    if (stat.isFile()) return full;
+  }
+  return null;
+}
+
+/** True when `pathname` is one of the paths STATIC_ROOTS owns. */
+export function isStaticPath(pathname) {
+  const first = pathname.replace(/^\/+/, '').split('/')[0];
+  if (first === '') return true; // the portal at /
+  return STATIC_ROOTS.includes(first);
+}

--- a/src/kernel/Kernel.astro
+++ b/src/kernel/Kernel.astro
@@ -1,0 +1,26 @@
+---
+// The Kernel: faces, the theme and the Turn, the Effect Stack, the corner
+// pictures and the Section loader. The only thing permitted to cross a Section
+// boundary, and the only place in the tree allowed to write a global selector.
+//
+// This is every part of it that has to stand BEFORE the Sections — the
+// stylesheets, the corner pictures that run in behind the opening composition,
+// and the client boot. The Effect Stack is the one part the Shell places itself,
+// at the foot of the body, because the layers have to paint over the Sections and
+// the one thing that would let them do it from up here is a z-index, which
+// breaks their blending outright. See effect-stack.css.
+import './faces.css';
+import './ground.css';
+import './corners.css';
+---
+
+{/* The corner pictures. Empty, decorative, and sized entirely in CSS. */}
+<div class="kernel-corners" aria-hidden="true">
+  <div class="plate"></div>
+  <div class="car"></div>
+  <div class="eye"></div>
+</div>
+
+<script>
+  import './kernel';
+</script>

--- a/src/kernel/NOTES.md
+++ b/src/kernel/NOTES.md
@@ -1,0 +1,113 @@
+# The Kernel
+
+The small set of things every Section may rely on, and the only thing permitted
+to cross a Section boundary: the faces, the theme and the Turn, the Effect Stack,
+the corner pictures, and the Section loader.
+
+It is also the only place in `src/` allowed to write a global selector. A Section
+that wants something global wants it in here, and adding it is a decision rather
+than a convenience.
+
+## What is in it, and what each file owns
+
+| file                        | owns                                                        |
+| --------------------------- | ----------------------------------------------------------- |
+| `faces.css`                 | the five families, six files, and the face Tokens            |
+| `ground.css`                | the theme's two papers, and the Turn across them             |
+| `corners.css` / `corners.ts`| the plate, the car and the eye — geometry, and which rung    |
+| `effect-stack/`             | the nine layers, and the grain tile                          |
+| `theme.ts`                  | which paper, where it is stored, and who is told when it changes |
+| `turn.ts`                   | the Turn, as one named seekable Timeline                     |
+| `loader.ts`                 | mounting a Section as it approaches the viewport             |
+| `motion.ts`                 | `hold()` / `release()` — see below                            |
+| `handles.ts`                | `window.portfolio`, and nothing else a Check may reach for   |
+| `content.ts`                | `defineContent` — how a Section's Content gets typed         |
+| `Kernel.astro`              | the part of the Kernel that stands before the Sections       |
+
+## Two things a Check has to know
+
+**Ask a Timeline for a moment, but `hold()` first.** A scrubbed Timeline is
+recomputed from the scroll position on the next tick, so a bare `seek()` survives
+about one frame and a Check that reads geometry after it is a coin toss. This cost
+a wrong diagnosis once already — the readings came back identical at every
+progress and looked like a broken Timeline. `window.portfolio.hold()`, seek as
+many moments as you like, `release()`.
+
+**One mount point per Section.** The loader registers a Section's Timeline under
+the Section's own name, so a second element carrying the same `data-section`
+replaces the first one's Timeline in the register — silently, and the symptom
+turns up later as a Timeline that will not seek. A Check that wants a mount point
+of its own should give it a name of its own; `observeSection` is exposed for
+exactly that.
+
+## The Effect Stack's one invariant
+
+`.fx` must not declare `z-index`, `isolation`, `mask` or anything else that makes
+it a stacking context. An isolated group hands every blending child a transparent
+backdrop instead of the page, so the layers stop blending and start painting — and
+the symptom is a flat grey wash that reads as "the strengths are too high", which
+is a day spent tuning the wrong numbers. `scripts/check-source.mjs` fails the
+build on it; `effect-stack.css` carries the measurement.
+
+Nine layers, and the names are CONTEXT.md's. That is one divergence from
+`portfolio/styles.css`, deliberately: the sheet gates the grille, the scan, the
+roll and the tube on one token called `crt`, and here each is named separately
+because the glossary lists four layers rather than one. Turning all four on is
+`data-fx="… grille scan roll tube"`.
+
+The grain tile is drawn once, at boot, and only if `grain` is on the stack at that
+moment. Switching the layer on later — which is what the Editor will do — leaves
+it with no tile, so whichever ticket builds that surface has to re-draw as well as
+re-write the attribute.
+
+Four effects that sheet has are **not** ported: `weave`, `chroma`,
+`chroma-pictures` and `ascii`. None is in CONTEXT.md's list, two of them are
+theme-specific in a way the attribute cannot express, and `ascii` needs a canvas
+redraw loop. They come back with whichever Section wants them, or not at all.
+
+## The corner pictures
+
+Three baked photographs, each at four widths and — where the grade needed a
+second answer on black — again per theme. So `corners.ts` picks one file out of a
+grid rather than off a list, and picks again when the theme or the display changes
+under it. A miss on a dark file is the ordinary untuned state and not an error:
+the generator writes no dark ladder while dark's grade matches light's, so there
+is one retry against the light rung of the same width.
+
+A picture whose whole ladder is missing is retried on every resize and every
+theme flip, because `shown` never advances past 0 and `upgrade()` only compares
+against that. Cheap, and the honest alternative — remembering the failure — would
+also remember a network blip. Worth knowing before reading a resize storm in a
+network panel as a bug.
+
+**`LADDER_BASE` is the one line in `src/` pointing at the old tree.** The files
+are still the ones `design/plate/build-plate.py` writes into `portfolio/img/`,
+because `/next` is not replacing `/portfolio` yet. The ticket that flips the route
+moves the bytes and changes that constant; nothing else knows where they live.
+
+Two things the live page does that are **not** here yet, both because they belong
+to the Front Screen's composition rather than to the Kernel: the `plate-wait`
+hold, which keeps the type off screen for up to 1.5s while the picture it is
+printed on arrives, and `--car-fade`, the one-sided dissolve on the car's inner
+edge. `--car-fade` is 0 on the live page today, so nothing is missing from what
+ships; the mask is not written at all rather than written and inert.
+
+`--eye-x` diverges: on the live page it is measured inboard from the Front
+Screen's photo strip, which does not exist on `/next`, so here it is measured out
+from the right edge and parked at 0. It is re-tuned when the Front Screen lands.
+
+## The build fingerprints anything it can see
+
+The fonts and the two Effect Stack textures are referenced from CSS `url()`, so
+Vite emits them into `/_astro/` under a content hash and rewrites the references.
+That is why there is no `?v=` digest here where `portfolio/styles.css` has one —
+the hash does that job by construction, and `vercel.json` caches `/_astro/`
+immutably.
+
+The cost is that those bytes ship twice while both trees are deployed, about
+1.1 MB. It ends when `/next` replaces `/portfolio`.
+
+The corner pictures are **not** fingerprinted, because their URLs are built in
+script rather than written in CSS and the bundler cannot see them. They keep the
+`?v=` digest and the day-long cache, which is why `LADDER_VERSION` has to be
+bumped in the same commit as a re-bake.

--- a/src/kernel/content.ts
+++ b/src/kernel/content.ts
@@ -1,0 +1,35 @@
+import { z } from 'astro/zod';
+
+export { z };
+
+/**
+ * A Section's Content, typed by its own schema.
+ *
+ * ADR 0002 buys a build step for two mechanisms, and this is the second of them:
+ * renaming a field has to be an error before the page is served rather than a
+ * blank space discovered later. That needs both halves.
+ *
+ * TypeScript catches the rename at three seams — schema against data, data
+ * against schema, and component against either — because `data` is typed as the
+ * schema's own input. The parse catches what a type cannot: a value that is the
+ * right shape and the wrong thing, and any drift in a file TypeScript was not
+ * asked about. `/next` is prerendered, so the parse runs at BUILD time; a Section
+ * whose Content does not satisfy its schema fails `pnpm build` rather than
+ * shipping.
+ *
+ * zod comes from `astro/zod`, which Astro already ships for content collections,
+ * so this costs no dependency of its own.
+ */
+export function defineContent<Schema extends z.ZodTypeAny>(
+  schema: Schema,
+  data: z.input<Schema>,
+): z.output<Schema> {
+  const parsed = schema.safeParse(data);
+  if (!parsed.success) {
+    const where = parsed.error.issues
+      .map((issue) => `  ${issue.path.join('.') || '(root)'}: ${issue.message}`)
+      .join('\n');
+    throw new Error(`Content does not satisfy its schema:\n${where}`);
+  }
+  return parsed.data;
+}

--- a/src/kernel/corners.css
+++ b/src/kernel/corners.css
@@ -1,0 +1,94 @@
+/* The corner pictures: the plate bottom-left, the car top-right, the eye
+   bottom-right. Three baked photographs run in behind the opening composition,
+   scaled to --fold so they grow together, and graded in the file rather than by
+   a filter here.
+
+   Every number below was tuned by eye on a 1920x1080 frame; src/kernel/NOTES.md
+   says what each one is measured from and which of them the ladder in corners.ts
+   has to agree with. --*-src is set by corners.ts, once it knows how many real
+   pixels this display will draw each picture in. `none` until then, so a dead
+   network leaves the page up rather than blank. */
+
+:root {
+  --plate-opacity: 0.12;
+  --plate-fill: 0.863;
+  --plate-y: 0px;
+  --plate-band: calc(var(--fold) - var(--plate-y));
+  --plate-w: min(calc(var(--plate-fill) * var(--plate-band)), 2400px);
+  --plate-x: 0px;
+  --plate-crop: 0.15;
+  --plate-src: none;
+
+  --car-opacity: 0.135;
+  --car-fill: 0.497;
+  --car-w: min(calc(var(--car-fill) * var(--fold)), 2400px);
+  --car-x: -60px;
+  --car-y: -78px;
+  --car-crop: 0;
+  --car-src: none;
+
+  --eye-opacity: 0.131;
+  --eye-fill: 0.582;
+  --eye-w: min(calc(var(--eye-fill) * var(--fold)), 2400px);
+  --eye-x: 0px;
+  --eye-y: 0px;
+  --eye-crop: 0;
+  --eye-src: none;
+}
+
+:root[data-theme='dark'] {
+  --plate-opacity: 0.17;
+  --car-opacity: 0.17;
+  --eye-opacity: 0.17;
+}
+
+/* One band, the height of the first screen, at the top of the document. No
+   positioned ancestor on purpose: absolute against the initial containing block
+   puts this at the document origin rather than at the Shell's. */
+.kernel-corners {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: var(--fold);
+  z-index: -1;
+  pointer-events: none;
+  contain: paint;
+}
+
+.kernel-corners > * {
+  position: absolute;
+  left: 0;
+  right: 0;
+  background-repeat: no-repeat;
+}
+
+/* Width from the token, height auto from the file's own aspect — so the aspect
+   ratio lives in the file and the picture is never squeezed into a band it is
+   the wrong shape for. It overflows and the box does the cutting. */
+.kernel-corners .plate {
+  top: 0;
+  height: var(--plate-band);
+  background-image: var(--plate-src);
+  background-position: left var(--plate-x) bottom calc(-1 * var(--plate-crop) * var(--plate-w));
+  background-size: var(--plate-w) auto;
+  opacity: var(--plate-opacity);
+}
+
+.kernel-corners .car {
+  top: 0;
+  height: var(--fold);
+  background-image: var(--car-src);
+  background-position: right var(--car-x) top calc(var(--car-y) - var(--car-crop) * var(--car-w));
+  background-size: var(--car-w) auto;
+  opacity: var(--car-opacity);
+}
+
+.kernel-corners .eye {
+  top: 0;
+  height: calc(var(--fold) - var(--eye-y));
+  background-image: var(--eye-src);
+  background-position: right var(--eye-x) bottom calc(-1 * var(--eye-crop) * var(--eye-w));
+  background-size: var(--eye-w) auto;
+  opacity: var(--eye-opacity);
+}

--- a/src/kernel/corners.ts
+++ b/src/kernel/corners.ts
@@ -1,0 +1,138 @@
+import { onThemeChange, theme, type Theme } from './theme';
+
+/**
+ * The corner pictures.
+ *
+ * Each is baked at four widths and, where its grade needed a second answer on
+ * black, again per theme — so this picks one file out of a grid rather than off a
+ * list, and picks again when the theme or the display changes under it.
+ *
+ * THE ONE LINE POINTING AT THE OLD TREE. The ladder is still the one
+ * design/plate/build-plate.py writes into portfolio/img/, because /next is not
+ * replacing /portfolio yet; the ticket that flips the route moves these bytes and
+ * changes this constant. Nothing else here knows where they live.
+ */
+const LADDER_BASE = '/portfolio/img/';
+
+/** Keep this equal to OUT_WIDTHS in design/plate/build-plate.py. */
+const RUNGS = [800, 1300, 2000, 2800] as const;
+
+/**
+ * A digest of every ladder file, appended to each URL. Not a cache-buster in the
+ * usual sense: a rung's filename is content-independent, and the deployment
+ * caches /portfolio/img/ for a day, so this is the only thing that makes a
+ * re-bake visible. build-plate.py prints the current value at the end of a run.
+ */
+const LADDER_VERSION = 'cd5a41c7';
+
+interface Picture {
+  /** the file stem, and Picture.out_path()'s in build-plate.py */
+  readonly stem: string;
+  /** the custom property corners.css draws it from */
+  readonly property: string;
+  /** drawn width as a share of the first screen. Keep equal to --<stem>-fill. */
+  readonly fill: number;
+  /** the ceiling on --<stem>-w, in CSS pixels */
+  readonly max: number;
+  /** the widest rung that has actually resolved, per theme */
+  shown: Record<Theme, number>;
+  /** and the URL it resolved to, so a theme flip is a repaint and not a fetch */
+  src: Record<Theme, string | null>;
+}
+
+function picture(stem: string, fill: number): Picture {
+  return {
+    stem,
+    property: `--${stem}-src`,
+    fill,
+    max: 2400,
+    shown: { light: 0, dark: 0 },
+    src: { light: null, dark: null },
+  };
+}
+
+/** Light is unsuffixed. Keep this spelling and build-plate.py's together. */
+function rungUrl(p: Picture, width: number, forTheme: Theme): string {
+  const dark = forTheme === 'dark' ? 'dark-' : '';
+  return `${LADDER_BASE}${p.stem}-${dark}${width}.webp?v=${LADDER_VERSION}`;
+}
+
+export function mountCorners(): void {
+  const root = document.documentElement;
+
+  // Metered or genuinely slow connections do not get them at all. They are
+  // ornaments, and this is the one honest way to treat them as optional.
+  const link = (navigator as { connection?: { saveData?: boolean; effectiveType?: string } })
+    .connection;
+  if (link?.saveData === true || /^(slow-)?2g$/.test(link?.effectiveType ?? '')) return;
+
+  const pictures = [picture('plate', 0.863), picture('car', 0.497), picture('eye', 0.582)];
+
+  const rungFor = (p: Picture): number => {
+    const drawnAt = Math.min(p.max, p.fill * (window.innerHeight || 1080));
+    const want = drawnAt * (window.devicePixelRatio || 1);
+    return RUNGS.find((rung) => rung >= want) ?? RUNGS[RUNGS.length - 1]!;
+  };
+
+  // Every picture, at whatever each has resolved to for the theme on screen —
+  // off the stored URLs rather than off the load that triggered it, so a flip
+  // repaints all of them from cache and none is blanked while another decides.
+  const paint = (): void => {
+    const current = theme();
+    for (const p of pictures) {
+      const src = p.src[current];
+      if (src) root.style.setProperty(p.property, `url("${src}")`);
+    }
+  };
+
+  // A miss on a dark file is the ordinary untuned state and not an error:
+  // build-plate.py writes no dark ladder while dark's grade matches light's. So
+  // one retry against the light rung of the same width, and only then give up.
+  const fetchRung = (p: Picture, width: number, forTheme: Theme): void => {
+    const attempt = (url: string, fallback: string | null): void => {
+      const img = new Image();
+      const land = (resolved: string | null): void => {
+        img.onload = img.onerror = null;
+        if (resolved && width > p.shown[forTheme]) {
+          p.shown[forTheme] = width;
+          p.src[forTheme] = resolved;
+        }
+        paint();
+      };
+      img.onload = () => land(url);
+      img.onerror = () => {
+        img.onload = img.onerror = null;
+        if (fallback) attempt(fallback, null);
+        else land(null);
+      };
+      img.src = url;
+      if (img.complete && img.naturalWidth > 0) land(url);
+    };
+    attempt(rungUrl(p, width, forTheme), forTheme === 'light' ? null : rungUrl(p, width, 'light'));
+  };
+
+  // Upgrade only, and for the theme on screen only: a rung already good enough
+  // is left alone so dragging a window cannot thrash, and the other theme is
+  // upgraded if and when it is next shown.
+  const upgrade = (): void => {
+    const current = theme();
+    for (const p of pictures) {
+      const need = rungFor(p);
+      if (need > p.shown[current]) fetchRung(p, need, current);
+    }
+  };
+
+  upgrade();
+  onThemeChange(() => {
+    paint();
+    upgrade();
+  });
+
+  // Dragged onto a denser screen, or pulled taller. Both now ask for more; width
+  // asks for nothing, because no picture here changes size with the window's.
+  let timer: number | undefined;
+  window.addEventListener('resize', () => {
+    window.clearTimeout(timer);
+    timer = window.setTimeout(upgrade, 250);
+  });
+}

--- a/src/kernel/effect-stack/EffectStack.astro
+++ b/src/kernel/effect-stack/EffectStack.astro
@@ -1,0 +1,21 @@
+---
+// The nine layers, in paint order. Empty, decorative, and inert until the layer
+// is named in <html data-fx>. effect-stack.css is what each one does.
+import './effect-stack.css';
+
+const LAYERS = [
+  'paper',
+  'halftone',
+  'film',
+  'grain',
+  'grille',
+  'scan',
+  'roll',
+  'tube',
+  'vignette',
+] as const;
+---
+
+<div class="fx" aria-hidden="true">
+  {LAYERS.map((layer) => <div class={`fx-${layer}`}></div>)}
+</div>

--- a/src/kernel/effect-stack/effect-stack.css
+++ b/src/kernel/effect-stack/effect-stack.css
@@ -1,0 +1,343 @@
+/* THE EFFECT STACK — nine layers over the finished page, each inert until named
+   in data-fx. The names are CONTEXT.md's: paper, halftone, film, grain, grille,
+   scan, roll, tube, vignette.
+
+   Every number here was tuned by eye and most of them are stated twice, once per
+   theme, because a texture over white and the same texture over black are not
+   the same picture. src/kernel/NOTES.md carries the reasoning; the one thing that
+   must not be read past is the warning on .fx below. */
+
+:root {
+  --fx-y: 0px;
+  --fx-band: calc(var(--fold) - var(--fx-y));
+  --fx-fade: 0;
+
+  /* film — Texturelabs 185XL, one frame over the whole band, never tiled.
+     No ?v= digest, unlike the copy of these URLs in portfolio/styles.css: the
+     build fingerprints anything it can see in a url(), so what ships is
+     /_astro/film-1600.<hash>.webp and a re-bake is a different filename by
+     construction. The digest that sheet carries is doing this job by hand. */
+  --fx-film-src: image-set(
+    url('/portfolio/img/tex/film-1600.webp') 1x,
+    url('/portfolio/img/tex/film-2600.webp') 2x
+  );
+  --fx-film-strength: 0.14;
+  --fx-film-blend: multiply;
+  --fx-film-scale: 0.25;
+  --fx-film-aspect: 1.3445;
+  --fx-film-invert: 1;
+  --fx-film-lift: 1.5;
+  --fx-film-contrast: 2;
+
+  /* paper — a 512px square that wraps in both axes, drawn at --fx-paper-size */
+  --fx-paper-src: image-set(
+    url('/portfolio/img/tex/paper-512.webp') 1x,
+    url('/portfolio/img/tex/paper-1024.webp') 2x
+  );
+  --fx-paper-size: 384px;
+  --fx-paper-strength: 0.18;
+  --fx-paper-blend: multiply;
+  --fx-paper-invert: 0;
+  --fx-paper-lift: 1.5;
+  --fx-paper-contrast: 1.25;
+
+  --fx-grain-opacity: 0.09;
+  --fx-grain-size: 600px;
+  --fx-grain-fps: 2;
+
+  --fx-halftone-pitch: 3.7px;
+  --fx-halftone-dot: 0.27;
+  --fx-halftone-angle: 11deg;
+  --fx-halftone-opacity: 1;
+  --fx-halftone-blend: soft-light;
+
+  --fx-vignette-start: 55%;
+  --fx-vignette-strength: 0.3;
+
+  --fx-scan-pitch: 3px;
+  --fx-scan-alpha: 0.28;
+  --fx-flicker: 0.04;
+  --fx-grille-pitch: 3px;
+  --fx-grille-alpha: 0.16;
+  --fx-tube-curve: 1.4rem;
+  --fx-tube-alpha: 0.5;
+  --fx-roll-height: 14%;
+  --fx-roll-alpha: 0.05;
+  --fx-roll-period: 7s;
+}
+
+/* A texture over black is a different picture from the same texture over white,
+   so the two that ship on are stated again rather than scaled. */
+:root[data-theme='dark'] {
+  --fx-film-invert: 0;
+  --fx-film-lift: 0.75;
+  --fx-film-contrast: 4;
+  --fx-film-blend: screen;
+  --fx-film-strength: 0.18;
+
+  --fx-paper-lift: 0.8;
+  --fx-paper-contrast: 8;
+  --fx-paper-blend: normal;
+  --fx-paper-strength: 0.06;
+
+  --fx-halftone-pitch: 3.9px;
+  --fx-halftone-dot: 0.2;
+  --fx-halftone-blend: multiply;
+}
+
+/* The film is one frame under `cover`: a narrow window sees LESS of the same
+   picture, not a smaller one, so four scratches end up sharing a phone screen.
+   A strength correction, not a scale one. The paper is a fixed tile and needs
+   none. 700px rather than the composition's own gate — this is a question about
+   how much of a photograph is on screen. */
+@media (max-width: 700px) {
+  :root {
+    --fx-film-strength: 0.07;
+  }
+  :root[data-theme='dark'] {
+    --fx-film-strength: 0.09;
+  }
+}
+
+/* NO z-index, NO isolation, NO mask ON THIS ELEMENT. This is the load-bearing
+   line in the file rather than an omission: an element with any of the three
+   becomes an isolated group, and an isolated group hands every blending child a
+   transparent backdrop instead of the page. `overlay` and `soft-light` are
+   no-ops over white, so correctly blended these layers leave #fff paper at
+   exactly #fff — with a z-index in, a bare patch measured 182 of 255 under the
+   film alone. The layers stop blending and start painting, which looks exactly
+   like the strengths being too high. If this stack ever reads as a flat grey
+   wash, measure a bare patch of paper before touching a strength.
+   .fx is the last positioned element in the body, so it paints over the Sections
+   on DOM order alone and needs nothing. */
+.fx {
+  position: absolute;
+  top: var(--fx-y);
+  left: 0;
+  right: 0;
+  height: var(--fx-band);
+  pointer-events: none;
+  overflow: hidden;
+}
+
+.fx > * {
+  display: none;
+  position: absolute;
+  inset: 0;
+  /* The dissolve at the foot, when --fx-fade is not 0. On each LAYER and never
+     on .fx — see above. A mask on the blending element itself is applied before
+     the blend and is harmless; only a mask between the blenders and the backdrop
+     isolates. */
+  mask-image: linear-gradient(
+    to bottom,
+    #000 calc(100% - var(--fx-fade) * var(--fx-band)),
+    transparent 100%
+  );
+}
+
+/* Each layer needs a z of its own, in the order it already paints in, and they
+   are EVEN so content excluded from the stack has an odd one to stand on
+   between any two of them. A z-index on a LAYER is safe; the warning above is
+   about the container. */
+.fx-paper {
+  z-index: 2;
+}
+.fx-halftone {
+  z-index: 4;
+}
+.fx-film {
+  z-index: 6;
+}
+.fx-grain {
+  z-index: 8;
+}
+.fx-grille {
+  z-index: 10;
+}
+.fx-scan {
+  z-index: 12;
+}
+.fx-roll {
+  z-index: 14;
+}
+.fx-tube {
+  z-index: 16;
+}
+.fx-vignette {
+  z-index: 18;
+}
+
+:root[data-fx~='paper'] .fx-paper {
+  display: block;
+  background-image: var(--fx-paper-src);
+  background-size: var(--fx-paper-size) var(--fx-paper-size);
+  background-repeat: repeat;
+  filter: invert(var(--fx-paper-invert)) brightness(var(--fx-paper-lift))
+    contrast(var(--fx-paper-contrast));
+  mix-blend-mode: var(--fx-paper-blend);
+  opacity: var(--fx-paper-strength);
+}
+
+/* Rotated about the centre and oversized to 150% so the corners of the band stay
+   covered at any angle — sqrt(2) is 1.415, and 1.5 leaves a margin. */
+:root[data-fx~='halftone'] .fx-halftone {
+  display: block;
+  background-image: radial-gradient(
+    circle at 50% 50%,
+    #000 0 calc(var(--fx-halftone-dot) * var(--fx-halftone-pitch)),
+    #fff calc(var(--fx-halftone-dot) * var(--fx-halftone-pitch) + 0.5px)
+  );
+  background-size: var(--fx-halftone-pitch) var(--fx-halftone-pitch);
+  width: 150%;
+  height: 150%;
+  inset: -25%;
+  rotate: var(--fx-halftone-angle);
+  mix-blend-mode: var(--fx-halftone-blend);
+  opacity: var(--fx-halftone-opacity);
+}
+
+/* max(100%, band x aspect) is what `cover` picks: whichever constraint binds.
+   The +1px is for the rounding underneath, not for the arithmetic — a subpixel
+   short after rounding is a hairline of the wrapped edge down one side. */
+:root[data-fx~='film'] .fx-film {
+  display: block;
+  background-image: var(--fx-film-src);
+  background-size: calc(1px + var(--fx-film-scale) * max(100%, var(--fx-band) * var(--fx-film-aspect)))
+    auto;
+  background-position: center;
+  background-repeat: repeat;
+  filter: invert(var(--fx-film-invert)) brightness(var(--fx-film-lift))
+    contrast(var(--fx-film-contrast));
+  mix-blend-mode: var(--fx-film-blend);
+  opacity: var(--fx-film-strength);
+}
+
+/* Moving grain over the still film. The tile is procedural — grain.ts draws
+   one square of white noise at boot and hands it here as a data URI — so there
+   is no asset to request for something a browser can make in half a
+   millisecond. It moves by jumping its own background-position on a steps()
+   timeline rather than by redrawing: eight positions, so a cycle of 8/fps
+   seconds spends exactly 1/fps on each and --fx-grain-fps is the real frame
+   rate. */
+:root[data-fx~='grain'] .fx-grain {
+  display: block;
+  background-image: var(--fx-grain-src, none);
+  background-size: var(--fx-grain-size) var(--fx-grain-size);
+  background-repeat: repeat;
+  mix-blend-mode: overlay;
+  opacity: var(--fx-grain-opacity);
+  animation: fx-grain-shift calc(8s / var(--fx-grain-fps)) steps(1, end) infinite;
+}
+
+@keyframes fx-grain-shift {
+  0% {
+    background-position: 0 0;
+  }
+  12.5% {
+    background-position: -13px 27px;
+  }
+  25% {
+    background-position: 31px -19px;
+  }
+  37.5% {
+    background-position: -41px -37px;
+  }
+  50% {
+    background-position: 23px 43px;
+  }
+  62.5% {
+    background-position: -29px 11px;
+  }
+  75% {
+    background-position: 47px -31px;
+  }
+  87.5% {
+    background-position: -17px -43px;
+  }
+}
+
+:root[data-fx~='scan'] .fx-scan {
+  display: block;
+  background-image: repeating-linear-gradient(
+    to bottom,
+    rgb(0 0 0 / var(--fx-scan-alpha)) 0 1px,
+    transparent 1px var(--fx-scan-pitch)
+  );
+  mix-blend-mode: multiply;
+  animation: fx-flicker 0.14s steps(2, end) infinite;
+}
+
+/* Three phosphor stripes to a triad — the pitch is the triad, so each stripe is
+   a third of it. */
+:root[data-fx~='grille'] .fx-grille {
+  display: block;
+  background-image: repeating-linear-gradient(
+    to right,
+    rgb(255 0 0 / var(--fx-grille-alpha)) 0 calc(var(--fx-grille-pitch) / 3),
+    rgb(0 255 0 / var(--fx-grille-alpha)) calc(var(--fx-grille-pitch) / 3)
+      calc(var(--fx-grille-pitch) / 3 * 2),
+    rgb(0 0 255 / var(--fx-grille-alpha)) calc(var(--fx-grille-pitch) / 3 * 2)
+      var(--fx-grille-pitch)
+  );
+  mix-blend-mode: screen;
+}
+
+:root[data-fx~='tube'] .fx-tube {
+  display: block;
+  border-radius: var(--fx-tube-curve);
+  box-shadow: inset 0 0 calc(var(--fx-tube-curve) * 4) calc(var(--fx-tube-curve) / 2)
+    rgb(0 0 0 / var(--fx-tube-alpha));
+  mix-blend-mode: multiply;
+}
+
+:root[data-fx~='roll'] .fx-roll {
+  display: block;
+  height: var(--fx-roll-height);
+  inset: auto 0 0 0;
+  background-image: linear-gradient(
+    to bottom,
+    transparent,
+    rgb(255 255 255 / var(--fx-roll-alpha)) 50%,
+    transparent
+  );
+  mix-blend-mode: screen;
+  animation: fx-roll var(--fx-roll-period) linear infinite;
+}
+
+@keyframes fx-flicker {
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: calc(1 - var(--fx-flicker));
+  }
+}
+
+@keyframes fx-roll {
+  from {
+    transform: translateY(0);
+  }
+  to {
+    transform: translateY(calc(-100svh - var(--fx-roll-height)));
+  }
+}
+
+:root[data-fx~='vignette'] .fx-vignette {
+  display: block;
+  background-image: radial-gradient(
+    ellipse at 50% 45%,
+    #fff var(--fx-vignette-start),
+    hsl(0 0% calc(100% - var(--fx-vignette-strength) * 100%)) 130%
+  );
+  mix-blend-mode: multiply;
+}
+
+/* A treatment is not motion, so a reader who asked for less of it still gets the
+   stack. What goes is the four things that actually travel. */
+@media (prefers-reduced-motion: reduce) {
+  .fx-grain,
+  .fx-roll,
+  .fx-scan {
+    animation: none;
+  }
+}

--- a/src/kernel/effect-stack/grain.ts
+++ b/src/kernel/effect-stack/grain.ts
@@ -1,0 +1,31 @@
+/**
+ * The grain tile: one square of white noise, drawn once at boot and handed to
+ * the stack as a data URI. Procedural rather than an asset, because a request
+ * and a cache entry are a lot to pay for something a canvas can make in half a
+ * millisecond — and because the tile is meant to be different every visit.
+ */
+export function drawGrainTile(size = 128): string | null {
+  const canvas = document.createElement('canvas');
+  canvas.width = canvas.height = size;
+  const context = canvas.getContext('2d');
+  if (!context) return null;
+
+  const image = context.createImageData(size, size);
+  for (let i = 0; i < image.data.length; i += 4) {
+    const value = (Math.random() * 255) | 0;
+    image.data[i] = value;
+    image.data[i + 1] = value;
+    image.data[i + 2] = value;
+    image.data[i + 3] = 255;
+  }
+  context.putImageData(image, 0, 0);
+  return canvas.toDataURL('image/png');
+}
+
+/** Only when the layer is actually on the stack — otherwise nothing reads it. */
+export function mountGrain(): void {
+  const root = document.documentElement;
+  if (!(root.getAttribute('data-fx') ?? '').split(/\s+/).includes('grain')) return;
+  const tile = drawGrainTile();
+  if (tile) root.style.setProperty('--fx-grain-src', `url("${tile}")`);
+}

--- a/src/kernel/faces.css
+++ b/src/kernel/faces.css
@@ -1,0 +1,64 @@
+/* The faces. Five families, six files, all static instances under /fonts/.
+   Why each weight exists and why Host Grotesk's second cut is declared 500 while
+   being drawn at 514: src/kernel/NOTES.md. */
+
+@font-face {
+  font-family: 'Vollkorn';
+  src: url('/fonts/vollkorn-regular.woff2') format('woff2');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: 'Vollkorn';
+  src: url('/fonts/vollkorn-bold.woff2') format('woff2');
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: 'Vollkorn';
+  src: url('/fonts/vollkorn-italic.woff2') format('woff2');
+  font-weight: 400;
+  font-style: italic;
+  font-display: swap;
+}
+@font-face {
+  font-family: 'Spectral';
+  src: url('/fonts/spectral-regular.woff2') format('woff2');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: 'Source Serif 4';
+  src: url('/fonts/sourceserif4-regular.woff2') format('woff2');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+@font-face {
+  font-family: 'Host Grotesk';
+  src: url('/fonts/hostgrotesk-regular.woff2') format('woff2');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+/* Drawn at wght 514 — the instance the cut title morphs into — and declared 500
+   because CSS has to be told a rung. Do not tidy to 500 in the build. */
+@font-face {
+  font-family: 'Host Grotesk';
+  src: url('/fonts/hostgrotesk-medium.woff2') format('woff2');
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+
+:root {
+  --face-body: Vollkorn, 'Sitka Text', Charter, 'Iowan Old Style', Georgia, serif;
+  --face-label: Spectral, 'Sitka Text', Charter, 'Iowan Old Style', Georgia, serif;
+  /* Georgia on purpose, and sized against Georgia. See NOTES.md. */
+  --face-lead: Georgia, 'Iowan Old Style', 'Palatino Linotype', serif;
+  --face-year: 'Source Serif 4', Georgia, serif;
+  --face-panel: 'Host Grotesk', 'Segoe UI Variable Text', 'Segoe UI', system-ui, sans-serif;
+}

--- a/src/kernel/ground.css
+++ b/src/kernel/ground.css
@@ -1,0 +1,62 @@
+/* The page's ground, and the Turn across it.
+   Two independent things share this file because they share their endpoints:
+   the THEME picks which paper the page is printed on, and the TURN carries that
+   paper into dark as the reader scrolls. Neither belongs to a Section. */
+
+/* --turn is registered so it is a number rather than a token, which is what
+   lets GSAP interpolate it and what makes the calc() below legal. Without this
+   the custom property is an untyped string and the page just does not turn. */
+@property --turn {
+  syntax: '<number>';
+  inherits: true;
+  initial-value: 0;
+}
+
+:root {
+  /* the theme's two endpoints */
+  --paper: #fff;
+  --paper-ink: #1a1917;
+  --paper-ink-soft: #46433d;
+
+  /* where the Turn arrives, in both themes */
+  --dark: #0e0d0c;
+  --dark-ink: #eaeaea;
+  --dark-ink-soft: #b8b8b8;
+
+  /* 0 is paper, 1 is dark. The Turn's Timeline owns this and nothing else does. */
+  --turn: 0;
+
+  --ground: color-mix(in oklab, var(--paper), var(--dark) calc(var(--turn) * 100%));
+  --ink: color-mix(in oklab, var(--paper-ink), var(--dark-ink) calc(var(--turn) * 100%));
+  --ink-soft: color-mix(in oklab, var(--paper-ink-soft), var(--dark-ink-soft) calc(var(--turn) * 100%));
+
+  /* The datum every Kernel picture is measured against: the bottom of the page
+     before any scrolling. svh and not vh — the difference is a phone. */
+  --fold: 100svh;
+}
+
+:root[data-theme='dark'] {
+  --paper: #131211;
+  --paper-ink: #eaeaea;
+  --paper-ink-soft: #b8b8b8;
+}
+
+html {
+  background: var(--ground);
+  color: var(--ink);
+  color-scheme: light dark;
+}
+
+body {
+  margin: 0;
+  font-family: var(--face-body);
+  background: transparent;
+}
+
+/* A reader who has asked for less motion gets the Turn as a state rather than a
+   crossing: the Kernel still sets --turn, the Timeline just does not scrub. */
+@media (prefers-reduced-motion: reduce) {
+  :root {
+    scroll-behavior: auto;
+  }
+}

--- a/src/kernel/handles.ts
+++ b/src/kernel/handles.ts
@@ -1,0 +1,31 @@
+/**
+ * `window.portfolio` — the Kernel's handles, and the only thing on the page a
+ * Check or the Editor is allowed to reach for.
+ *
+ * `timelines` is ADR 0003's seam: ask a named Timeline for a moment and read the
+ * frame — with `hold()` called first, or the scroll recomputes it a frame later.
+ * The rest are filled in by kernel.ts once the modules that own them have run, so
+ * this file can be imported by any of them without importing any of them.
+ */
+export interface Handles {
+  timelines: Map<string, gsap.core.Timeline>;
+  observeSection?: (root: HTMLElement) => void;
+  toggleTheme?: () => 'light' | 'dark';
+  hold?: () => void;
+  release?: () => void;
+}
+
+declare global {
+  interface Window {
+    portfolio?: Handles;
+  }
+}
+
+export function handles(): Handles {
+  window.portfolio ??= { timelines: new Map() };
+  return window.portfolio;
+}
+
+export function register(name: string, timeline: gsap.core.Timeline): void {
+  handles().timelines.set(name, timeline);
+}

--- a/src/kernel/kernel.ts
+++ b/src/kernel/kernel.ts
@@ -1,0 +1,25 @@
+import { mountCorners } from './corners';
+import { mountGrain } from './effect-stack/grain';
+import { handles } from './handles';
+import { mountSections, observeSection } from './loader';
+import { hold, release } from './motion';
+import { followSystemTheme, toggleTheme } from './theme';
+import { createTurn } from './turn';
+
+/**
+ * The Kernel's client half, and the whole of what crosses a Section boundary at
+ * run time. Everything here is either something every Section may rely on or a
+ * handle a Check or the Editor needs.
+ */
+
+createTurn();
+mountCorners();
+mountGrain();
+followSystemTheme();
+mountSections();
+
+const kernel = handles();
+kernel.observeSection = observeSection;
+kernel.toggleTheme = toggleTheme;
+kernel.hold = hold;
+kernel.release = release;

--- a/src/kernel/loader.ts
+++ b/src/kernel/loader.ts
@@ -1,0 +1,91 @@
+import { register } from './handles';
+
+/**
+ * What a Section's `timeline.ts` exports: a function handed the Section's root
+ * element, returning the Section's Timeline. Returning nothing is allowed — a
+ * Section with no motion still mounts, it just registers no Timeline.
+ */
+export type SectionTimeline = {
+  default?: (root: HTMLElement) => gsap.core.Timeline | void;
+};
+
+/**
+ * One chunk per Section, resolved lazily.
+ *
+ * The glob is what makes the Section folder convention mechanical rather than
+ * described: dropping a folder under src/sections/ with a `timeline.ts` in it is
+ * the whole of registering a Section, and there is no list anywhere to forget to
+ * add it to. Vite code-splits each match, so a Section's motion is bytes the page
+ * does not fetch until the reader is nearly at it.
+ */
+const timelineModules = import.meta.glob<SectionTimeline>('../sections/*/timeline.ts');
+
+const byName = new Map<string, () => Promise<SectionTimeline>>();
+for (const [path, load] of Object.entries(timelineModules)) {
+  const name = /\/sections\/([^/]+)\/timeline\.ts$/.exec(path)?.[1];
+  if (name) byName.set(name, load);
+}
+
+/**
+ * How much of a screen ahead of the viewport counts as approaching. Generous on
+ * purpose: the point is that the Section's work is done before the reader
+ * arrives, not that it is done as late as possible.
+ */
+const APPROACH = '50%';
+
+async function mount(root: HTMLElement): Promise<void> {
+  const name = root.dataset.section;
+  if (!name) return;
+
+  // Set before the await, so the Section's own styles can start decoding assets
+  // while its Timeline is still in flight.
+  root.dataset.mounted = 'pending';
+
+  const load = byName.get(name);
+  if (load) {
+    // A chunk that will not arrive — a stale deployment, a dead network — must
+    // not leave the Section stuck at `pending`. Without this the mount point
+    // never reaches `true`, which is the state a Check reads, so the failure
+    // shows up as a Section that silently never mounted rather than as an error.
+    try {
+      const module = await load();
+      const timeline = module.default?.(root);
+      if (timeline) register(name, timeline);
+    } catch (error) {
+      console.error(`kernel: the ${name} Section's Timeline did not load`, error);
+    }
+  }
+
+  root.dataset.mounted = 'true';
+  root.dispatchEvent(new CustomEvent('section:mounted', { bubbles: true, detail: { name } }));
+}
+
+let observer: IntersectionObserver | undefined;
+
+function sectionObserver(): IntersectionObserver {
+  observer ??= new IntersectionObserver(
+    (entries) => {
+      for (const entry of entries) {
+        if (!entry.isIntersecting) continue;
+        const root = entry.target as HTMLElement;
+        observer?.unobserve(root);
+        void mount(root);
+      }
+    },
+    { rootMargin: `${APPROACH} 0px` },
+  );
+  return observer;
+}
+
+/** Mount this element's Section as it approaches the viewport. */
+export function observeSection(root: HTMLElement): void {
+  if (root.dataset.mounted) return;
+  sectionObserver().observe(root);
+}
+
+/** Every Section mount point the Shell laid down. */
+export function mountSections(): void {
+  for (const root of document.querySelectorAll<HTMLElement>('[data-section]')) {
+    observeSection(root);
+  }
+}

--- a/src/kernel/motion.ts
+++ b/src/kernel/motion.ts
@@ -1,0 +1,22 @@
+import { ScrollTrigger } from 'gsap/ScrollTrigger';
+
+/**
+ * Stop the scroll driving the Timelines, and start it again.
+ *
+ * ADR 0003 says a Check asserts choreography by asking a Timeline for a moment.
+ * On its own that is not enough: a scrubbed Timeline is recomputed from the
+ * scroll position on the next tick, so a `seek()` survives about one frame and a
+ * Check that reads geometry after it is a coin toss. This is the missing half —
+ * `hold()` first, then seek as many moments as you like, then `release()`.
+ *
+ * `disable(false)` leaves every Timeline exactly where it is rather than
+ * reverting it, so holding does not itself move the page.
+ */
+export function hold(): void {
+  for (const trigger of ScrollTrigger.getAll()) trigger.disable(false);
+}
+
+export function release(): void {
+  for (const trigger of ScrollTrigger.getAll()) trigger.enable();
+  ScrollTrigger.refresh();
+}

--- a/src/kernel/theme.ts
+++ b/src/kernel/theme.ts
@@ -1,0 +1,56 @@
+/** The two papers the Portfolio can be printed on. */
+export type Theme = 'light' | 'dark';
+
+export const THEME_KEY = 'portfolio-theme';
+
+/**
+ * The theme on screen. Read off the attribute rather than off storage, because
+ * the attribute is what every route into a theme change lands on — the toggle
+ * here, the system preference this follows until the toggle is used, and the
+ * Editor priming storage — and so it is the one thing all of them agree about.
+ */
+export function theme(): Theme {
+  return document.documentElement.getAttribute('data-theme') === 'dark' ? 'dark' : 'light';
+}
+
+export function setTheme(next: Theme): void {
+  document.documentElement.setAttribute('data-theme', next);
+  try {
+    localStorage.setItem(THEME_KEY, next);
+  } catch {
+    // Private browsing refuses storage. The theme still applies for this visit;
+    // it just is not remembered, which is the right way for this to degrade.
+  }
+}
+
+export function toggleTheme(): Theme {
+  const next: Theme = theme() === 'dark' ? 'light' : 'dark';
+  setTheme(next);
+  return next;
+}
+
+/** Run `then` whenever the theme on screen changes, whoever changed it. */
+export function onThemeChange(then: (theme: Theme) => void): void {
+  new MutationObserver(() => then(theme())).observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['data-theme'],
+  });
+}
+
+/**
+ * Follow the system preference for as long as the reader has not chosen. Once
+ * they have, the stored choice wins and this stops speaking.
+ */
+export function followSystemTheme(): void {
+  const media = window.matchMedia('(prefers-color-scheme: dark)');
+  media.addEventListener('change', (event) => {
+    let stored: string | null = null;
+    try {
+      stored = localStorage.getItem(THEME_KEY);
+    } catch {
+      stored = null;
+    }
+    if (stored === 'light' || stored === 'dark') return;
+    document.documentElement.setAttribute('data-theme', event.matches ? 'dark' : 'light');
+  });
+}

--- a/src/kernel/turn.ts
+++ b/src/kernel/turn.ts
@@ -1,0 +1,49 @@
+import gsap from 'gsap';
+import { ScrollTrigger } from 'gsap/ScrollTrigger';
+import { register } from './handles';
+
+gsap.registerPlugin(ScrollTrigger);
+
+export const TURN = 'turn';
+
+/**
+ * The Turn: the Portfolio crossing from paper into dark as the reader scrolls.
+ *
+ * Built PAUSED and driven from a separate ScrollTrigger rather than handed to
+ * `gsap.timeline({ scrollTrigger })`. Both scrub identically; the difference is
+ * that a paused timeline stays authoritative about its own progress, so
+ * `seek(0.34)` produces a frame that stays put until the reader scrolls again.
+ * That is the whole reason ADR 0003 asks for a named seekable Timeline — it is
+ * how a Check asserts the crossing and how the Editor scrubs it.
+ *
+ * A Section says where the crossing happens by marking one element
+ * `data-turn`; with nothing marked the Turn spans the document's whole scroll.
+ */
+export function createTurn(): gsap.core.Timeline {
+  const root = document.documentElement;
+  const state = { turn: 0 };
+
+  const timeline = gsap.timeline({ paused: true });
+  timeline.to(state, {
+    turn: 1,
+    duration: 1,
+    ease: 'none',
+    onUpdate: () => root.style.setProperty('--turn', String(state.turn)),
+  });
+
+  // Across the marked element's own scroll: paper when its top reaches the top
+  // of the window, dark when its bottom reaches the bottom. The same two edges
+  // for the document as for a Section, so the page opens on paper either way —
+  // `top bottom` reads better in prose and starts the Turn half-crossed, because
+  // an element at the top of the document is already past that edge at load.
+  const trigger = document.querySelector<HTMLElement>('[data-turn]') ?? root;
+  ScrollTrigger.create({
+    trigger,
+    start: 'top top',
+    end: 'bottom bottom',
+    onUpdate: (self) => timeline.progress(self.progress),
+  });
+
+  register(TURN, timeline);
+  return timeline;
+}

--- a/src/pages/next.astro
+++ b/src/pages/next.astro
@@ -1,0 +1,20 @@
+---
+// /next — the Portfolio's new foundation, deployed and visible and not yet
+// replacing anything. `/portfolio` goes on being the live document until the
+// ticket that flips this route; keeping both up is what lets every porting ticket
+// land without taking the site down.
+import Stub from '../sections/stub/Stub.astro';
+import Shell from '../shell/Shell.astro';
+---
+
+<Shell
+  title="Christian Juresh"
+  description="Software engineer in London."
+>
+  <Fragment slot="head">
+    {/* Nothing here is the live document yet, and nothing should index it as
+        though it were. */}
+    <meta name="robots" content="noindex" />
+  </Fragment>
+  <Stub />
+</Shell>

--- a/src/sections/stub/NOTES.md
+++ b/src/sections/stub/NOTES.md
@@ -1,0 +1,79 @@
+# The stub Section
+
+Not a part of the Portfolio. It exists so the Section folder convention is real
+rather than described — an agent building the first actual Section copies this
+folder and replaces its contents, and the guard in `scripts/check-source.mjs`
+already has something to pass against.
+
+It is deleted by whichever ticket lands the second real Section, not before: with
+one real Section on the page there is nothing to prove that a selector cannot
+reach out of one, and this is the thing it cannot reach.
+
+## The folder, file by file
+
+Every Section holds exactly these, and `check-source.mjs` fails the build if one
+is missing.
+
+| file          | what it is                                                          |
+| ------------- | ------------------------------------------------------------------- |
+| `Stub.astro`  | the component: markup, and the scoped `<style>` that is the Section's own rules |
+| `content.ts`  | the words and the list of assets, typed by a schema declared beside them |
+| `tokens.css`  | the Section's named numbers and colours, as plain custom properties  |
+| `timeline.ts` | the Section's motion, as one named seekable object                   |
+| `variants.css`| complete alternative directions, selected by attribute               |
+| `assets/`     | the Section's own files, and nothing another Section reads           |
+| `NOTES.md`    | this — the reasoning that used to be a comment                       |
+
+The component is named for the Section rather than called `index.astro`, so a
+grep for `Stub` finds the Section and a stack trace names it.
+
+## Where the boundary actually is
+
+Three separate mechanisms, and it is worth being clear which does what, because
+only two of them are the compiler.
+
+**The rules** are in the component's `<style>`, which Astro scopes: every
+selector is rewritten with this component's own attribute, so it cannot match an
+element in another Section even by accident. This is the mechanism ADR 0002 buys
+a build step for.
+
+**The Tokens and the Variants** are plain CSS files imported in the frontmatter,
+which means they are *not* scoped — Astro's compiler never sees inside them.
+They are safe because of what they are allowed to contain, and that is enforced
+rather than trusted: `check-source.mjs` fails the build unless every declaration
+in `tokens.css` and `variants.css` is a custom property named `--stub-…` on a
+selector ending in this Section's own root class. A rule that could reach another
+Section is not a warning here, it is a build failure.
+
+The reason they are not simply moved into the scoped `<style>` block is ADR 0004:
+`tokens.css` is the one file the Editor writes, and it has to stay a plain CSS
+file the Editor can parse and rewrite without touching a composition.
+
+A consequence worth stating, because it will come up: **a Token cannot vary by
+media query.** `check-source.mjs` reads these two files as a flat list of rules,
+so an `@media` block in either fails the build. That is deliberate rather than a
+limitation of the checker — the Editor writes a value, not a breakpoint. A Token
+that genuinely needs to change with the viewport belongs in the component's scoped
+`<style>`, where it is a composition decision and not something to drag.
+
+**The imports** are checked too: a Section may import from its own folder and
+from `src/kernel/`, and nothing else. That is CONTEXT.md's "a Section may read
+the Kernel and nothing else", made mechanical.
+
+## The Timeline runs from the settled state
+
+`timeline.ts` animates *away* from how the markup reads, never towards it. So the
+module never arriving — a dead network, a parse error, scripting off — costs the
+motion and nothing else. Nothing in a Section may be the only thing standing
+between the reader and the words.
+
+That is also why there is no `opacity: 0` anywhere in the component's styles. The
+obvious way to write a reveal is to hide the content in CSS and let the Timeline
+uncover it, and it is wrong here for the same reason.
+
+## Tokens that are not used yet
+
+`--stub-rise` is read by `timeline.ts` rather than by the stylesheet, which is
+the one case where a Token is not a CSS value: it is the distance the motion
+covers, and the Editor is meant to be able to drag it. A Token read only by a
+Timeline still belongs in `tokens.css`.

--- a/src/sections/stub/Stub.astro
+++ b/src/sections/stub/Stub.astro
@@ -1,0 +1,81 @@
+---
+// The stub Section. NOTES.md is what this folder is for and what each file in it
+// has to be; nothing behavioural is decided in this file.
+import { content } from './content';
+import './tokens.css';
+import './variants.css';
+---
+
+{/* data-section is the loader's handle: it names the Section whose timeline.ts
+    gets fetched as this element approaches the viewport. data-turn says the
+    crossing into dark happens across this Section's scroll. */}
+<section class="stub" data-section="stub" data-turn aria-labelledby="stub-heading">
+  <div class="stub__measure">
+    <h2 class="stub__heading" id="stub-heading" data-stub-rise>{content.heading}</h2>
+    <p class="stub__lead" data-stub-rise>{content.lead}</p>
+    <ul class="stub__points">
+      {content.points.map((point) => <li data-stub-rise>{point}</li>)}
+    </ul>
+  </div>
+</section>
+
+<style>
+  /* Scoped by the build. Astro rewrites every selector below with this
+     component's own attribute, so none of them can match an element in another
+     Section even by accident — which is the mechanism ADR 0002 buys a build step
+     for, and the reason there is no `is:global` anywhere in a Section. */
+  .stub {
+    min-height: var(--stub-height);
+    box-sizing: border-box;
+    padding: var(--stub-inset);
+    display: flex;
+    align-items: flex-start;
+  }
+
+  .stub__measure {
+    max-width: var(--stub-measure);
+    display: flex;
+    flex-direction: column;
+    gap: var(--stub-gap);
+  }
+
+  .stub__heading {
+    margin: 0;
+    font-family: var(--face-label);
+    font-size: var(--stub-heading-size);
+    font-weight: var(--stub-heading-weight);
+    line-height: 0.95;
+    letter-spacing: -0.01em;
+  }
+
+  .stub__lead {
+    margin: 0;
+    font-family: var(--face-lead);
+    font-size: var(--stub-lead-size);
+    line-height: var(--stub-lead-leading);
+    font-style: italic;
+  }
+
+  .stub__points {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--stub-gap) / 2);
+    font-size: var(--stub-point-size);
+    color: var(--ink-soft);
+  }
+
+  .stub__points li {
+    padding-block-start: calc(var(--stub-gap) / 2);
+    border-block-start: var(--stub-rule) solid currentcolor;
+    border-color: color-mix(in oklab, var(--ink-soft), transparent 78%);
+  }
+
+  /* data-stub-rise marks what the Section's Timeline moves, and nothing here
+     hides it. The motion runs FROM the settled state rather than towards it, so a
+     dead network, a parse error or a reader with scripting off all leave the
+     Section reading exactly as it does now. No rule in a Section may be the only
+     thing standing between the reader and the words. */
+</style>

--- a/src/sections/stub/content.ts
+++ b/src/sections/stub/content.ts
@@ -1,0 +1,31 @@
+import { defineContent, z } from '../../kernel/content';
+
+/**
+ * The stub Section's Content, and its schema.
+ *
+ * Rename a field in either half and the build stops: TypeScript on the pair,
+ * because `data` below is typed as this schema's own input, and the parse on
+ * anything a type cannot see. Rename it in the component instead and TypeScript
+ * stops there. There is no third way for a field to go missing quietly.
+ */
+const schema = z.object({
+  heading: z.string().min(1),
+  lead: z.string().min(1),
+  points: z.array(z.string().min(1)).min(1),
+});
+
+export type StubContent = z.output<typeof schema>;
+
+export const content = defineContent(schema, {
+  heading: 'Stub',
+  lead:
+    'A Section that exists to make the convention real rather than described. ' +
+    'It owns this markup, these styles, these Tokens, this Content, its Timeline ' +
+    'and its assets, and it reads nothing but the Kernel.',
+  points: [
+    'Its styles are scoped by the build, so no selector here can reach another Section.',
+    'Its Content is typed, so renaming a field is a build error and not a blank space.',
+    'Its Timeline is one named seekable object, so a Check can ask it for a moment.',
+    'It mounts as it approaches the viewport, not at load.',
+  ],
+});

--- a/src/sections/stub/timeline.ts
+++ b/src/sections/stub/timeline.ts
@@ -1,0 +1,44 @@
+import gsap from 'gsap';
+import { ScrollTrigger } from 'gsap/ScrollTrigger';
+
+gsap.registerPlugin(ScrollTrigger);
+
+/**
+ * The stub Section's Timeline.
+ *
+ * One named, seekable object (ADR 0003), returned so the Kernel's loader can
+ * register it under this Section's name. Paused and driven from a ScrollTrigger's
+ * onUpdate rather than handed to `gsap.timeline({ scrollTrigger })`: both scrub
+ * the same, but a paused timeline stays authoritative about its own progress, so
+ * a Check that asks it for a moment gets a frame that stays put.
+ *
+ * It runs FROM the settled state, never towards it. At progress 0 the Section
+ * reads exactly as the markup does, so this module failing to arrive costs the
+ * motion and nothing else.
+ */
+export default function stubTimeline(root: HTMLElement): gsap.core.Timeline {
+  const risen = root.querySelectorAll('[data-stub-rise]');
+  const timeline = gsap.timeline({ paused: true });
+
+  timeline.to(risen, {
+    y: (index: number) => -1 * (index + 1) * parseFloat(getComputedStyle(root).getPropertyValue('--stub-rise') || '8'),
+    opacity: 0.35,
+    duration: 1,
+    ease: 'none',
+    stagger: 0.05,
+  });
+
+  // A reader who asked for less motion gets the Section settled and nothing
+  // scrubbing. The Timeline still exists and is still seekable, so a Check reads
+  // the same numbers either way.
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return timeline;
+
+  ScrollTrigger.create({
+    trigger: root,
+    start: 'top top',
+    end: 'bottom bottom',
+    onUpdate: (self) => timeline.progress(self.progress),
+  });
+
+  return timeline;
+}

--- a/src/sections/stub/tokens.css
+++ b/src/sections/stub/tokens.css
@@ -1,0 +1,18 @@
+/* The stub Section's Tokens. Plain custom properties on the Section's own root,
+   and the only style file the Editor writes.
+   Every name is prefixed with the Section's, and there is nothing here but
+   custom properties — scripts/check-source.mjs fails the build otherwise, which
+   is what stops this file from quietly becoming a second stylesheet. */
+.stub {
+  --stub-height: 240svh;
+  --stub-measure: 34rem;
+  --stub-inset: 8vmin;
+  --stub-gap: 1.25rem;
+  --stub-heading-size: clamp(2.5rem, 9vmin, 6rem);
+  --stub-heading-weight: 400;
+  --stub-lead-size: 1.05rem;
+  --stub-lead-leading: 1.55;
+  --stub-point-size: 0.9rem;
+  --stub-rule: 1px;
+  --stub-rise: 8px;
+}

--- a/src/sections/stub/variants.css
+++ b/src/sections/stub/variants.css
@@ -1,0 +1,23 @@
+/* The stub Section's Variants: complete alternative directions, all present at
+   once and selected by attribute, so several can be rendered side by side and
+   chosen by eye. A Variant restates Tokens and nothing else — same rule as
+   tokens.css, same guard.
+
+   Two here, and they exist so the attribute is real rather than described. The
+   Section renders under whichever Variant [data-variant] names; with none named
+   it renders the direction in tokens.css. */
+
+[data-variant='tight'] .stub {
+  --stub-measure: 26rem;
+  --stub-gap: 0.75rem;
+  --stub-heading-size: clamp(2rem, 6vmin, 4rem);
+  --stub-lead-leading: 1.4;
+}
+
+[data-variant='airy'] .stub {
+  --stub-measure: 42rem;
+  --stub-inset: 14vmin;
+  --stub-gap: 2.25rem;
+  --stub-heading-size: clamp(3rem, 12vmin, 8rem);
+  --stub-lead-leading: 1.75;
+}

--- a/src/shell/Shell.astro
+++ b/src/shell/Shell.astro
@@ -1,0 +1,62 @@
+---
+// The Shell: the head, the Kernel, and the Sections' mount points. It holds no
+// composition of its own — every length, colour and word on the page belongs to
+// a Section or to the Kernel, and anything that looks like design being decided
+// here is a bug.
+import EffectStack from '../kernel/effect-stack/EffectStack.astro';
+import Kernel from '../kernel/Kernel.astro';
+import { THEME_KEY } from '../kernel/theme';
+
+interface Props {
+  title: string;
+  description: string;
+  /** The Effect Stack's layers, by name. Written here so the page opens already
+   *  treated instead of flashing untreated a script-load later. */
+  fx?: string;
+}
+
+const { title, description, fx = 'halftone paper' } = Astro.props;
+---
+
+<!doctype html>
+<html lang="en" data-fx={fx}>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{title}</title>
+    <meta name="description" content={description} />
+    <meta name="author" content="Christian Juresh" />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:type" content="profile" />
+    <meta property="og:site_name" content="Christian Juresh" />
+    <link
+      rel="icon"
+      href="data:image/svg+xml,%3Csvg%20xmlns='http://www.w3.org/2000/svg'%20viewBox='0%200%2032%2032'%3E%3Ctext%20x='16'%20y='23'%20font-family='Sitka%20Text,Charter,Iowan%20Old%20Style,Georgia,serif'%20font-size='19'%20text-anchor='middle'%20fill='%231a1917'%3Ecj%3C/text%3E%3C/svg%3E"
+    />
+    {/* The theme, before first paint. Inline and blocking on purpose: every
+        other script on the page is a deferred module, and a deferred module
+        means the reader sees the light page flash before the dark one arrives.
+        This is the whole reason the Shell has any inline script at all. */}
+    <script is:inline define:vars={{ THEME_KEY }}>
+      (() => {
+        let theme = 'light';
+        let stored = null;
+        try {
+          stored = localStorage.getItem(THEME_KEY);
+        } catch {}
+        if (stored === 'dark' || stored === 'light') theme = stored;
+        else if (window.matchMedia?.('(prefers-color-scheme: dark)').matches) theme = 'dark';
+        document.documentElement.setAttribute('data-theme', theme);
+      })();
+    </script>
+    <slot name="head" />
+  </head>
+  <body>
+    <Kernel />
+    <slot />
+    {/* Last in the body, and the position is load-bearing — see the note in
+        Kernel.astro. */}
+    <EffectStack />
+  </body>
+</html>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "astro/tsconfigs/strict",
+  "include": [".astro/types.d.ts", "src/**/*", "scripts/**/*", "astro.config.mjs"],
+  "exclude": ["dist", "design", "node_modules"],
+  "compilerOptions": {
+    "strictNullChecks": true,
+    "noUncheckedIndexedAccess": true,
+    // A Section's Content is typed so that renaming a field is a build error
+    // rather than a blank space on the page (ADR 0002). Unused locals are on so
+    // that a field left behind by a rename is one too.
+    "noUnusedLocals": true,
+    "noUnusedParameters": true
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,12 +1,22 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "cleanUrls": true,
+  "framework": null,
+  "installCommand": "pnpm install --frozen-lockfile",
+  "buildCommand": "pnpm build",
+  "outputDirectory": "dist",
   "redirects": [
     { "source": "/projects", "destination": "/portfolio#projects", "permanent": true },
     { "source": "/projects/", "destination": "/portfolio#projects", "permanent": true },
     { "source": "/projects/index.html", "destination": "/portfolio#projects", "permanent": true }
   ],
   "headers": [
+    {
+      "source": "/_astro/(.*)",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    },
     {
       "source": "/portfolio/img/(.*)",
       "headers": [


### PR DESCRIPTION
An Astro and TypeScript tree beside the live site rather than under it: /next
builds, renders a stub Section, and /portfolio is byte-identical in the output.

The Shell carries the head, the Kernel and the Sections' mount points and no
composition. The Kernel carries the faces, the theme and the Turn, the Effect
Stack's nine layers, the corner pictures and the Section loader — and is the only
thing in src/ allowed a global selector.

Two boundaries are the build's rather than a convention. A Section's rules live
in a scoped <style> the compiler rewrites; its Tokens and Variants are plain CSS
the compiler never sees, so what those files may contain is checked instead —
custom properties named for the Section, on the Section's own root, and nothing
else. Its Content is typed by a schema declared beside it, and the parse runs at
build time, so a renamed field fails the build from either side and an empty one
fails it too.

The Turn and each Section's motion are named seekable GSAP timelines on
window.portfolio, with hold()/release() beside them: a scrubbed timeline is
recomputed from the scroll a frame later, so seeking without holding first reads
as a timeline that will not move.

dist/ is assembled — Astro's output, then index.html, portfolio/, projects/ and
fonts/ copied in. A collision fails the build, which is what keeps /next off a
path /portfolio answers on.

Verified in headless Chromium: no console errors and no failed requests, the Turn
at 0 on load and 1 at the foot, both timelines seeking exactly, a mount point
four screens down still unmounted until scrolled to, the corner pictures picking
the dark ladder on a theme flip, seven of the nine layers inert, and /portfolio
still 200. The lazy mount cannot be seen in the in-app preview at all — it does
not run the rendering steps, so IntersectionObserver never delivers there.

Every version pinned exactly, no CI, no automated updates (ADR 0002).
