### PR TITLE
Generalise Variants, and render them into one sheet (#142)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,13 @@ photos/
 # every run, and nothing serves it.
 portfolio/img/tex/paper-seam-proof.png
 
+# the Variant sheet, and the renders it is assembled from. design/tools/
+# render-variants.mjs wipes and rewrites this directory on every run, and what it
+# holds is a picture of the source it was run against — so a committed copy could
+# only ever be a picture of a Variant that has since been rewritten, captioned
+# with the declarations it used to have. `pnpm variants` is a minute.
+design/sheets/
+
 # secrets — never commit
 .env
 .env.*
@@ -122,7 +129,8 @@ design/plinth/maps/
 # that still has this directory. Keep anything you care about elsewhere too.
 design/plinth/sources/
 
-# per-candidate plinth shots from ender.mjs --stones. 1.4MB each and
+# per-candidate plinth shots from 
+ender.mjs --stones. 1.4MB each and
 # regenerable in a minute; what is committed is the contact sheet built from
 # them, design/shots/plinth-stones.jpg.
 design/shots/*__stone-*.png

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,6 +190,20 @@ Timeline, and one mount point per Section. `scripts/check-source.mjs` is what
 turns those rules into build failures rather than hopes — it runs first in
 `pnpm build`, and on its own as `pnpm check:sections`.
 
+A Section's alternative directions are its **Variants**, and choosing between
+them is looking rather than describing:
+
+```bash
+pnpm variants
+```
+
+That renders every Variant of every Section into `design/sheets/index.html`,
+captioned with what each one declares. Two things about them are easy to get
+wrong and silent when you do — `:root` in a Variant's selector is what makes it
+outrank the composition it argues with, and nothing imports `variants.css`,
+because an unselected Variant has to cost the shipped page nothing.
+`docs/agents/variants.md` is the authority; read it before writing one.
+
 `IntersectionObserver` never delivers in the in-app browser pane, for the same
 reason `requestAnimationFrame` never ticks there: the pane does not run the
 rendering steps. Lazy mounting and motion have to be verified in a real headless

--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ pnpm install --frozen-lockfile
 pnpm build       # checks, typechecks, builds, assembles dist/
 pnpm preview     # serves that dist/ — of the tree it is run from
 pnpm dev         # Astro's dev server, with the static site beside it
+pnpm variants    # renders every Variant of every Section into one sheet
 ```
 
 `/next` is one document made of Sections. A **Section** owns its markup, styles,
@@ -255,11 +256,22 @@ rather than a convention: a Section's styles are scoped by the compiler, and its
 Content is typed, so renaming a field stops the build instead of blanking the
 page. `pnpm check:sections` is the rest of it.
 
+A Section can also carry **Variants**: several complete alternative directions,
+all present in the source at once and selected by an attribute, so that choosing
+between them is looking rather than describing. `pnpm variants` renders the whole
+matrix — every Variant of every Section, both themes — into one sheet at
+`design/sheets/index.html`, each picture captioned with what that Variant
+declares. The rejected ones stay in the source as the record of what was
+compared, and cost a reader nothing: nothing imports them, so they are not in the
+build at all. This is the general form of the typographic comparison in `design/`
+described above.
+
 Nothing at `/next` is live yet — it carries a stub Section, and `/portfolio` goes
 on being the document until the ticket that flips the route.
 
 Reading order for the detail: `CONTEXT.md` for the vocabulary, `docs/adr/` for the
 decisions, then `src/kernel/NOTES.md` and `src/sections/stub/NOTES.md`.
+`docs/agents/variants.md` is the Variants and the sheet.
 
 ## Deployment
 

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -45,6 +45,20 @@ export default defineConfig({
   // /next, not /next/index.html — vercel.json's cleanUrls serves the directory
   // form at the bare path.
   build: { format: 'directory' },
+  // Astro scopes a component's rules by narrowing every compound in them, and
+  // the DEFAULT strategy narrows with a bare attribute selector — which adds
+  // (0,1,0) of specificity per compound. That makes a scoped rule's weight grow
+  // with the length of its selector, and a Variant, which is one fixed gate in
+  // front of the same selector, then wins or loses depending on how many
+  // compounds the composition happened to write. `.stub__points li` was an exact
+  // tie, settled by whichever stylesheet the bundler emitted second.
+  //
+  // `where` wraps the same attribute in :where(), so it selects identically and
+  // weighs nothing. Scoped rules keep the specificity they are written with, and
+  // `:root[data-variant='…']` in front of one always outranks it by (0,2,0) —
+  // which is the whole mechanism a Variant is selected by. See
+  // src/sections/stub/NOTES.md.
+  scopedStyleStrategy: 'where',
   devToolbar: { enabled: false },
   vite: { plugins: [servesTheExistingSite()] },
 });

--- a/design/README.md
+++ b/design/README.md
@@ -3,6 +3,15 @@
 Dev-only. Nothing here is served by the site; `.vercelignore` keeps the whole
 folder out of deployments. The site itself stays dependency-free and build-free.
 
+**Two things called variants live here, and they are not the same thing.**
+`variants.css` and `tools/render.mjs` are the typographic comparison this folder
+was built for: eight variants of one type stack, across `/portfolio`, which is a
+plain static tree with no Sections in it. They are kept as that comparison was
+judged. `tools/render-variants.mjs` is the general mechanism it became — a
+**Variant** is any complete alternative direction for a Section, declared in that
+Section's own `variants.css`, and `pnpm variants` renders them all into
+`sheets/index.html`. See [`../docs/agents/variants.md`](../docs/agents/variants.md).
+
 **Outcome: `sitka` won**, with two exceptions the lab shows too — the year column,
 kept in Georgia because its old-style figures reach 78% of the cap height beside
 them where Sitka's lining figures stand to 84%, and the italic lead paragraph,
@@ -27,7 +36,9 @@ now stands relative to a base that has moved.
 
 ```
 design/
-  variants.css       every variant, defined ONCE — the source of truth
+  variants.css       every TYPE variant, defined ONCE — the source of truth.
+                     Not the same thing as a Section's Variants: see the note
+                     under this tree
   type-lab.html      interactive: flip variants on the real pages in a browser
   type-tuner.html    interactive: free-form size/spacing/font sliders + CSS export
   layout-tuner.html  interactive: drag and resize every box in the Projects Panel
@@ -35,6 +46,14 @@ design/
                      export says where each box ended up in pixels, in shares of
                      --panel-w, and on the composition's own grid lines
   shots/             committed renders + index.html contact sheet
+  sheets/            the Variant sheet — /next's Sections rendered under every
+                     Variant they declare, captioned with what each one changes.
+                     Written by tools/render-variants.mjs, wiped on every run and
+                     not committed
+  tools/
+    render-variants.mjs  `pnpm variants`. The general form of render.mjs below:
+                     any Section, any number of Variants, layout and palette and
+                     motion rather than only type. docs/agents/variants.md
   plate/
     build-plate.py   develops a source into portfolio/img/<stem>-*.webp — the grade
     plate-tuner.html interactive: the same pipeline on sliders + Python/CSS export

--- a/design/tools/render-variants.mjs
+++ b/design/tools/render-variants.mjs
@@ -114,6 +114,10 @@ const out = resolve(ROOT, opt.out || join('design', 'sheets'));
 for (const key of viewKeys) if (!VIEWPORTS[key]) fail(`unknown viewport "${key}" — have: ${Object.keys(VIEWPORTS).join(', ')}`);
 for (const p of progresses) if (!Number.isFinite(p) || p < 0 || p > 1) fail(`--progress takes numbers from 0 to 1, not "${p}"`);
 if (turn !== null && (!Number.isFinite(turn) || turn < 0 || turn > 1)) fail('--turn takes a number from 0 to 1');
+/* Git Bash rewrites a lone `/next` into a Windows path on the way in, and the
+   error that comes out the far end is Chromium's `Cannot navigate to invalid
+   URL` against a mangled origin, which reads as anything but a shell problem. */
+if (!route.startsWith('/')) fail(`--route must begin with "/" — got "${route}". A POSIX shell on Windows may have rewritten it`);
 for (const theme of themes) if (theme !== 'light' && theme !== 'dark') fail(`unknown theme "${theme}" — have: light, dark`);
 
 /* ---- what the Sections declare ------------------------------------------

--- a/design/tools/render-variants.mjs
+++ b/design/tools/render-variants.mjs
@@ -1,0 +1,463 @@
+/* ============================================================================
+   render-variants.mjs — render every Variant of every Section into one sheet.
+
+     pnpm variants
+     pnpm variants -- --sections stub --variants split,plate
+     pnpm variants -- --progress 0,0.5,1        # a Variant that is only motion
+     pnpm variants -- --turn 1                  # past the crossing into dark
+     pnpm variants -- --viewports desktop,mobile --themes light
+     pnpm variants -- --format jpeg              # a wide matrix, a fifth the bytes
+
+   Choosing between Variants is looking, not describing, and this is the looking:
+   the matrix rendered and assembled into design/sheets/index.html, captioned
+   with what each Variant actually declares so the choice can be made without
+   opening a file.
+
+   THIS SCRIPT DEFINES NO STYLING. Every Variant it renders is written in a
+   Section's own variants.css and selected by the attribute that file's selectors
+   gate on. What is here is the matrix, the harness, and the sheet.
+
+   Three things about it that are decisions rather than details:
+
+   IT SERVES THE dist/ OF THE TREE IT IS RUN FROM, for the reason
+   scripts/serve-dist.mjs exists at all — the in-app preview serves the main
+   checkout, so in a worktree it reports on `development` while looking like it
+   reports on the branch. It needs `pnpm build` to have run and says so.
+
+   THE VARIANT SHEET IS INJECTED, NOT BUILT IN. Nothing imports variants.css —
+   that is what makes an unselected Variant cost the shipped page nothing, and
+   check-source.mjs fails the build if anything starts to. So this reads the file
+   off disk and puts it into the page itself, as a <style> written before any of
+   the page's own scripts run. Not a <link>: a Section's Timeline reads Tokens
+   with getComputedStyle as it mounts, and a stylesheet that is still in flight at
+   that moment would silently give it the shipped value under a Variant's name.
+
+   IT ASKS THE TIMELINE FOR THE MOMENT, WITH hold() FIRST. A scrubbed Timeline is
+   recomputed from the scroll position on the next tick, so a bare seek survives
+   about one frame — src/kernel/NOTES.md has the whole of that, and it cost a
+   wrong diagnosis once already.
+
+   Playwright resolves out of design/tools/node_modules, like every other tool in
+   this directory:  npm --prefix design/tools install
+   ========================================================================== */
+
+import { createReadStream, statSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { mkdir, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+import { contentType, resolveFile } from '../../scripts/static-tree.mjs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, '..', '..');
+const DIST = join(ROOT, 'dist');
+const SECTIONS = join(ROOT, 'src', 'sections');
+
+/* ---- the matrix --------------------------------------------------------- */
+
+/** The route the Sections are on. Temporary by construction — /portfolio is
+ *  still the live document, and the ticket that flips the route moves this. */
+const ROUTE = '/next';
+
+const VIEWPORTS = {
+  desktop: { width: 1280, height: 900 },
+  tablet: { width: 820, height: 1000 },
+  mobile: { width: 390, height: 844 },
+};
+
+/* ---- args --------------------------------------------------------------- */
+
+function fail(message) {
+  console.error(`error: ${message}`);
+  process.exit(1);
+}
+
+function args(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (!argv[i].startsWith('--')) continue;
+    const key = argv[i].slice(2);
+    out[key] = argv[i + 1] && !argv[i + 1].startsWith('--') ? argv[++i] : 'true';
+  }
+  return out;
+}
+
+const opt = args(process.argv.slice(2));
+const list = (value, fallback) =>
+  value ? value.split(',').map((one) => one.trim()).filter(Boolean) : fallback;
+
+const wanted = {
+  sections: list(opt.sections, null),
+  variants: list(opt.variants, null),
+};
+const themes = list(opt.themes, ['light', 'dark']);
+const viewKeys = list(opt.viewports, ['desktop']);
+const progresses = list(opt.progress, ['0']).map(Number);
+/** The Turn is the Kernel's, not a Section's, so it is pinned rather than
+ *  crossed: one value for the whole run, or left where the scroll put it. */
+const turn = opt.turn === undefined ? null : Number(opt.turn);
+const scale = Number(opt.scale || 1);
+const route = opt.route || ROUTE;
+const full = opt.full === 'true';
+/* PNG is faithful and PNG is what these cost: the Effect Stack's grain and
+   halftone are noise by construction, so a screen of nearly blank paper comes
+   out at over a megabyte and a full matrix at forty. JPEG is a fifth of that and
+   smears the grain, which is the one thing on the page nobody chooses a Variant
+   on — so it is the right answer for a wide matrix and the wrong one for judging
+   a texture. Hence a flag rather than a default. */
+const format = (opt.format || 'png').toLowerCase();
+const quality = Number(opt.quality || 92);
+if (format !== 'png' && format !== 'jpeg') fail('--format must be png or jpeg');
+const out = resolve(ROOT, opt.out || join('design', 'sheets'));
+
+for (const key of viewKeys) if (!VIEWPORTS[key]) fail(`unknown viewport "${key}" — have: ${Object.keys(VIEWPORTS).join(', ')}`);
+for (const p of progresses) if (!Number.isFinite(p) || p < 0 || p > 1) fail(`--progress takes numbers from 0 to 1, not "${p}"`);
+if (turn !== null && (!Number.isFinite(turn) || turn < 0 || turn > 1)) fail('--turn takes a number from 0 to 1');
+for (const theme of themes) if (theme !== 'light' && theme !== 'dark') fail(`unknown theme "${theme}" — have: light, dark`);
+
+/* ---- what the Sections declare ------------------------------------------
+   Read off the source rather than listed here, for the reason the Kernel's
+   loader globs for a Section's Timeline instead of keeping a register: adding a
+   Variant is writing one, and there is nowhere to forget to add it. */
+
+const COMMENTS = /\/\*[\s\S]*?\*\//g;
+const RULE = /([^{}]+)\{([^{}]*)\}/g;
+const GATE = /:root\[data-variant=(?:'([^']*)'|"([^"]*)"|([^\]]*))\]/;
+
+/** A Variant's rules, as CSS, keyed by the name its selectors gate on. */
+function byVariant(css) {
+  const found = new Map();
+  for (const [, selector, body] of css.replace(COMMENTS, '').matchAll(RULE)) {
+    const gate = GATE.exec(selector);
+    if (!gate) continue;
+    const name = (gate[1] ?? gate[2] ?? gate[3] ?? '').trim();
+    const rule = `${selector.trim().replace(/\s*\n\s*/g, '\n')} {${body.replace(/\s+$/, '')}\n}`;
+    found.set(name, [...(found.get(name) ?? []), rule]);
+  }
+  return found;
+}
+
+/** The declarations of a flat stylesheet, for the sheet to caption `base` with. */
+function declarations(css) {
+  const found = [];
+  for (const [, , body] of css.replace(COMMENTS, '').matchAll(RULE)) {
+    for (const declaration of body.split(';')) {
+      const trimmed = declaration.trim().replace(/\s+/g, ' ');
+      if (trimmed) found.push(`${trimmed};`);
+    }
+  }
+  return found.join('\n');
+}
+
+/** A Variant may reach for one of its Section's own assets, and a relative URL
+ *  in an injected <style> would resolve against the page instead of the sheet. */
+function absoluteUrls(css, base) {
+  return css.replace(/url\(\s*(['"]?)(?!data:|https?:|\/)/g, (_, quote) => `url(${quote}${base}`);
+}
+
+async function present(path) {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function declaredVariants() {
+  const found = [];
+  for (const entry of await readdir(SECTIONS, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    if (wanted.sections && !wanted.sections.includes(entry.name)) continue;
+    const dir = join(SECTIONS, entry.name);
+    if (!(await present(join(dir, 'variants.css')))) continue;
+    const css = await readFile(join(dir, 'variants.css'), 'utf8');
+    const tokens = await readFile(join(dir, 'tokens.css'), 'utf8');
+    const rules = byVariant(css);
+    let names = [...rules.keys()];
+    if (wanted.variants) names = names.filter((name) => wanted.variants.includes(name));
+    found.push({
+      name: entry.name,
+      // `base` first and always: the direction that ships is the thing every
+      // Variant is an argument against, so it belongs in the picture beside them.
+      names: ['base', ...names],
+      rules,
+      tokens: declarations(tokens),
+      style: absoluteUrls(css.replace(COMMENTS, ''), `/src/sections/${entry.name}/`),
+    });
+  }
+  return found;
+}
+
+/* ---- the server: dist/, plus src/ for a Variant's own assets ------------ */
+
+function serve() {
+  const server = createServer((request, response) => {
+    const pathname = (request.url ?? '/').split('?')[0];
+    const file = pathname.startsWith('/src/')
+      ? resolveFile(ROOT, pathname, { statSync })
+      : resolveFile(DIST, pathname, { statSync });
+    if (!file) {
+      response.statusCode = 404;
+      response.end('not found\n');
+      return;
+    }
+    response.setHeader('content-type', contentType(file));
+    createReadStream(file)
+      .on('error', () => response.destroy())
+      .pipe(response);
+  });
+  // An ephemeral port, but not any ephemeral port. Chromium refuses to navigate
+  // to about eighty low ports outright — ERR_UNSAFE_PORT, which reads as a
+  // broken page rather than as a bad number — and this machine's dynamic range
+  // starts inside them. Every blocked port is under 10081, so ask again until
+  // the kernel offers one above them.
+  return new Promise((ok) => {
+    const listen = () =>
+      server.listen(0, '127.0.0.1', () => {
+        if (server.address().port >= 10100) return ok(server);
+        server.close(listen);
+      });
+    listen();
+  });
+}
+
+/* ---- the page ----------------------------------------------------------- */
+
+/** Written before any of the page's own scripts run: the attribute a Variant is
+ *  selected by, and the sheet that reads it. A MutationObserver because at
+ *  document start there is no documentElement to hang either off yet. */
+const INJECT = (variant, css) => `
+  new MutationObserver((_, o) => {
+    if (!document.documentElement) return;
+    ${variant === 'base' ? '' : `document.documentElement.setAttribute("data-variant", ${JSON.stringify(variant)});`}
+    const style = document.createElement("style");
+    style.textContent = ${JSON.stringify(css)};
+    (document.head || document.documentElement).appendChild(style);
+    o.disconnect();
+  }).observe(document, { childList: true, subtree: true });
+`;
+
+/** Two shots of the same Variant should differ only where the Variant does. */
+const STILL = `
+  *, *::before, *::after {
+    animation: none !important;
+    transition: none !important;
+    caret-color: transparent !important;
+  }
+`;
+
+async function settle(page, section) {
+  await page.waitForLoadState('load');
+  if ((await page.locator(`[data-section="${section}"]`).count()) === 0) {
+    fail(`the ${section} Section is not on ${route} — nothing mounts it, so there is nothing to render`);
+  }
+  // The Section's top at the top of the window: where its own Timeline starts,
+  // and the one scroll position every shot of it can share.
+  await page.evaluate((name) => {
+    const root = document.querySelector(`[data-section="${name}"]`);
+    window.scrollTo(0, Math.round(root.getBoundingClientRect().top + window.scrollY));
+  }, section);
+  // Mounting is what fetches the Timeline, so this has to be waited for and not
+  // guessed at. IntersectionObserver delivers in a real headless browser; it
+  // never does in the in-app preview pane, which is why this tool exists rather
+  // than a preview.
+  await page.waitForSelector(`[data-section="${section}"][data-mounted="true"]`);
+  await page.waitForFunction(() => Boolean(window.portfolio?.hold));
+  await page.evaluate(async () => {
+    await document.fonts.ready;
+  });
+  await page.addStyleTag({ content: STILL });
+}
+
+async function moment(page, section, progress) {
+  return page.evaluate(
+    ([name, p, t]) => {
+      const kernel = window.portfolio;
+      // hold() first, or the scroll recomputes the frame a tick later and the
+      // shot is of whatever the page settled back to.
+      kernel.hold();
+      kernel.timelines.get(name)?.progress(p);
+      if (t !== null) kernel.timelines.get('turn')?.progress(t);
+
+      const root = document.querySelector(`[data-section="${name}"]`);
+      const box = root.getBoundingClientRect();
+      const heading = root.querySelector('h1, h2, h3');
+      const style = heading ? getComputedStyle(heading) : null;
+      return {
+        box: `${Math.round(box.width)}×${Math.round(box.height)}`,
+        face: style ? style.fontFamily.split(',')[0].replace(/["']/g, '') : '—',
+        size: style ? `${Math.round(parseFloat(style.fontSize) * 10) / 10}px` : '',
+        turn: Math.round(Number(getComputedStyle(document.documentElement).getPropertyValue('--turn')) * 100) / 100,
+      };
+    },
+    [section, progress, turn],
+  );
+}
+
+/* ---- the sheet ---------------------------------------------------------- */
+
+function escape(text) {
+  return String(text).replace(/[&<>]/g, (one) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' })[one]);
+}
+
+async function sheet(rows, declared) {
+  const groups = new Map();
+  for (const row of rows) {
+    const key =
+      `${row.section} · ${row.viewport} · ${row.theme}` +
+      (progresses.length > 1 ? ` · progress ${row.progress}` : '');
+    groups.set(key, [...(groups.get(key) ?? []), row]);
+  }
+
+  const source = new Map(declared.map((one) => [one.name, one]));
+  const css = (row) => {
+    const section = source.get(row.section);
+    if (row.variant === 'base')
+      return `/* tokens.css — the direction that ships */\n${section.tokens}`;
+    return (section.rules.get(row.variant) ?? []).join('\n\n');
+  };
+
+  const figures = (key) =>
+    groups
+      .get(key)
+      .map(
+        (row) => `
+        <figure>
+          <figcaption>
+            <b>${escape(row.variant)}</b>
+            <span>${escape(row.face)} ${escape(row.size)} · ${escape(row.box)} · turn ${escape(row.turn)}</span>
+          </figcaption>
+          <a href="${row.file}" target="_blank" rel="noopener"
+            ><img src="${row.file}" alt="${escape(row.section)} under ${escape(row.variant)}" loading="lazy"
+          /></a>
+          <pre>${escape(css(row))}</pre>
+        </figure>`,
+      )
+      .join('');
+
+  const html = `<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Variants — the sheet</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { margin: 0; padding: 1.5rem; font: 13px/1.55 "Segoe UI", system-ui, sans-serif; }
+  h1 { font-size: 1.1rem; margin: 0 0 0.2rem; }
+  .meta { opacity: 0.65; margin: 0 0 1.5rem; max-width: 70ch; }
+  h2 { font-size: 0.78rem; letter-spacing: 0.08em; text-transform: uppercase; opacity: 0.6; margin: 2.2rem 0 0.6rem; }
+  .strip { display: flex; gap: 1rem; overflow-x: auto; padding-bottom: 0.5rem; align-items: flex-start; }
+  figure { margin: 0; flex: 0 0 auto; width: 460px; display: flex; flex-direction: column; gap: 0.35rem; }
+  figcaption { display: flex; justify-content: space-between; gap: 0.5rem; align-items: baseline; }
+  figcaption b { font-size: 0.95rem; }
+  figcaption span { opacity: 0.6; font-family: ui-monospace, monospace; font-size: 11px; text-align: right; }
+  img { width: 100%; height: auto; border: 1px solid rgba(128,128,128,0.35); border-radius: 4px; display: block; }
+  /* Capped and scrolling, so a Variant that declares a lot does not push the
+     next group's pictures out of line with this one's. Comparing them is the
+     entire point of a strip. */
+  pre { margin: 0; padding: 0.6rem 0.7rem; max-height: 13rem; overflow: auto;
+        font-family: ui-monospace, monospace; font-size: 11px; line-height: 1.5;
+        border: 1px solid rgba(128,128,128,0.25); border-radius: 4px;
+        background: rgba(128,128,128,0.08); }
+</style></head>
+<body>
+  <h1>Variants</h1>
+  <p class="meta">${rows.length} render${rows.length === 1 ? '' : 's'} of ${route}, at ${scale}x, by
+     <code>design/tools/render-variants.mjs</code>. Under each picture is what that
+     Variant declares and nothing else, so the choice can be made here rather than
+     in the files. <b>base</b> is the direction that ships — what is in
+     <code>tokens.css</code>, with no Variant selected. Click a picture for full
+     size. Every run rewrites this directory.</p>
+${/* In the order the run made them — viewport, then theme, then Section — rather
+      than alphabetically, which would put dark before light for no reason. */
+   [...groups.keys()].map((key) => `    <section><h2>${escape(key)}</h2><div class="strip">${figures(key)}</div></section>`).join('\n')}
+</body></html>
+`;
+  await writeFile(join(out, 'index.html'), html, 'utf8');
+}
+
+/* ---- run ---------------------------------------------------------------- */
+
+if (!(await present(DIST))) {
+  fail('dist/ does not exist — run `pnpm build` first, in this tree');
+}
+
+const declared = await declaredVariants();
+if (declared.length === 0) fail('no Section declares a Variant to render');
+
+// Wiped rather than written over. The sheet is one command's output and is
+// regenerable in a minute, so a directory holding half of one run and half of
+// another would only ever be a way to look at a picture that is not there.
+await rm(out, { recursive: true, force: true });
+await mkdir(out, { recursive: true });
+
+const server = await serve();
+const origin = `http://127.0.0.1:${server.address().port}`;
+const browser = await chromium.launch();
+const rows = [];
+const total =
+  viewKeys.length *
+  themes.length *
+  progresses.length *
+  declared.reduce((sum, one) => sum + one.names.length, 0);
+
+console.log(`serving ${DIST}\n  on ${origin}${route}`);
+console.log(
+  `rendering ${total} shot(s) — ${declared.map((one) => `${one.name} (${one.names.length})`).join(', ')}` +
+    ` x ${themes.length} theme(s) x ${viewKeys.length} viewport(s) x ${progresses.length} moment(s)\n`,
+);
+
+let n = 0;
+for (const viewport of viewKeys) {
+  for (const theme of themes) {
+    for (const section of declared) {
+      for (const variant of section.names) {
+        const context = await browser.newContext({
+          viewport: VIEWPORTS[viewport],
+          deviceScaleFactor: scale,
+          colorScheme: theme,
+        });
+        // The Shell reads this before first paint, so it has to be here rather
+        // than set on the page afterwards.
+        await context.addInitScript(
+          `try { localStorage.setItem("portfolio-theme", "${theme}"); } catch (e) {}`,
+        );
+        await context.addInitScript(INJECT(variant, section.style));
+        const page = await context.newPage();
+        await page.goto(origin + route, { waitUntil: 'load' });
+        await settle(page, section.name);
+
+        for (const progress of progresses) {
+          const info = await moment(page, section.name, progress);
+          const file =
+            `${section.name}__${variant}__${theme}__${viewport}` +
+            (progresses.length > 1 || progress !== 0 ? `__p${Math.round(progress * 100)}` : '') +
+            (turn === null ? '' : `__turn${Math.round(turn * 100)}`) +
+            `.${format}`;
+          const target = {
+            path: join(out, file),
+            ...(format === 'jpeg' ? { type: 'jpeg', quality } : { type: 'png' }),
+          };
+          if (full) await page.locator(`[data-section="${section.name}"]`).screenshot(target);
+          else await page.screenshot(target);
+          const bytes = (await stat(join(out, file))).size;
+          rows.push({ section: section.name, variant, theme, viewport, progress, file, ...info });
+          console.log(
+            `  [${String(++n).padStart(String(total).length)}/${total}] ${file}` +
+              `  ${info.face} ${info.size} · ${info.box} · turn ${info.turn}` +
+              `  (${Math.round(bytes / 1024)} KB)`,
+          );
+        }
+        await context.close();
+      }
+    }
+  }
+}
+
+await browser.close();
+server.close();
+await sheet(rows, declared);
+
+console.log(`\nwrote ${rows.length} shot(s) + index.html to ${opt.out || 'design/sheets'}/`);
+console.log('open design/sheets/index.html — the sheet');

--- a/docs/agents/variants.md
+++ b/docs/agents/variants.md
@@ -1,0 +1,137 @@
+# Variants, and the sheet
+
+**Variant** — one of several complete alternative directions for a Section, all
+present in the source at once, selected by attribute so they can be rendered side
+by side and chosen by eye. The losers stay as the record of what was judged.
+(`CONTEXT.md`.)
+
+This is the authority on writing one and on the tool that renders them. It is
+short because the two mechanisms are small; what is long is the reasoning for the
+three things in them that are decisions.
+
+## Writing one
+
+A Section's Variants live in its own `variants.css`, one file per Section, any
+number of Variants in it. Every selector reads:
+
+```css
+:root[data-variant='split'] .stub__points li { flex: 1 1 0 }
+└──────── the gate ────────┘ └── owned ──┘ └ its descendants ┘
+```
+
+- **the gate** — `:root[data-variant='<name>']`, exactly. Lower case, digits and
+  dashes in the name.
+- **owned** — the compound straight after the gate must be the Section's:
+  `.stub`, `.stub__…`, or `[data-stub-…]`.
+- **after that** — anything. `li`, `:first-child`, `> .stub__measure`. It is all a
+  descendant of something the Section owns, so it can match nothing outside it.
+- **no sibling combinator** anywhere. A sibling of a Section's root is another
+  Section.
+- **declare anything** — layout, palette, surface, a motion distance. Custom
+  properties are the one exception: they inherit, so they have to be named
+  `--stub-…`.
+- **no at-rules.** The file is a flat list of rules. A Variant is a direction, not
+  something that arrives at a width; a direction that only holds on one viewport
+  is two Variants.
+
+`scripts/check-source.mjs` is all of that as a build failure, and `pnpm
+check:sections` is it on its own.
+
+## Rendering them
+
+```bash
+pnpm build          # once — the sheet is rendered against dist/
+pnpm variants       # every Variant of every Section, both themes, one sheet
+```
+
+Then open `design/sheets/index.html`. Under each picture is what that Variant
+declares and nothing else, so the choice is made there rather than in the files.
+`base` is the direction that ships — `tokens.css`, with no Variant selected — and
+it is in every strip, because it is the thing each Variant is an argument against.
+
+```bash
+pnpm variants -- --sections stub --variants split,plate
+pnpm variants -- --progress 0,0.5,1     # a Variant that is only visible in motion
+pnpm variants -- --turn 1               # past the Kernel's crossing into dark
+pnpm variants -- --viewports desktop,tablet,mobile --format jpeg
+pnpm variants -- --full                 # the whole Section, not its first screen
+```
+
+`--format jpeg` is a fifth of the bytes and worth it past about a dozen shots:
+the Effect Stack's grain and halftone are noise by construction, so a screen of
+near-blank paper is over a megabyte of PNG. It smears the grain, which is the one
+thing on the page nobody chooses a Variant on.
+
+## The three things that are decisions
+
+**`:root` is what makes a Variant win.** Astro narrows every compound of a scoped
+rule, and its default strategy narrows with a bare attribute selector worth
+(0,1,0) *per compound* — so a scoped rule's weight grows with the length of its
+selector, and a Variant, which is one fixed gate in front of the same selector,
+wins or loses depending on how many compounds the composition happened to write.
+`.stub__points li` was an exact tie, settled by whichever stylesheet the bundler
+emitted second. So `astro.config.mjs` sets `scopedStyleStrategy: 'where'`, which
+selects identically and weighs nothing, and the gate then outranks the
+composition by (0,2,0) in every case. **Both halves are load-bearing.** Change
+either and Variants start losing silently, which reads as a Variant that "did not
+apply".
+
+**Nothing imports `variants.css`.** That is the whole of an unselected Variant
+costing the shipped page nothing: the file is not in the build, so rejected
+directions are not bytes a reader fetches, not selectors a browser matches, and
+not in `dist/`. The render tool reads the file off disk and injects it as a
+`<style>` written before any of the page's own scripts run — a `<link>` would
+still be in flight when a Section's Timeline reads its Tokens with
+`getComputedStyle`, which would hand it the shipped value under a Variant's name.
+`check-source.mjs` fails the build if an import is ever added back.
+
+**The sheet shoots the first screen of a Section, held at a moment.** A Section is
+taller than a screen — the stub is 240svh, because its Timeline is scrubbed by its
+own scroll — so the shot is the Section's top at the top of the window, which is
+what a reader arriving at it sees. Two consequences:
+
+- A Variant that centres anything *vertically* centres it in that whole box and
+  out of the frame. The picture comes back as empty paper, and it is right: the
+  Variant put the composition off screen. `--full` shoots the element instead.
+- The moment is reached by `hold()` and then seeking the Section's Timeline, per
+  `src/kernel/NOTES.md`. A bare seek survives about one frame, and that cost a
+  wrong diagnosis once already.
+
+## Traps
+
+**`IntersectionObserver` never delivers in the in-app browser pane**, which is
+also where `requestAnimationFrame` never ticks: the pane does not run the
+rendering steps. A Section mounts on approach, so nothing mounts there and no
+Timeline is ever registered. This tool drives real headless Chromium; do not
+try to verify a Variant in the preview.
+
+**It serves the `dist/` of the tree it is run from**, which is why it exists
+rather than `preview_start` — the in-app preview serves the main checkout, so in
+a worktree it reports on `development` while looking like it reports on your
+branch. Run `pnpm build` in the same tree first; the tool says so if `dist/` is
+missing.
+
+**`design/sheets/` is wiped on every run** and is not committed. It is a picture
+of the source it was run against, so a kept copy could only ever be a picture of
+a Variant that has since been rewritten, captioned with the declarations it used
+to have.
+
+**Playwright resolves from `design/tools/node_modules`**, like every other tool
+in that directory, and it is not what `pnpm install` at the root installs:
+
+```bash
+npm --prefix design/tools install
+```
+
+A worktree does not get it at all — the directory is gitignored — so a fresh one
+needs either that install or a junction to the main checkout's copy.
+
+## Not to be confused with
+
+`design/variants.css` and `design/tools/render.mjs` are the *typographic*
+comparison this generalises, and they are still there and still work: eight
+variants of one type stack across `/portfolio`, which is a plain static tree with
+no Sections in it. They are kept as the comparison was judged. A Section's
+Variants are the mechanism that replaces them once `/next` replaces
+`/portfolio` — the same idea, no longer only about type, and per Section rather
+than per site.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "astro dev",
     "build": "node scripts/check-source.mjs && astro check && astro build && node scripts/assemble-dist.mjs",
     "preview": "node scripts/serve-dist.mjs",
+    "variants": "node design/tools/render-variants.mjs",
     "check:sections": "node scripts/check-source.mjs",
     "check:types": "astro check"
   },

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,5 +10,15 @@ saveExact: true
 # esbuild ships a platform binary it fetches in a postinstall script. pnpm blocks
 # build scripts by default and asks; naming it here answers once. Nothing else in
 # the tree is allowed to run one.
+#
+# BOTH KEYS, and `allowBuilds` really does have to be a boolean. pnpm 11 writes
+# the placeholder `set this to true or false` into this file itself and then reads
+# it as "still undecided" — so every install ends ERR_PNPM_IGNORED_BUILDS and
+# exits 1, and because pnpm checks the dependency state before running any
+# script, EVERY `pnpm <script>` in the repository fails before it starts. It does
+# not look like a config problem: it looks like `pnpm build` being broken.
 onlyBuiltDependencies:
   - esbuild
+
+allowBuilds:
+  esbuild: true

--- a/scripts/check-source.mjs
+++ b/scripts/check-source.mjs
@@ -51,6 +51,56 @@ function withoutComments(source) {
   return source.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/^\s*\/\/.*$/gm, ' ');
 }
 
+/** Every module specifier in a source file, from either import form. */
+function imports(code) {
+  const found = [];
+  for (const [, specifier] of code.matchAll(/\bfrom\s+['"]([^'"]+)['"]/g)) found.push(specifier);
+  for (const [, specifier] of code.matchAll(/\bimport\s+['"]([^'"]+)['"]/g)) found.push(specifier);
+  return found;
+}
+
+/**
+ * A selector split into its compounds, on the combinators between them — or
+ * null if it uses a sibling combinator.
+ *
+ * The split has to know about brackets and quotes, because `[data-x~='a']` and
+ * `:is(a + b)` both carry characters that mean something else at the top level.
+ * Sibling combinators are refused outright rather than reasoned about: the
+ * guarantee below is that a Variant's rule can only match inside its own
+ * Section, and a sibling of a Section's root is another Section.
+ */
+function compounds(selector) {
+  const parts = [];
+  let current = '';
+  let depth = 0;
+  let quote = null;
+  for (const character of selector) {
+    if (quote) {
+      current += character;
+      if (character === quote) quote = null;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+      current += character;
+      continue;
+    }
+    if (character === '[' || character === '(') depth += 1;
+    if (character === ']' || character === ')') depth -= 1;
+    if (depth === 0) {
+      if (character === '+' || character === '~') return null;
+      if (character === '>' || /\s/.test(character)) {
+        if (current) parts.push(current);
+        current = '';
+        continue;
+      }
+    }
+    current += character;
+  }
+  if (current) parts.push(current);
+  return parts;
+}
+
 // ---------------------------------------------------------------------------
 // A Section is a folder, and the folder shape is the same every time.
 // ---------------------------------------------------------------------------
@@ -64,12 +114,77 @@ const SOURCE = /\.(astro|ts|css)$/;
 /** A Section may read its own folder and the Kernel. Nothing else. */
 const ALLOWED_IMPORT = /^(?:\.\/|gsap(?:\/|$)|astro(?:\/|$)|\.\.\/\.\.\/kernel\/)/;
 
+/** Nothing in a Section imports variants.css: the sheet is not part of the build
+ *  at all, which is what makes an unselected Variant cost the shipped page
+ *  nothing. design/tools/render-variants.mjs injects it at render time. */
+const VARIANT_SHEET = /(^|\/)variants\.css$/;
+
 /** `is:global` and `:global(` are the escape hatches out of Astro's scoping. */
 const SCOPE_ESCAPES = [
   [/\bis:global\b/, 'is:global — a Section may not write a global rule'],
   [/:global\s*\(/, ':global() — a Section may not write a global rule'],
   [/<style[^>]*\bis:inline\b/, '<style is:inline> — an inline style block is not scoped'],
 ];
+
+/** One top-level `selector { … }`. Both stylesheets are a flat list of them, and
+ *  the check just above the loop is what makes that an assertion. Global, so
+ *  that stripping every rule out of the file really does strip every one —
+ *  without the flag `replace` takes the first and the leftover reads as an
+ *  error in every file that has more than one rule in it. */
+const RULE = /([^{}]+)\{([^{}]*)\}/g;
+
+/** How a Variant is selected: an attribute on the document's root element.
+ *
+ *  `:root` is not decoration and not a habit. It is what makes a Variant win.
+ *  Together with `scopedStyleStrategy: 'where'` in astro.config.mjs it is the
+ *  whole of the mechanism: that strategy narrows a component's rules with
+ *  :where(), which weighs nothing, so a scoped rule keeps the specificity it is
+ *  written with and `:root[data-variant='…']` in front of the same selector
+ *  outranks it by (0,2,0) every time. Drop either half and a Variant starts
+ *  winning or losing on how many compounds the composition happened to write —
+ *  which reads as a Variant that "did not apply". docs/agents/variants.md. */
+const VARIANT_GATE = /^:root\[data-variant=(?:'([^']*)'|"([^"]*)"|([^\]]*))\]$/;
+
+/**
+ * Every compound after the gate has to be one the Section owns, and only the
+ * first one does: `.stub__points li` can match nothing outside `.stub__points`,
+ * which is why the rest of a selector is the Variant's business.
+ */
+function ownedBy(section, compound) {
+  return new RegExp(`^(?:\\.${section}(?:__[a-z0-9-]+)*|\\[data-${section}-[a-z0-9-]+\\])`).test(compound);
+}
+
+/**
+ * A Variant's selector: the gate, then something this Section owns, then
+ * whatever the direction needs.
+ *
+ * That grammar is the boundary. It is not that a Variant may not write a
+ * layout — it must be able to, or a Variant is a set of Tokens by another name —
+ * it is that whatever it writes can only land inside its own Section.
+ */
+function checkVariantSelector(file, section, selector) {
+  const parts = compounds(selector);
+  if (!parts) {
+    fail(file, `selector "${selector}" uses a sibling combinator — a sibling of a Section is another Section`);
+    return;
+  }
+  const gate = VARIANT_GATE.exec(parts[0] ?? '');
+  if (!gate) {
+    fail(file, `selector "${selector}" does not begin with :root[data-variant='…'] — that is how a Variant is selected`);
+    return;
+  }
+  const named = (gate[1] ?? gate[2] ?? gate[3] ?? '').trim();
+  if (!/^[a-z][a-z0-9-]*$/.test(named)) {
+    fail(file, `"${named}" is not a Variant name — lower case, digits and dashes`);
+  }
+  if (parts.length < 2) {
+    fail(file, `selector "${selector}" names a Variant and nothing in the Section — it would style the whole document`);
+    return;
+  }
+  if (!ownedBy(section, parts[1])) {
+    fail(file, `selector "${selector}": "${parts[1]}" is not this Section's — expected .${section}, .${section}__… or [data-${section}-…]`);
+  }
+}
 
 const sections = exists(sectionsDir)
   ? readdirSync(sectionsDir, { withFileTypes: true })
@@ -98,41 +213,78 @@ for (const section of sections) {
       if (pattern.test(code)) fail(file, why);
     }
 
-    // Reaching another Section, whether by relative path or by alias.
-    for (const [, specifier] of code.matchAll(/\bfrom\s+['"]([^'"]+)['"]/g)) {
+    for (const specifier of imports(code)) {
+      // Reaching another Section, whether by relative path or by alias.
       if (!ALLOWED_IMPORT.test(specifier)) {
         fail(file, `imports "${specifier}" — a Section may read its own folder and src/kernel/ only`);
       }
-    }
-    for (const [, specifier] of code.matchAll(/\bimport\s+['"]([^'"]+)['"]/g)) {
-      if (!ALLOWED_IMPORT.test(specifier)) {
-        fail(file, `imports "${specifier}" — a Section may read its own folder and src/kernel/ only`);
+      if (VARIANT_SHEET.test(specifier)) {
+        fail(
+          file,
+          `imports "${specifier}" — a Variant that is not selected costs the shipped page nothing,` +
+            ' so nothing in a Section imports its Variants; the render tool injects the sheet',
+        );
       }
     }
   }
 
   // tokens.css and variants.css are not scoped by the compiler — Astro never
   // looks inside a plain stylesheet — so what they may contain is what makes
-  // them safe, and it is checked rather than trusted. Custom properties only,
-  // every one prefixed with the Section's name, on a selector ending in the
-  // Section's own root class.
+  // them safe, and it is checked rather than trusted.
+  //
+  // The two files are NOT held to the same rule, and the difference is the whole
+  // of what a Variant is. tokens.css is the Editor's file (ADR 0004), so it stays
+  // as narrow as it can be: Tokens, on the Section's own root. variants.css is
+  // written by an agent, is not imported by anything, and never reaches a reader
+  // — so it may write whole compositional directions, layout and palette
+  // included. What keeps it safe is the guarantee Astro's scoping gives the
+  // component: a rule here cannot match an element in another Section. Here that
+  // is a grammar rather than a hash.
   for (const name of ['tokens.css', 'variants.css']) {
     const file = join(dir, name);
     if (!exists(file)) continue;
     const css = withoutComments(readFileSync(file, 'utf8'));
 
-    for (const [, selector, body] of css.matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
-      const trimmed = selector.trim().replace(/\s+/g, ' ');
-      for (const one of trimmed.split(',')) {
-        if (!new RegExp(`\\.${section}$`).test(one.trim())) {
-          fail(file, `selector "${one.trim()}" does not end in .${section}`);
+    // Anything left once every top-level `selector { … }` is taken out. An
+    // @media block is the case this exists for, and it is worth being exact
+    // about why: the query's INNER rule is a perfectly good match for the
+    // pattern below, so without this the wrapper is skipped in silence and the
+    // file is checked as though the query were not there. NOTES.md has claimed
+    // an @media here fails the build since the convention was written; this is
+    // the line that makes that true. The Editor writes a value and not a
+    // breakpoint, and a Variant is a direction rather than something that
+    // arrives at a width.
+    const outside = css.replace(RULE, '').trim();
+    if (outside) {
+      const shown = outside.replace(/\s+/g, ' ').slice(0, 48);
+      fail(file, `"${shown}" is outside any rule — this file is a flat list of rules`);
+    }
+
+    for (const [, selector, body] of css.matchAll(RULE)) {
+      for (const one of selector.split(',')) {
+        const trimmed = one.trim().replace(/\s+/g, ' ');
+        if (!trimmed) continue;
+        if (name === 'tokens.css') {
+          if (!new RegExp(`\\.${section}$`).test(trimmed)) {
+            fail(file, `selector "${trimmed}" does not end in .${section}`);
+          }
+        } else {
+          checkVariantSelector(file, section, trimmed);
         }
       }
       for (const declaration of body.split(';')) {
         const property = declaration.split(':')[0]?.trim();
         if (!property) continue;
-        if (!property.startsWith(`--${section}-`)) {
-          fail(file, `"${property}" is not a Token — expected a custom property named --${section}-…`);
+        const own = property.startsWith(`--${section}-`);
+        if (name === 'tokens.css') {
+          if (!own) {
+            fail(file, `"${property}" is not a Token — expected a custom property named --${section}-…`);
+          }
+        } else if (property.startsWith('--') && !own) {
+          // A custom property inherits, so one not named for this Section is how
+          // a Variant would reach out and rewrite the Kernel's values for
+          // everything below it. Ordinary properties are the Variant's business.
+          fail(file, `"${property}" is a custom property this Section does not own — expected --${section}-…`);
         }
       }
     }

--- a/src/sections/stub/NOTES.md
+++ b/src/sections/stub/NOTES.md
@@ -20,7 +20,7 @@ is missing.
 | `content.ts`  | the words and the list of assets, typed by a schema declared beside them |
 | `tokens.css`  | the Section's named numbers and colours, as plain custom properties  |
 | `timeline.ts` | the Section's motion, as one named seekable object                   |
-| `variants.css`| complete alternative directions, selected by attribute               |
+| `variants.css`| complete alternative directions, selected by attribute, shipped never |
 | `assets/`     | the Section's own files, and nothing another Section reads           |
 | `NOTES.md`    | this — the reasoning that used to be a comment                       |
 
@@ -37,24 +37,75 @@ selector is rewritten with this component's own attribute, so it cannot match an
 element in another Section even by accident. This is the mechanism ADR 0002 buys
 a build step for.
 
-**The Tokens and the Variants** are plain CSS files imported in the frontmatter,
-which means they are *not* scoped — Astro's compiler never sees inside them.
-They are safe because of what they are allowed to contain, and that is enforced
-rather than trusted: `check-source.mjs` fails the build unless every declaration
-in `tokens.css` and `variants.css` is a custom property named `--stub-…` on a
-selector ending in this Section's own root class. A rule that could reach another
-Section is not a warning here, it is a build failure.
+**The Tokens** are a plain CSS file imported in the frontmatter, which means it
+is *not* scoped — Astro's compiler never sees inside a stylesheet. It is safe
+because of what it is allowed to contain, and that is enforced rather than
+trusted: `check-source.mjs` fails the build unless every declaration in
+`tokens.css` is a custom property named `--stub-…` on this Section's own root
+class, `.stub` and nothing else. A rule that could reach another Section is not a
+warning here, it is a build failure.
 
-The reason they are not simply moved into the scoped `<style>` block is ADR 0004:
+The reason it is not simply moved into the scoped `<style>` block is ADR 0004:
 `tokens.css` is the one file the Editor writes, and it has to stay a plain CSS
 file the Editor can parse and rewrite without touching a composition.
 
 A consequence worth stating, because it will come up: **a Token cannot vary by
-media query.** `check-source.mjs` reads these two files as a flat list of rules,
-so an `@media` block in either fails the build. That is deliberate rather than a
-limitation of the checker — the Editor writes a value, not a breakpoint. A Token
-that genuinely needs to change with the viewport belongs in the component's scoped
-`<style>`, where it is a composition decision and not something to drag.
+media query.** `check-source.mjs` reads the file as a flat list of rules and
+fails on anything outside one, so an `@media` block fails the build. That is
+deliberate rather than a limitation of the checker — the Editor writes a value,
+not a breakpoint. A Token that genuinely needs to change with the viewport
+belongs in the component's scoped `<style>`, where it is a composition decision
+and not something to drag.
+
+**The Variants** are the other plain CSS file, and they are held to a different
+rule, because a Variant that could only restate Tokens would be a set of Tokens
+by another name. `variants.css` may declare **anything** — a layout, a surface, a
+palette, a motion distance. What keeps it inside the Section is not what it
+declares but where it can land, and that is a grammar:
+
+```css
+:root[data-variant='split'] .stub__points li { flex: 1 1 0 }
+└──────── the gate ────────┘ └── owned ──┘ └ its descendants ┘
+```
+
+`check-source.mjs` fails the build unless every selector in the file is the gate,
+then a compound this Section owns — `.stub`, `.stub__…` or `[data-stub-…]` — and
+then whatever the direction needs. Only the compound right after the gate is
+checked, because everything after it is a descendant of something this Section
+owns and can match nothing outside it. Sibling combinators are refused outright
+for the same reason read the other way: a sibling of a Section's root is another
+Section. Custom properties still have to be named `--stub-…`, since one that is
+not inherits down into everything below it.
+
+**`:root` is load-bearing, not a habit.** Astro narrows every compound of a
+scoped rule, and with the default strategy that narrowing is a bare attribute
+selector worth (0,1,0) *per compound* — so a scoped rule's weight grows with the
+length of its selector and a Variant would win or lose depending on how long the
+composition's selector happened to be. `.stub__points li` was an exact tie,
+settled by whichever stylesheet the bundler emitted second. `astro.config.mjs`
+therefore sets `scopedStyleStrategy: 'where'`, which selects identically and
+weighs nothing; `:root[data-variant='…']` in front of the same selector then
+outranks it by (0,2,0), always. Change either half and Variants start losing
+silently.
+
+**Nothing imports `variants.css`.** That is the whole of "a Variant that is not
+selected costs the shipped page nothing" — the file is not part of the build, so
+the five directions below this one are not bytes a reader fetches, they are not a
+selector the browser matches, and they are not in `dist/` at all. Add the import
+back and `check-source.mjs` fails the build. What renders them instead is:
+
+```bash
+pnpm variants
+```
+
+which reads the sheet off disk, injects it into `/next` before the page's own
+scripts run, and assembles `design/sheets/index.html` — every Variant of every
+Section, in both themes, captioned with what it declares.
+`docs/agents/variants.md` is the authority on that tool and on writing a Variant.
+
+A Variant is judged and then **kept**, whichever way the judgement went. The
+losers are the record of what was compared, which is why there are five in
+`variants.css` and one direction in `tokens.css`.
 
 **The imports** are checked too: a Section may import from its own folder and
 from `src/kernel/`, and nothing else. That is CONTEXT.md's "a Section may read

--- a/src/sections/stub/Stub.astro
+++ b/src/sections/stub/Stub.astro
@@ -3,7 +3,9 @@
 // has to be; nothing behavioural is decided in this file.
 import { content } from './content';
 import './tokens.css';
-import './variants.css';
+// variants.css is deliberately NOT imported: an unselected Variant has to cost
+// the shipped page nothing, so the sheet is not part of the build at all and the
+// render tool injects it. NOTES.md, and check-source.mjs if this is ever undone.
 ---
 
 {/* data-section is the loader's handle: it names the Section whose timeline.ts

--- a/src/sections/stub/variants.css
+++ b/src/sections/stub/variants.css
@@ -1,23 +1,106 @@
-/* The stub Section's Variants: complete alternative directions, all present at
-   once and selected by attribute, so several can be rendered side by side and
-   chosen by eye. A Variant restates Tokens and nothing else — same rule as
-   tokens.css, same guard.
+/* The stub Section's Variants: complete alternative directions, all present in
+   the source at once, selected by an attribute on the document's root so several
+   can be rendered side by side and chosen by eye.
 
-   Two here, and they exist so the attribute is real rather than described. The
-   Section renders under whichever Variant [data-variant] names; with none named
-   it renders the direction in tokens.css. */
+     pnpm variants
 
-[data-variant='tight'] .stub {
+   Nothing imports this file — that is what makes an unselected Variant cost the
+   shipped page nothing — and scripts/check-source.mjs fails the build if
+   anything starts to. design/tools/render-variants.mjs injects it at render
+   time, and NOTES.md is the rest of it, including the grammar every selector
+   below has to keep and why `:root` is load-bearing.
+
+   Five here, and they are five different KINDS of direction rather than five
+   sizes of the same one: a Variant that restates Tokens, one that does it the
+   other way, one that changes the layout, one that changes the surface, and one
+   that is only visible in motion. */
+
+/* Tokens, and nothing else. The whole of a typographic or rhythmic direction
+   fits here, and this is what a Variant looked like when it could only be this. */
+:root[data-variant='tight'] .stub {
   --stub-measure: 26rem;
   --stub-gap: 0.75rem;
   --stub-heading-size: clamp(2rem, 6vmin, 4rem);
   --stub-lead-leading: 1.4;
 }
 
-[data-variant='airy'] .stub {
+:root[data-variant='airy'] .stub {
   --stub-measure: 42rem;
   --stub-inset: 14vmin;
   --stub-gap: 2.25rem;
   --stub-heading-size: clamp(3rem, 12vmin, 8rem);
   --stub-lead-leading: 1.75;
+}
+
+/* A Section is taller than a screen — the stub is 240svh, because its Timeline
+   is scrubbed by its own scroll — and the sheet shoots the first screen of it,
+   which is what a reader arriving at the Section sees. So a Variant centring
+   anything vertically centres it in that whole box and out of the frame. It is
+   not the sheet mis-measuring; it is the Variant putting the composition off
+   screen, and the first draft of `split` below did exactly that.
+
+   LAYOUT. The measure stops being a column and becomes two: the heading down the
+   left against the copy, and the points laid across the foot rather than listed.
+   Not expressible as Tokens at any price — the component reads Tokens for its
+   lengths, not for its structure, and a direction that has to ask permission of
+   the composition it is arguing with is not an alternative to it. */
+:root[data-variant='split'] .stub {
+  --stub-measure: 66rem;
+  --stub-gap: 2rem;
+  justify-content: center;
+}
+
+:root[data-variant='split'] .stub__measure {
+  display: grid;
+  grid-template-columns: minmax(0, 6fr) minmax(0, 11fr);
+  align-items: start;
+}
+
+:root[data-variant='split'] .stub__heading {
+  grid-row: 1 / span 2;
+  text-align: right;
+  line-height: 0.85;
+}
+
+:root[data-variant='split'] .stub__points {
+  flex-direction: row;
+}
+
+/* The one selector here that is not the Section's own: `li` can match nothing
+   outside `.stub__points`, which is why the grammar only asks about the compound
+   right after the gate. */
+:root[data-variant='split'] .stub__points li {
+  flex: 1 1 0;
+}
+
+/* SURFACE. The same layout on a plate instead of on the ground, drawn from the
+   Kernel's ink so it holds in both papers and across the Turn. Reading the
+   Kernel is what a Section may do; declaring `--ink` here would be reaching out
+   of it, and the build refuses that. */
+:root[data-variant='plate'] .stub {
+  --stub-inset: 10vmin;
+  justify-content: center;
+}
+
+:root[data-variant='plate'] .stub__measure {
+  padding: calc(var(--stub-gap) * 1.75);
+  background: color-mix(in oklab, var(--ink), transparent 93%);
+  border: var(--stub-rule) solid color-mix(in oklab, var(--ink), transparent 82%);
+  border-radius: calc(var(--stub-gap) / 2);
+}
+
+:root[data-variant='plate'] .stub__heading {
+  font-family: var(--face-lead);
+  font-style: italic;
+}
+
+/* MOTION. Nothing to see at rest — --stub-rise is the distance timeline.ts moves
+   the Section through, so this Variant and the Section as it ships are the same
+   picture at progress 0 and different ones at every other moment. Look at it
+   with the sheet's own axis:
+
+     pnpm variants -- --progress 0,0.5,1                                       */
+:root[data-variant='drift'] .stub {
+  --stub-rise: 56px;
+  --stub-gap: 1.75rem;
 }


### PR DESCRIPTION
Closes #142

A Variant was a Section restating its own Tokens. Now it is a whole
compositional direction — layout, surface, palette, motion — and `pnpm variants`
renders every one of them into a sheet to choose from.

## A Variant may change layout, not only type

`variants.css` may declare **anything**. What is checked is not what it declares
but where it can land, and that is a grammar:

```css
:root[data-variant='split'] .stub__points li { flex: 1 1 0 }
└──────── the gate ────────┘ └── owned ──┘ └ its descendants ┘
```

The gate, then a compound the Section owns (`.stub`, `.stub__…`,
`[data-stub-…]`), then whatever the direction needs. Only the compound after the
gate is checked — everything past it is a descendant of something the Section
owns and can match nothing outside it. Sibling combinators are refused, because a
sibling of a Section's root is another Section. Custom properties still have to be
the Section's own, since one that is not inherits into everything below it, and
`tokens.css` keeps exactly the rule it had — it is the Editor's file (ADR 0004).

Verified by running the checker against each violating form: no gate, no `:root`,
gate alone, another Section's class, a bare type selector first, `+`, `~`, a
foreign custom property, `@media`, `@keyframes`, a bad name — and against seven
legitimate forms, including `.stub__points li`, `> .stub__measure`,
`[data-stub-rise]`, `:first-child` and a selector list.

## `:root` is load-bearing, and it needed the config to be

Astro's default scoping narrows **every compound** of a scoped rule with a bare
attribute selector worth (0,1,0) — so a scoped rule's weight grows with the length
of its selector, and a Variant, which is one fixed gate in front of the same
selector, wins or loses on how long the composition's selector happened to be.
`.stub__points li` came out an exact tie, settled by whichever stylesheet the
bundler emitted second.

`astro.config.mjs` therefore sets `scopedStyleStrategy: 'where'`, which selects
identically and weighs nothing. The built CSS is now
`.stub__points:where(.astro-2kt4qm5s) li:where(.astro-2kt4qm5s)`, and the gate
outranks it by (0,2,0) in every case. Both halves are load-bearing; change either
and Variants start losing silently, which reads as a Variant that "did not apply".

## An unselected Variant costs the shipped page nothing

Literally, not nearly. **Nothing imports `variants.css`**, so it is not in the
build: not bytes a reader fetches, not a selector the browser matches, not in
`dist/` at all. `grep -c data-variant dist/_astro/*.css dist/next/index.html`
returns 0. `check-source.mjs` fails the build if the import comes back.

## One command, one sheet

```bash
pnpm variants
```

Renders the matrix — every Variant of every Section, both themes, **discovered
off the source** rather than listed anywhere — and assembles
`design/sheets/index.html`. Each picture is captioned with what that Variant
declares and nothing else, so the choice is made on the sheet rather than in the
files; `base` is in every strip, because it is the thing each Variant argues
against.

```bash
pnpm variants -- --progress 0,0.5,1   # a Variant that is only visible in motion
pnpm variants -- --turn 1             # past the Kernel's crossing into dark
pnpm variants -- --viewports desktop,tablet,mobile --format jpeg
pnpm variants -- --sections stub --variants split,plate --full
```

`--progress` seeks the Section's Timeline with `hold()` first (ADR 0003, and
`src/kernel/NOTES.md`); `--turn` pins the Kernel's crossing. The sheet is injected
as a `<style>` written before the page's own scripts run — a `<link>` would still
be in flight when a Timeline reads its Tokens with `getComputedStyle`, and would
hand it the shipped value under a Variant's name.

## The stub grows five Variants

Five different **kinds** of direction rather than five sizes of one: `tight` and
`airy` restate Tokens, `split` changes the layout, `plate` changes the surface,
`drift` is invisible at rest and only exists at `--progress`. All five stay in the
source; that is what a Variant is for.

One of them earned a note. `split`'s first draft centred the measure vertically,
and the sheet came back as blank paper — a Section is taller than a screen, so
centring in it centres out of frame. The sheet was right, and `variants.css` now
says so where the next Variant will read it.

## Every Check passes

- `pnpm build` — `check-source`, `astro check` (0 errors), build, assemble
- `pnpm check:sections`
- `python design/tools/check-capture-contract.py` — all four gutters, both
  luminances. `/portfolio` is untouched by this change, and asserted anyway

Also verified: a Variant reaching for one of its Section's own assets
(`url('assets/…')`) resolves and paints — the injected sheet's relative URLs are
rewritten and `/src/` is served for it.

## One unrelated fix, because it blocked every command here

`pnpm-workspace.yaml` carried pnpm 11's own `set this to true or false`
placeholder for `allowBuilds`, which pnpm reads as undecided. Every install
therefore exited 1 on `ERR_PNPM_IGNORED_BUILDS` and — since pnpm checks dependency
state *before* running a script — **every `pnpm <script>` in the repository failed
before starting**, `pnpm build` included. `pnpm variants` would have been dead on
arrival. One line, with the failure mode written down beside it.
