### PR TITLE
Close out the code review of #142 (#154)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,8 +129,7 @@ design/plinth/maps/
 # that still has this directory. Keep anything you care about elsewhere too.
 design/plinth/sources/
 
-# per-candidate plinth shots from 
-ender.mjs --stones. 1.4MB each and
+# per-candidate plinth shots from render.mjs --stones. 1.4MB each and
 # regenerable in a minute; what is committed is the contact sheet built from
 # them, design/shots/plinth-stones.jpg.
 design/shots/*__stone-*.png

--- a/design/tools/render-variants.mjs
+++ b/design/tools/render-variants.mjs
@@ -38,16 +38,36 @@
    wrong diagnosis once already.
 
    Playwright resolves out of design/tools/node_modules, like every other tool in
-   this directory:  npm --prefix design/tools install
+   this directory:  cd design/tools && npm ci
    ========================================================================== */
 
+import { createHash } from 'node:crypto';
 import { createReadStream, statSync } from 'node:fs';
 import { createServer } from 'node:http';
 import { mkdir, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { chromium } from 'playwright';
 import { contentType, resolveFile } from '../../scripts/static-tree.mjs';
+import { rules, variantsIn, withoutComments } from '../../scripts/variant-sheet.mjs';
+
+/* Playwright is design/tools/'s dependency, not the root install's, so the first
+   thing this can fail at is not finding it — and a bare ERR_MODULE_NOT_FOUND for
+   a package the README never told you to install is a poor way to learn that.
+   A worktree never has it at all: the directory is gitignored, so git does not
+   put it there. */
+let chromium;
+try {
+  ({ chromium } = await import('playwright'));
+} catch (error) {
+  if (error?.code !== 'ERR_MODULE_NOT_FOUND') throw error;
+  console.error(
+    'error: playwright is not installed for design/tools.\n' +
+      '  cd design/tools && npm ci\n' +
+      '  (it is not part of `pnpm install`, and a fresh worktree never has it —\n' +
+      '   design/tools/node_modules is gitignored. docs/agents/variants.md)',
+  );
+  process.exit(1);
+}
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(HERE, '..', '..');
@@ -87,6 +107,22 @@ const opt = args(process.argv.slice(2));
 const list = (value, fallback) =>
   value ? value.split(',').map((one) => one.trim()).filter(Boolean) : fallback;
 
+/* `args` gives a flag with no value the string 'true', so an unvalidated
+   Number(opt.x || d) turns `--scale` into NaN — and a NaN deviceScaleFactor is a
+   run that looks fine and writes nothing you can compare. */
+function number(name, value, fallback) {
+  if (value === undefined) return fallback;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) fail(`--${name} takes a positive number, not "${value}"`);
+  return parsed;
+}
+
+function flag(name, value) {
+  if (value === undefined) return false;
+  if (value !== 'true') fail(`--${name} takes no value — got "${value}"`);
+  return true;
+}
+
 const wanted = {
   sections: list(opt.sections, null),
   variants: list(opt.variants, null),
@@ -97,9 +133,12 @@ const progresses = list(opt.progress, ['0']).map(Number);
 /** The Turn is the Kernel's, not a Section's, so it is pinned rather than
  *  crossed: one value for the whole run, or left where the scroll put it. */
 const turn = opt.turn === undefined ? null : Number(opt.turn);
-const scale = Number(opt.scale || 1);
+const scale = number('scale', opt.scale, 1);
 const route = opt.route || ROUTE;
-const full = opt.full === 'true';
+/* `--full` takes no value, so `args` gives it the string 'true' when it is
+   present. Anything else was a typo — `--full 1` reading as false is the kind of
+   quiet wrong answer this whole tool exists to avoid. */
+const full = flag('full', opt.full);
 /* PNG is faithful and PNG is what these cost: the Effect Stack's grain and
    halftone are noise by construction, so a screen of nearly blank paper comes
    out at over a megabyte and a full matrix at forty. JPEG is a fifth of that and
@@ -107,9 +146,12 @@ const full = opt.full === 'true';
    on — so it is the right answer for a wide matrix and the wrong one for judging
    a texture. Hence a flag rather than a default. */
 const format = (opt.format || 'png').toLowerCase();
-const quality = Number(opt.quality || 92);
+const quality = number('quality', opt.quality, 92);
 if (format !== 'png' && format !== 'jpeg') fail('--format must be png or jpeg');
-const out = resolve(ROOT, opt.out || join('design', 'sheets'));
+/* One output directory, named once. It was a flag, and the flag was never
+   passed and the closing log ignored it anyway. */
+const OUT_REL = join('design', 'sheets');
+const out = resolve(ROOT, OUT_REL);
 
 for (const key of viewKeys) if (!VIEWPORTS[key]) fail(`unknown viewport "${key}" — have: ${Object.keys(VIEWPORTS).join(', ')}`);
 for (const p of progresses) if (!Number.isFinite(p) || p < 0 || p > 1) fail(`--progress takes numbers from 0 to 1, not "${p}"`);
@@ -125,33 +167,22 @@ for (const theme of themes) if (theme !== 'light' && theme !== 'dark') fail(`unk
    loader globs for a Section's Timeline instead of keeping a register: adding a
    Variant is writing one, and there is nowhere to forget to add it. */
 
-const COMMENTS = /\/\*[\s\S]*?\*\//g;
-const RULE = /([^{}]+)\{([^{}]*)\}/g;
-const GATE = /:root\[data-variant=(?:'([^']*)'|"([^"]*)"|([^\]]*))\]/;
+/* The sheet and the Check read variants.css through one parser
+   (scripts/variant-sheet.mjs), because they have to agree about what is in it and
+   once did not: a Variant reached by the second half of a selector LIST passed
+   every Check and was never rendered. */
 
-/** A Variant's rules, as CSS, keyed by the name its selectors gate on. */
-function byVariant(css) {
-  const found = new Map();
-  for (const [, selector, body] of css.replace(COMMENTS, '').matchAll(RULE)) {
-    const gate = GATE.exec(selector);
-    if (!gate) continue;
-    const name = (gate[1] ?? gate[2] ?? gate[3] ?? '').trim();
-    const rule = `${selector.trim().replace(/\s*\n\s*/g, '\n')} {${body.replace(/\s+$/, '')}\n}`;
-    found.set(name, [...(found.get(name) ?? []), rule]);
-  }
-  return found;
-}
+/** The name for the direction with no Variant selected — what tokens.css says on
+ *  its own. Not `base`: CONTEXT.md's Kernel entry puts that on an avoid list, and
+ *  this is the one state that cannot be confused with a Variant's own name. */
+const UNSELECTED = 'unselected';
 
-/** The declarations of a flat stylesheet, for the sheet to caption `base` with. */
+/** tokens.css as a flat list of declarations, to caption `unselected` with. */
 function declarations(css) {
-  const found = [];
-  for (const [, , body] of css.replace(COMMENTS, '').matchAll(RULE)) {
-    for (const declaration of body.split(';')) {
-      const trimmed = declaration.trim().replace(/\s+/g, ' ');
-      if (trimmed) found.push(`${trimmed};`);
-    }
-  }
-  return found.join('\n');
+  return rules(css)
+    .flatMap((rule) => rule.declarations)
+    .map((one) => `${one};`)
+    .join('\n');
 }
 
 /** A Variant may reach for one of its Section's own assets, and a relative URL
@@ -176,19 +207,27 @@ async function declaredVariants() {
     if (wanted.sections && !wanted.sections.includes(entry.name)) continue;
     const dir = join(SECTIONS, entry.name);
     if (!(await present(join(dir, 'variants.css')))) continue;
+    // Guarded, like variants.css beside it: this tool does not run
+    // check-source, so a Section missing a file is a message and not a stack.
+    if (!(await present(join(dir, 'tokens.css')))) {
+      fail(`${entry.name} has no tokens.css — run \`pnpm check:sections\``);
+    }
     const css = await readFile(join(dir, 'variants.css'), 'utf8');
     const tokens = await readFile(join(dir, 'tokens.css'), 'utf8');
-    const rules = byVariant(css);
-    let names = [...rules.keys()];
+    const declared = variantsIn(css);
+    let names = [...declared.keys()];
     if (wanted.variants) names = names.filter((name) => wanted.variants.includes(name));
+    if (declared.has(UNSELECTED)) {
+      fail(`${entry.name} declares a Variant called "${UNSELECTED}", which is what the sheet calls no Variant at all`);
+    }
     found.push({
       name: entry.name,
-      // `base` first and always: the direction that ships is the thing every
-      // Variant is an argument against, so it belongs in the picture beside them.
-      names: ['base', ...names],
-      rules,
+      // The unselected direction first and always: it is the thing every Variant
+      // is an argument against, so it belongs in the picture beside them.
+      names: [UNSELECTED, ...names],
+      rules: declared,
       tokens: declarations(tokens),
-      style: absoluteUrls(css.replace(COMMENTS, ''), `/src/sections/${entry.name}/`),
+      style: absoluteUrls(withoutComments(css), `/src/sections/${entry.name}/`),
     });
   }
   return found;
@@ -235,7 +274,7 @@ function serve() {
 const INJECT = (variant, css) => `
   new MutationObserver((_, o) => {
     if (!document.documentElement) return;
-    ${variant === 'base' ? '' : `document.documentElement.setAttribute("data-variant", ${JSON.stringify(variant)});`}
+    ${variant === UNSELECTED ? '' : `document.documentElement.setAttribute("data-variant", ${JSON.stringify(variant)});`}
     const style = document.createElement("style");
     style.textContent = ${JSON.stringify(css)};
     (document.head || document.documentElement).appendChild(style);
@@ -318,8 +357,8 @@ async function sheet(rows, declared) {
   const source = new Map(declared.map((one) => [one.name, one]));
   const css = (row) => {
     const section = source.get(row.section);
-    if (row.variant === 'base')
-      return `/* tokens.css — the direction that ships */\n${section.tokens}`;
+    if (row.variant === UNSELECTED)
+      return `/* tokens.css — with no Variant selected */\n${section.tokens}`;
     return (section.rules.get(row.variant) ?? []).join('\n\n');
   };
 
@@ -330,7 +369,7 @@ async function sheet(rows, declared) {
         (row) => `
         <figure>
           <figcaption>
-            <b>${escape(row.variant)}</b>
+            <b>${escape(row.variant)}${row.identical ? ' <i>identical</i>' : ''}</b>
             <span>${escape(row.face)} ${escape(row.size)} · ${escape(row.box)} · turn ${escape(row.turn)}</span>
           </figcaption>
           <a href="${row.file}" target="_blank" rel="noopener"
@@ -355,6 +394,7 @@ async function sheet(rows, declared) {
   figure { margin: 0; flex: 0 0 auto; width: 460px; display: flex; flex-direction: column; gap: 0.35rem; }
   figcaption { display: flex; justify-content: space-between; gap: 0.5rem; align-items: baseline; }
   figcaption b { font-size: 0.95rem; }
+  figcaption i { font-weight: 400; font-style: normal; opacity: 0.55; font-size: 0.8rem; }
   figcaption span { opacity: 0.6; font-family: ui-monospace, monospace; font-size: 11px; text-align: right; }
   img { width: 100%; height: auto; border: 1px solid rgba(128,128,128,0.35); border-radius: 4px; display: block; }
   /* Capped and scrolling, so a Variant that declares a lot does not push the
@@ -370,9 +410,12 @@ async function sheet(rows, declared) {
   <p class="meta">${rows.length} render${rows.length === 1 ? '' : 's'} of ${route}, at ${scale}x, by
      <code>design/tools/render-variants.mjs</code>. Under each picture is what that
      Variant declares and nothing else, so the choice can be made here rather than
-     in the files. <b>base</b> is the direction that ships — what is in
-     <code>tokens.css</code>, with no Variant selected. Click a picture for full
-     size. Every run rewrites this directory.</p>
+     in the files. <b>${UNSELECTED}</b> is what <code>tokens.css</code> says on its
+     own, with no Variant selected — the thing each Variant is an argument against.
+     A picture marked <i>identical</i> came back byte-for-byte the same as it, which
+     is the honest answer for a Variant that only exists in motion: give it
+     <code>--progress</code>. Click a picture for full size. Every run rewrites
+     this directory.</p>
 ${/* In the order the run made them — viewport, then theme, then Section — rather
       than alphabetically, which would put dark before light for no reason. */
    [...groups.keys()].map((key) => `    <section><h2>${escape(key)}</h2><div class="strip">${figures(key)}</div></section>`).join('\n')}
@@ -400,6 +443,14 @@ const server = await serve();
 const origin = `http://127.0.0.1:${server.address().port}`;
 const browser = await chromium.launch();
 const rows = [];
+/* What the unselected direction looked like, per group, so a Variant whose render
+   is byte-for-byte the same can be labelled as such rather than left looking like
+   a picture of nothing. `drift` is exactly that at progress 0 — the whole of it is
+   a distance the Timeline moves through — and a sheet that does not say so is a
+   sheet with a card you cannot read. The unselected render comes first in every
+   group, which is what makes this possible in one pass. */
+const unselectedDigest = new Map();
+const groupOf = (section, theme, viewport, progress) => `${section}|${theme}|${viewport}|${progress}`;
 const total =
   viewKeys.length *
   themes.length *
@@ -446,11 +497,16 @@ for (const viewport of viewKeys) {
           if (full) await page.locator(`[data-section="${section.name}"]`).screenshot(target);
           else await page.screenshot(target);
           const bytes = (await stat(join(out, file))).size;
-          rows.push({ section: section.name, variant, theme, viewport, progress, file, ...info });
+          const group = groupOf(section.name, theme, viewport, progress);
+          const digest = createHash('sha256').update(await readFile(join(out, file))).digest('hex');
+          if (variant === UNSELECTED) unselectedDigest.set(group, digest);
+          const identical = variant !== UNSELECTED && unselectedDigest.get(group) === digest;
+          rows.push({ section: section.name, variant, theme, viewport, progress, file, identical, ...info });
           console.log(
             `  [${String(++n).padStart(String(total).length)}/${total}] ${file}` +
               `  ${info.face} ${info.size} · ${info.box} · turn ${info.turn}` +
-              `  (${Math.round(bytes / 1024)} KB)`,
+              `  (${Math.round(bytes / 1024)} KB)` +
+              (identical ? `  — identical to ${UNSELECTED}` : ''),
           );
         }
         await context.close();
@@ -463,5 +519,12 @@ await browser.close();
 server.close();
 await sheet(rows, declared);
 
-console.log(`\nwrote ${rows.length} shot(s) + index.html to ${opt.out || 'design/sheets'}/`);
-console.log('open design/sheets/index.html — the sheet');
+const identical = rows.filter((row) => row.identical).length;
+console.log(`\nwrote ${rows.length} shot(s) + index.html to ${OUT_REL.replace(/\\/g, '/')}/`);
+if (identical) {
+  console.log(
+    `${identical} render(s) came back identical to ${UNSELECTED} — a Variant that only exists` +
+      ' in motion needs --progress',
+  );
+}
+console.log(`open ${join(OUT_REL, 'index.html').replace(/\\/g, '/')} — the sheet`);

--- a/docs/agents/variants.md
+++ b/docs/agents/variants.md
@@ -35,7 +35,10 @@ number of Variants in it. Every selector reads:
   is two Variants.
 
 `scripts/check-source.mjs` is all of that as a build failure, and `pnpm
-check:sections` is it on its own.
+check:sections` is it on its own. It and the render tool read the file through one
+parser, `scripts/variant-sheet.mjs` — they have to agree about what is in it, and
+once did not: a Variant reached only by the second half of a selector *list*
+passed every Check and was never rendered.
 
 ## Rendering them
 
@@ -46,8 +49,10 @@ pnpm variants       # every Variant of every Section, both themes, one sheet
 
 Then open `design/sheets/index.html`. Under each picture is what that Variant
 declares and nothing else, so the choice is made there rather than in the files.
-`base` is the direction that ships — `tokens.css`, with no Variant selected — and
-it is in every strip, because it is the thing each Variant is an argument against.
+`unselected` is what `tokens.css` says on its own, and it is in every strip because
+it is the thing each Variant is an argument against. A card marked *identical* came
+back byte-for-byte the same as it — the honest answer for a Variant that only
+exists in motion, and the cue to pass `--progress`.
 
 ```bash
 pnpm variants -- --sections stub --variants split,plate
@@ -72,9 +77,12 @@ wins or loses depending on how many compounds the composition happened to write.
 `.stub__points li` was an exact tie, settled by whichever stylesheet the bundler
 emitted second. So `astro.config.mjs` sets `scopedStyleStrategy: 'where'`, which
 selects identically and weighs nothing, and the gate then outranks the
-composition by (0,2,0) in every case. **Both halves are load-bearing.** Change
-either and Variants start losing silently, which reads as a Variant that "did not
-apply".
+composition by (0,2,0) in every case.
+
+Both halves are load-bearing, so both are checked — `check-source.mjs` reads
+`astro.config.mjs` and fails the build if the strategy is missing or changed. It
+has to be a Check rather than a note: the regression is a Variant that renders as
+though it had not been selected, and nothing else about the page looks wrong.
 
 **Nothing imports `variants.css`.** That is the whole of an unselected Variant
 costing the shipped page nothing: the file is not in the build, so rejected
@@ -120,11 +128,24 @@ to have.
 in that directory, and it is not what `pnpm install` at the root installs:
 
 ```bash
-npm --prefix design/tools install
+cd design/tools && npm ci
 ```
 
-A worktree does not get it at all — the directory is gitignored — so a fresh one
-needs either that install or a junction to the main checkout's copy.
+**From that directory, and `ci` rather than `install`.** `npm --prefix
+design/tools install`, run from the repo root, installs the package in the *cwd*
+into the prefix — so it adds `"portfolio": "file:../.."` to
+`design/tools/package.json` and rewrites the lockfile, two tracked files, as a
+side effect of installing Playwright. `npm ci` also refuses to touch either one.
+
+A worktree does not get the directory at all — it is gitignored, so git never puts
+it there — and `pnpm variants` says so rather than failing with a bare
+`ERR_MODULE_NOT_FOUND`.
+
+**Install it, do not link it.** A junction from a worktree to the main checkout's
+copy works and then takes the main checkout down with it: `git worktree remove`
+walks the link and deletes the contents of the *target*, leaving the main
+checkout's `design/tools/node_modules` an empty directory and every tool in that
+folder broken. It has happened. The install is two seconds.
 
 ## Not to be confused with
 

--- a/scripts/check-source.mjs
+++ b/scripts/check-source.mjs
@@ -14,6 +14,7 @@
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { VARIANT_GATE, compounds, outsideAnyRule, rules } from './variant-sheet.mjs';
 
 const repoRoot = fileURLToPath(new URL('..', import.meta.url));
 const sectionsDir = join(repoRoot, 'src', 'sections');
@@ -46,11 +47,6 @@ function filesUnder(dir) {
   return found;
 }
 
-/** Comments carry examples of the things being banned, so they come out first. */
-function withoutComments(source) {
-  return source.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/^\s*\/\/.*$/gm, ' ');
-}
-
 /** Every module specifier in a source file, from either import form. */
 function imports(code) {
   const found = [];
@@ -59,46 +55,11 @@ function imports(code) {
   return found;
 }
 
-/**
- * A selector split into its compounds, on the combinators between them — or
- * null if it uses a sibling combinator.
- *
- * The split has to know about brackets and quotes, because `[data-x~='a']` and
- * `:is(a + b)` both carry characters that mean something else at the top level.
- * Sibling combinators are refused outright rather than reasoned about: the
- * guarantee below is that a Variant's rule can only match inside its own
- * Section, and a sibling of a Section's root is another Section.
- */
-function compounds(selector) {
-  const parts = [];
-  let current = '';
-  let depth = 0;
-  let quote = null;
-  for (const character of selector) {
-    if (quote) {
-      current += character;
-      if (character === quote) quote = null;
-      continue;
-    }
-    if (character === '"' || character === "'") {
-      quote = character;
-      current += character;
-      continue;
-    }
-    if (character === '[' || character === '(') depth += 1;
-    if (character === ']' || character === ')') depth -= 1;
-    if (depth === 0) {
-      if (character === '+' || character === '~') return null;
-      if (character === '>' || /\s/.test(character)) {
-        if (current) parts.push(current);
-        current = '';
-        continue;
-      }
-    }
-    current += character;
-  }
-  if (current) parts.push(current);
-  return parts;
+/** Comments carry examples of the things being banned, so they come out first.
+ *  Only the .astro/.ts scans need this here; the stylesheets go through
+ *  variant-sheet.mjs, which strips them itself. */
+function withoutComments(source) {
+  return source.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/^\s*\/\/.*$/gm, ' ');
 }
 
 // ---------------------------------------------------------------------------
@@ -125,25 +86,6 @@ const SCOPE_ESCAPES = [
   [/:global\s*\(/, ':global() — a Section may not write a global rule'],
   [/<style[^>]*\bis:inline\b/, '<style is:inline> — an inline style block is not scoped'],
 ];
-
-/** One top-level `selector { … }`. Both stylesheets are a flat list of them, and
- *  the check just above the loop is what makes that an assertion. Global, so
- *  that stripping every rule out of the file really does strip every one —
- *  without the flag `replace` takes the first and the leftover reads as an
- *  error in every file that has more than one rule in it. */
-const RULE = /([^{}]+)\{([^{}]*)\}/g;
-
-/** How a Variant is selected: an attribute on the document's root element.
- *
- *  `:root` is not decoration and not a habit. It is what makes a Variant win.
- *  Together with `scopedStyleStrategy: 'where'` in astro.config.mjs it is the
- *  whole of the mechanism: that strategy narrows a component's rules with
- *  :where(), which weighs nothing, so a scoped rule keeps the specificity it is
- *  written with and `:root[data-variant='…']` in front of the same selector
- *  outranks it by (0,2,0) every time. Drop either half and a Variant starts
- *  winning or losing on how many compounds the composition happened to write —
- *  which reads as a Variant that "did not apply". docs/agents/variants.md. */
-const VARIANT_GATE = /^:root\[data-variant=(?:'([^']*)'|"([^"]*)"|([^\]]*))\]$/;
 
 /**
  * Every compound after the gate has to be one the Section owns, and only the
@@ -245,34 +187,30 @@ for (const section of sections) {
     if (!exists(file)) continue;
     const css = withoutComments(readFileSync(file, 'utf8'));
 
-    // Anything left once every top-level `selector { … }` is taken out. An
-    // @media block is the case this exists for, and it is worth being exact
-    // about why: the query's INNER rule is a perfectly good match for the
-    // pattern below, so without this the wrapper is skipped in silence and the
-    // file is checked as though the query were not there. NOTES.md has claimed
-    // an @media here fails the build since the convention was written; this is
-    // the line that makes that true. The Editor writes a value and not a
+    // Anything left once every top-level rule is taken out. An @media block is
+    // the case this exists for, and it is worth being exact about why: the
+    // query's INNER rule is a perfectly good match for a rule pattern, so
+    // without this the wrapper is skipped in silence and the file is checked as
+    // though the query were not there. The Editor writes a value and not a
     // breakpoint, and a Variant is a direction rather than something that
     // arrives at a width.
-    const outside = css.replace(RULE, '').trim();
+    const outside = outsideAnyRule(css);
     if (outside) {
       const shown = outside.replace(/\s+/g, ' ').slice(0, 48);
       fail(file, `"${shown}" is outside any rule — this file is a flat list of rules`);
     }
 
-    for (const [, selector, body] of css.matchAll(RULE)) {
-      for (const one of selector.split(',')) {
-        const trimmed = one.trim().replace(/\s+/g, ' ');
-        if (!trimmed) continue;
+    for (const rule of rules(css)) {
+      for (const selector of rule.selectors) {
         if (name === 'tokens.css') {
-          if (!new RegExp(`\\.${section}$`).test(trimmed)) {
-            fail(file, `selector "${trimmed}" does not end in .${section}`);
+          if (!new RegExp(`\\.${section}$`).test(selector)) {
+            fail(file, `selector "${selector}" does not end in .${section}`);
           }
         } else {
-          checkVariantSelector(file, section, trimmed);
+          checkVariantSelector(file, section, selector);
         }
       }
-      for (const declaration of body.split(';')) {
+      for (const declaration of rule.declarations) {
         const property = declaration.split(':')[0]?.trim();
         if (!property) continue;
         const own = property.startsWith(`--${section}-`);
@@ -288,6 +226,45 @@ for (const section of sections) {
         }
       }
     }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The half of the Variant mechanism that does not live in a Section.
+// ---------------------------------------------------------------------------
+
+// A Variant is selected by `:root[data-variant='…']` in front of a selector the
+// composition already wrote, and it has to WIN that pairing. It only does because
+// of two things that are nowhere near each other: the gate above, checked per
+// selector, and one line of Astro configuration.
+//
+// Astro narrows every compound of a scoped rule so it cannot match another
+// component's elements. HOW it narrows decides the arithmetic. The default
+// strategy appends a bare attribute selector, worth (0,1,0) — PER COMPOUND — so a
+// scoped rule's weight grows with the length of its selector, and a Variant, which
+// is one fixed gate in front of the same selector, wins or loses on how many
+// compounds the composition happened to write. `.stub__points li` came out an
+// exact tie, settled by whichever stylesheet the bundler emitted second.
+// `scopedStyleStrategy: 'where'` wraps the same narrowing in :where(), which
+// selects identically and weighs nothing, so the gate outranks the composition by
+// (0,2,0) in every case.
+//
+// This was a paragraph in five files and an assertion in none, which is exactly
+// what ADR 0006 says not to do: a comment saying "do not break this" is a wish.
+// The failure it is guarding against is silent — a Variant that renders as though
+// it had not been selected — so it is worth the eleven lines.
+const astroConfig = join(repoRoot, 'astro.config.mjs');
+if (exists(astroConfig)) {
+  const config = withoutComments(readFileSync(astroConfig, 'utf8'));
+  const strategy = /scopedStyleStrategy\s*:\s*['"]([a-z-]+)['"]/.exec(config);
+  if (!strategy) {
+    fail(astroConfig, "no scopedStyleStrategy — Variants need 'where' to outrank a Section's own rules");
+  } else if (strategy[1] !== 'where') {
+    fail(
+      astroConfig,
+      `scopedStyleStrategy is '${strategy[1]}' — Variants need 'where', or a scoped rule's` +
+        " specificity grows with its selector and :root[data-variant='…'] stops outranking it",
+    );
   }
 }
 

--- a/scripts/variant-sheet.mjs
+++ b/scripts/variant-sheet.mjs
@@ -1,0 +1,141 @@
+// Reading a Section's plain stylesheets, named once.
+//
+// Two things read `variants.css` and they have to agree about what is in it: the
+// Check that decides whether it is legal, and the tool that renders every Variant
+// it declares. They did not. Each had its own rule pattern and its own gate
+// pattern, and the two had already drifted — the Check anchored the gate and
+// validated every comma-separated selector in a rule, the renderer matched the
+// first gate anywhere in one and stopped. So this passed the build:
+//
+//   :root[data-variant='a'] .stub,
+//   :root[data-variant='b'] .stub { --stub-gap: 2rem }
+//
+// and `b` was never rendered. Not an error, not a warning, not a shot — a Variant
+// that exists, is legal, and cannot be looked at. One parser, read by both.
+
+/** Comments carry examples of the things being banned, so they come out first. */
+export function withoutComments(source) {
+  return source.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/^\s*\/\/.*$/gm, ' ');
+}
+
+/** One top-level `selector { … }`. Both stylesheets are a flat list of them, and
+ *  `check-source.mjs` is what makes that an assertion rather than an assumption.
+ *  A function rather than a shared constant: a `g` regex carries `lastIndex`, and
+ *  two callers sharing one is a bug waiting for a `while` loop. */
+const RULE = () => /([^{}]+)\{([^{}]*)\}/g;
+
+/** How a Variant is selected: an attribute on the document's root element.
+ *
+ *  `:root` is not decoration and not a habit. Together with
+ *  `scopedStyleStrategy: 'where'` in astro.config.mjs it is the whole mechanism —
+ *  that strategy narrows a component's rules with `:where()`, which weighs
+ *  nothing, so `:root[data-variant='…']` in front of the same selector outranks it
+ *  by (0,2,0) every time. `check-source.mjs` asserts both halves, because prose
+ *  cannot: drop either and Variants start losing silently. */
+export const VARIANT_GATE = /^:root\[data-variant=(?:'([^']*)'|"([^"]*)"|([^\]]*))\]$/;
+
+/**
+ * A selector split into its compounds, on the combinators between them — or null
+ * if it uses a sibling combinator.
+ *
+ * The split has to know about brackets and quotes, because `[data-x~='a']` and
+ * `:is(a + b)` both carry characters that mean something else at the top level.
+ * Sibling combinators come back as null rather than as a compound: the guarantee
+ * the Check is built on is that a Variant's rule can only match inside its own
+ * Section, and a sibling of a Section's root is another Section.
+ */
+export function compounds(selector) {
+  const parts = [];
+  let current = '';
+  let depth = 0;
+  let quote = null;
+  for (const character of selector) {
+    if (quote) {
+      current += character;
+      if (character === quote) quote = null;
+      continue;
+    }
+    if (character === '"' || character === "'") {
+      quote = character;
+      current += character;
+      continue;
+    }
+    if (character === '[' || character === '(') depth += 1;
+    if (character === ']' || character === ')') depth -= 1;
+    if (depth === 0) {
+      if (character === '+' || character === '~') return null;
+      if (character === '>' || /\s/.test(character)) {
+        if (current) parts.push(current);
+        current = '';
+        continue;
+      }
+    }
+    current += character;
+  }
+  if (current) parts.push(current);
+  return parts;
+}
+
+/**
+ * A stylesheet as a flat list of `{ selectors, declarations, text }`.
+ *
+ * `selectors` is already split on commas and whitespace-normalised, because every
+ * caller wants them one at a time — and the one that did not is the reason this
+ * module exists.
+ */
+export function rules(css) {
+  const found = [];
+  for (const [text, selector, body] of withoutComments(css).matchAll(RULE())) {
+    found.push({
+      selectors: selector
+        .split(',')
+        .map((one) => one.trim().replace(/\s+/g, ' '))
+        .filter(Boolean),
+      declarations: body
+        .split(';')
+        .map((one) => one.trim().replace(/\s+/g, ' '))
+        .filter(Boolean),
+      text: text.trim(),
+    });
+  }
+  return found;
+}
+
+/** Anything in the file that is not inside a top-level rule — an `@media` wrapper
+ *  being the case worth naming, since its inner rule matches the pattern above
+ *  perfectly and the wrapper would otherwise be skipped in silence. */
+export function outsideAnyRule(css) {
+  return withoutComments(css).replace(RULE(), '').trim();
+}
+
+/** The Variant a selector is gated on, or null if it is not gated at all. */
+export function gatedOn(selector) {
+  const gate = VARIANT_GATE.exec(compounds(selector)?.[0] ?? '');
+  if (!gate) return null;
+  return (gate[1] ?? gate[2] ?? gate[3] ?? '').trim();
+}
+
+/**
+ * Every Variant a sheet declares, in the order it declares them, each with the
+ * rules that belong to it as CSS.
+ *
+ * A rule reached by more than one gate belongs to each of them, which is the
+ * behaviour the renderer used to be missing.
+ */
+export function variantsIn(css) {
+  const found = new Map();
+  for (const rule of rules(css)) {
+    for (const selector of rule.selectors) {
+      const name = gatedOn(selector);
+      if (!name) continue;
+      // Shown to each Variant as the one selector that reached it rather than as
+      // the whole list: the other half of a shared list is a different Variant's
+      // business, and this text is what the sheet captions the picture with.
+      const text = `${selector} {${rule.text.slice(rule.text.indexOf('{') + 1)}`;
+      const own = found.get(name) ?? [];
+      if (!own.includes(text)) own.push(text);
+      found.set(name, own);
+    }
+  }
+  return found;
+}

--- a/src/sections/stub/NOTES.md
+++ b/src/sections/stub/NOTES.md
@@ -77,16 +77,23 @@ for the same reason read the other way: a sibling of a Section's root is another
 Section. Custom properties still have to be named `--stub-…`, since one that is
 not inherits down into everything below it.
 
-**`:root` is load-bearing, not a habit.** Astro narrows every compound of a
-scoped rule, and with the default strategy that narrowing is a bare attribute
-selector worth (0,1,0) *per compound* — so a scoped rule's weight grows with the
-length of its selector and a Variant would win or lose depending on how long the
-composition's selector happened to be. `.stub__points li` was an exact tie,
-settled by whichever stylesheet the bundler emitted second. `astro.config.mjs`
-therefore sets `scopedStyleStrategy: 'where'`, which selects identically and
-weighs nothing; `:root[data-variant='…']` in front of the same selector then
-outranks it by (0,2,0), always. Change either half and Variants start losing
-silently.
+**`:root` is load-bearing, not a habit** — and so is one line of
+`astro.config.mjs`. Astro narrows every compound of a scoped rule, and with the
+default strategy that narrowing is a bare attribute selector worth (0,1,0) *per
+compound*, so a scoped rule's weight grows with the length of its selector and a
+Variant would win or lose depending on how long the composition's selector
+happened to be. `.stub__points li` was an exact tie, settled by whichever
+stylesheet the bundler emitted second. `scopedStyleStrategy: 'where'` wraps the
+same narrowing in `:where()`, which selects identically and weighs nothing, so
+`:root[data-variant='…']` in front of the same selector outranks it by (0,2,0),
+always.
+
+Both halves are checked, and that is the point rather than a detail:
+`check-source.mjs` reads `astro.config.mjs` and fails the build if the strategy is
+missing or is anything else. This paragraph used to end "change either half and
+Variants start losing silently", which is exactly the wish ADR 0006 says to
+replace with an assertion — the failure it warns about is a Variant that renders
+as though it had not been selected, which nobody would notice.
 
 **Nothing imports `variants.css`.** That is the whole of "a Variant that is not
 selected costs the shipped page nothing" — the file is not part of the build, so
@@ -105,7 +112,21 @@ Section, in both themes, captioned with what it declares.
 
 A Variant is judged and then **kept**, whichever way the judgement went. The
 losers are the record of what was compared, which is why there are five in
-`variants.css` and one direction in `tokens.css`.
+`variants.css` and one direction in `tokens.css`. They are five different *kinds*
+of direction rather than five sizes of one: `tight` and `airy` restate Tokens,
+`split` changes the layout, `plate` changes the surface, and `drift` is invisible
+at rest — it is a distance `timeline.ts` moves through, so it and the unselected
+direction are the same picture at progress 0 and different ones everywhere else.
+The sheet marks a render that came back identical, and `--progress` is how you
+look at that one.
+
+**A Variant may not centre anything vertically here, and the reason is the
+Section's own height.** The stub is 240svh, because its Timeline is scrubbed by
+its own scroll, and the sheet shoots the first screen — which is what a reader
+arriving at the Section sees. So `align-items: center` on `.stub` centres the
+composition in that whole box and out of the frame, and the picture comes back as
+empty paper. `split`'s first draft did exactly that. The sheet was right; the
+Variant was wrong.
 
 **The imports** are checked too: a Section may import from its own folder and
 from `src/kernel/`, and nothing else. That is CONTEXT.md's "a Section may read

--- a/src/sections/stub/variants.css
+++ b/src/sections/stub/variants.css
@@ -1,22 +1,9 @@
-/* The stub Section's Variants: complete alternative directions, all present in
-   the source at once, selected by an attribute on the document's root so several
-   can be rendered side by side and chosen by eye.
+/* The stub Section's Variants — complete alternative directions, selected by
+   attribute, rendered side by side with `pnpm variants`. Nothing imports this
+   file. NOTES.md is the grammar every selector below keeps, why `:root` is
+   load-bearing, and why a Variant may not centre anything vertically here. */
 
-     pnpm variants
-
-   Nothing imports this file — that is what makes an unselected Variant cost the
-   shipped page nothing — and scripts/check-source.mjs fails the build if
-   anything starts to. design/tools/render-variants.mjs injects it at render
-   time, and NOTES.md is the rest of it, including the grammar every selector
-   below has to keep and why `:root` is load-bearing.
-
-   Five here, and they are five different KINDS of direction rather than five
-   sizes of the same one: a Variant that restates Tokens, one that does it the
-   other way, one that changes the layout, one that changes the surface, and one
-   that is only visible in motion. */
-
-/* Tokens, and nothing else. The whole of a typographic or rhythmic direction
-   fits here, and this is what a Variant looked like when it could only be this. */
+/* Tokens only — a typographic and rhythmic direction. */
 :root[data-variant='tight'] .stub {
   --stub-measure: 26rem;
   --stub-gap: 0.75rem;
@@ -32,18 +19,7 @@
   --stub-lead-leading: 1.75;
 }
 
-/* A Section is taller than a screen — the stub is 240svh, because its Timeline
-   is scrubbed by its own scroll — and the sheet shoots the first screen of it,
-   which is what a reader arriving at the Section sees. So a Variant centring
-   anything vertically centres it in that whole box and out of the frame. It is
-   not the sheet mis-measuring; it is the Variant putting the composition off
-   screen, and the first draft of `split` below did exactly that.
-
-   LAYOUT. The measure stops being a column and becomes two: the heading down the
-   left against the copy, and the points laid across the foot rather than listed.
-   Not expressible as Tokens at any price — the component reads Tokens for its
-   lengths, not for its structure, and a direction that has to ask permission of
-   the composition it is arguing with is not an alternative to it. */
+/* Layout: the measure becomes two columns, the points a row across the foot. */
 :root[data-variant='split'] .stub {
   --stub-measure: 66rem;
   --stub-gap: 2rem;
@@ -66,17 +42,12 @@
   flex-direction: row;
 }
 
-/* The one selector here that is not the Section's own: `li` can match nothing
-   outside `.stub__points`, which is why the grammar only asks about the compound
-   right after the gate. */
 :root[data-variant='split'] .stub__points li {
   flex: 1 1 0;
 }
 
-/* SURFACE. The same layout on a plate instead of on the ground, drawn from the
-   Kernel's ink so it holds in both papers and across the Turn. Reading the
-   Kernel is what a Section may do; declaring `--ink` here would be reaching out
-   of it, and the build refuses that. */
+/* Surface: the same copy on a plate, drawn from the Kernel's ink so it holds in
+   both papers and across the Turn. */
 :root[data-variant='plate'] .stub {
   --stub-inset: 10vmin;
   justify-content: center;
@@ -94,13 +65,9 @@
   font-style: italic;
 }
 
-/* MOTION. Nothing to see at rest — --stub-rise is the distance timeline.ts moves
-   the Section through, so this Variant and the Section as it ships are the same
-   picture at progress 0 and different ones at every other moment. Look at it
-   with the sheet's own axis:
-
-     pnpm variants -- --progress 0,0.5,1                                       */
+/* Motion, and NOTHING else, which is what makes it worth having here: at rest it
+   is the unselected direction to the byte, and the sheet says so.
+   `pnpm variants -- --progress 0,0.5,1`. */
 :root[data-variant='drift'] .stub {
   --stub-rise: 56px;
-  --stub-gap: 1.75rem;
 }


### PR DESCRIPTION
Close out the code review of #142

Eleven findings from a two-axis review of #152 — does it keep this repository's
documented standards, and does it do what the ticket asked. Ten fixed, one kept
with a reason.

**A comment that lost its hash, and the trap under it.** `.gitignore` line 129
became two lines, the second a live ignore pattern. The edit that did it never
touched that line: `.gitignore` carries a lone `\r` mid-comment between `from ` and
`render.mjs` — the only CR in the file — and universal-newline decoding turns a
bare CR into a line ending, so any tool that reads the file as text and writes it
back splits the comment. Fixed on bytes, and the CR is gone so the next tool to
round-trip it cannot re-break it.

**A Variant could pass every Check and be impossible to look at.** The Check
validated every comma-separated selector in a rule; the renderer matched the first
gate in one and stopped. So

    :root[data-variant='a'] .stub,
    :root[data-variant='b'] .stub { --stub-gap: 2rem }

built cleanly and `b` was never enumerated — no shot, no caption, no error. The two
had their own rule and gate patterns and had already drifted three ways. There is
now one parser, `scripts/variant-sheet.mjs`, read by both.

**The specificity invariant is a Check.** `scopedStyleStrategy: 'where'` plus the
`:root` gate is what makes a Variant outrank the composition it argues with, and it
was a paragraph in five files and an assertion in none — with NOTES.md saying
"change either half and Variants start losing silently", which is the wish ADR 0006
exists to replace. `check-source.mjs` now reads `astro.config.mjs` and fails on a
missing or changed strategy. Both failure modes exercised; four of the five essays
are shorter for it.

**`base` was on an avoid list.** CONTEXT.md's Kernel entry says *avoid: globals,
shared, common, base*, and #142 made `base` the name for the direction with no
Variant selected. It is `unselected` now — which is also the one name a real
Variant cannot collide with, and the tool refuses a Variant that tries.

**The sheet said nothing about a card with nothing in it.** `drift` is the motion
Variant and the default run renders progress 0, where it is the unselected
direction to the byte. Renders are now digested and marked *identical* on the
sheet and in the log, with the cue to pass `--progress`. `drift` also declared a
gap, so it was never actually identical — it is motion and nothing else now, which
is what its comment always claimed.

**Flags.** `--scale` and `--quality` with no value became `NaN` silently, and
`--full 1` silently meant false, while four other flags were validated. All
validated now. `--out` is gone: never passed, and the closing log ignored it
anyway.

**Failures that were stack traces.** A Section with no `tokens.css` was an
unhandled rejection; missing Playwright was a bare `ERR_MODULE_NOT_FOUND` for a
package nothing tells you to install. Both say what to do.

**And the install command itself was wrong** — found by running it. `npm --prefix
design/tools install` from the repo root installs the *cwd's* package into the
prefix, so it adds `"portfolio": "file:../.."` to `design/tools/package.json` and
rewrites the lockfile as a side effect. It is `cd design/tools && npm ci`, and the
docs say why. Also written down: a junction from a worktree to the main checkout's
`design/tools/node_modules` makes `git worktree remove` walk the link and empty the
target.

**Prose out of a Section's source** (ADR 0006). `variants.css` lost about forty
lines of reasoning to NOTES.md, which is where the next Section will read it.

Kept, with the reason in #154: `--turn`, `--full`, `--format`, `--route` and the
tablet and mobile viewports, all called speculative — a Variant may change layout,
so judging one needs viewports, the route is temporary by construction, and the
Effect Stack makes PNG cost a megabyte a screen.

Closes #154
