### PR TITLE
Port the Projects Panel's structure, Rail, masthead and copy (#138)

### DIFF
--- a/src/pages/next.astro
+++ b/src/pages/next.astro
@@ -3,6 +3,7 @@
 // replacing anything. `/portfolio` goes on being the live document until the
 // ticket that flips this route; keeping both up is what lets every porting ticket
 // land without taking the site down.
+import ProjectsPanel from '../sections/projects-panel/ProjectsPanel.astro';
 import Stub from '../sections/stub/Stub.astro';
 import Shell from '../shell/Shell.astro';
 ---
@@ -16,5 +17,9 @@ import Shell from '../shell/Shell.astro';
         though it were. */}
     <meta name="robots" content="noindex" />
   </Fragment>
+  {/* The stub carries data-turn, which is where the crossing into dark happens:
+      across the scroll of whatever stands above the Panel. It is the Front
+      Screen's job once #136 lands it, and the stub goes then. */}
   <Stub />
+  <ProjectsPanel />
 </Shell>

--- a/src/sections/projects-panel/NOTES.md
+++ b/src/sections/projects-panel/NOTES.md
@@ -1,0 +1,329 @@
+# The Projects Panel
+
+The dark Section presenting one project at a time. This folder holds the Rail,
+the masthead and its two authored lines, the copy and the engineering points —
+the Panel's shell. **The Frame is #139's and the Plinth is #140's**, and both
+land in this same folder; the two holes they leave are named below so neither
+ticket has to re-derive what the composition already assumes about them.
+
+It is a **port**. Every share, every colour and every word here is
+`portfolio/styles.css`'s and `portfolio/index.html`'s, carried over unchanged.
+The Panel's text, its sizes, its positioning and its motion are all due a rework,
+and that rework is deliberately a later session — once the Editor exists, so the
+alternatives can be judged by eye instead of described. Rebuilding it twice is
+what that ordering avoids, and it is why `variants.css` is empty.
+
+## What it is called
+
+The folder is `projects-panel`, so the root class is `.projects-panel`, the
+Tokens are `--projects-panel-…` and the loader's handle is
+`data-section="projects-panel"` — `check-source.mjs` enforces all three off the
+folder name. The live sheet calls it `.panel` and `--panel-…`; CONTEXT.md calls
+it the **Projects Panel**, and where the two disagree the glossary wins. The
+fragment stays `#projects`, because that is a URL other people may already hold.
+
+## One length, and everything is a share of it
+
+`--projects-panel-w` is the composition's own width — not the window's. Every
+length in the Section is a fraction of it, so the Panel is one drawing at one set
+of proportions and the only thing that changes between windows is how big it is.
+That is what makes "the composition fits the screen" a solvable sentence: a
+self-similar drawing has one height-to-width ratio, so you can solve for the
+width whose height lands exactly on the screen.
+
+Two things can bind it, and the smaller wins:
+
+| branch     | what it is                                                                 |
+| ---------- | -------------------------------------------------------------------------- |
+| the width  | what the page has across, less the Rail and its gap. `--projects-panel-across` is 1 − 0.0274, and 0.0274 is the Rail's own width plus the gap as a share of the composition — added up once, because a grid track cannot be sized from its own siblings. It rounds towards asking for LESS, which is safe twice over: the Rail's floor makes it relatively wider on a small window, and `100vw` counts a scrollbar the layout does not get. Over-asking cannot overflow either way, because the track is `minmax(0, …)`. |
+| the height | the screen less the page's two margins, divided by `--projects-panel-fit` — the composition's height as a share of its width. |
+
+### Where 0.5651 comes from, and when to re-derive it
+
+The height ratio measures 0.5634:
+
+```
+  0.86  × 0.0598      the masthead's line, which is row one's top
++ 1.66  × 0.0380      one subheading line (the rest of row one), plus the 0.66
+                      the Frame is dropped by
++ 0.746923 / 1.945    the Frame: nine columns of twelve less a quarter of a
+                      gutter, over its aspect ratio
++ 0.0869 × 0.746923   the Plinth the Frame stands on, which hangs below its foot
+```
+
+`--projects-panel-fit` is 0.5651, which is that plus a third of a percent of
+slack for sub-pixel rounding and for the copy's floor on a small window.
+
+**Two of those four terms are for things this folder does not contain yet**, and
+they are kept anyway. The alternative — fitting the drawing to the masthead and
+the copy alone — would make the Panel bigger now and smaller again the moment
+#139 lands the Frame, which is churn in the one number every other length reads.
+So the composition is already the size it will be, and row two is empty until the
+Frame arrives to fill it.
+
+**Re-derive it** if you move the masthead or the subheading share, the Frame's
+columns or its aspect, or either of the Plinth's two depths. Those seven numbers
+*are* this one. It was 0.5 before the Plinth arrived.
+
+### Two of the five sizes get a floor, and it is in px
+
+A share of the composition stops being readable somewhere — a 1280×720 laptop
+draws the drawing at half the width a 2560 display does — so a floor is wanted.
+But a floor is a break in the self-similarity the fit is solved on, and a block
+that stops shrinking eventually outgrows the space the drawing left it.
+
+The points and the Rail can afford one because they sit in slack: the points
+column runs to two fifths of its row and the Rail is three words against the
+whole screen's height. **The copy cannot**, and it is the one that would most
+like to: its height goes as the *square* of its type against its column — a floor
+makes the type bigger and the column no wider — and it is measured against row
+one, which is a stated height. Floored at 0.7rem it ran 30px past a row of 71 at
+an 800px composition. The masthead and the subheading have no floor for the
+harder version of the same reason: those two *are* the composition's height.
+
+The floors are in **px and not rem** because inside the live page's one-screen
+band the root's font size is solved from the window, so a rem is 11-something px
+on exactly the short screens the floors exist for. A floor that shrinks with the
+thing it holds up is not a floor. `/next` has no such band yet; the numbers are
+carried as they are so that the Front Screen's port does not have to re-choose
+them.
+
+## Row one is a stated height, and the second line hangs out of it
+
+The head is bottom-aligned in row one and carries a negative bottom margin of
+exactly one subheading line, so its box ends after the **first** line and the
+second hangs below it — into row two, whose top edge is therefore the second
+line's top edge, at every window width and whatever set row one's height. That
+one trick is what will make the Frame's occlusion exact rather than lucky: #139
+takes a positive drop from that same edge and lands a fixed fraction of the way
+down the letters. Nothing in the arithmetic goes through the head's total height,
+the copy's height, or the row's.
+
+Row one is `--projects-panel-mast-line` plus one subheading line and **not the
+taller of its two occupants**. It used to be `auto` on the live page, and the
+copy was allowed to set it: the Career Record's page intro ran to 145 words
+against the design render's 55, so on anything narrower than a 2K display the
+paragraph was the taller block, row one grew, and the bottom-aligned head sank a
+third of the way down the screen. That is not available at all once row one's
+height is a term in the fit constant.
+
+There is **no row gap**, and that is load-bearing rather than tidy: the seam
+between the two rows *is* the second line's top edge, so a gap would open under
+the first line and push the subheading apart. Everything that wants air below the
+head asks for it by margin — which is what `--projects-panel-points-air-share`
+is, on top of the one hanging line the points have to clear.
+
+## The masthead, the Cut Title, and why this is a relationship
+
+The word **PROJECTS** is drawn twice on the live page and appears once: in the
+one-screen band the Cut Title — the word cut as a picture at the Front Screen's
+foot — stands in this masthead's slot, and the masthead goes `visibility: hidden`
+underneath it. The word does not fly down to the Section; **the Section comes up
+to the word.**
+
+Two measured quantities are what make that true at every window size rather than
+at the one it was tuned on, and both are declared in the component:
+
+| property                        | what it is                                                                |
+| ------------------------------- | ------------------------------------------------------------------------- |
+| `--projects-panel-masthead-cap` | the masthead's cap height — 0.700 em of Host Grotesk. The Cut Title is cut to exactly this, which is what holds the render's own masthead-cap-to-subheading-cap proportion of 1.59 at every size. Before it was expressed this way the two agreed to within 2% at 1440×1000 and the word ran 29% larger than the masthead at 1920×1080. |
+| `--projects-panel-mast-top`     | where that cap top sits inside its own line box: Host Grotesk spans 1.330 em ascent-to-descent, against a line-height of 0.86, so the half-leading is (0.86 − 1.330)/2 = −0.235, the baseline lands at −0.235 + 1.015 = 0.780, and the cap top is 0.700 above that — 0.080 em of the masthead's size. |
+
+Neither is a Token, because neither is a choice: they are metrics of the face,
+and an Editor slider on one would be a slider that makes the composition wrong.
+
+`--projects-panel-mast-top` is in use here rather than parked: the Section's
+`scroll-margin-top` is the page's own inset **less** the mast top, so following
+the Rail's link comes to rest with the masthead's cap on the line the page's
+margin names — not with the Section's box edge on it. That is the same
+relationship the live page's landing writes, one term shorter because the term it
+drops belongs to the Front Screen's name.
+
+**#136 is where the other half lands.** The Cut Title is the Front Screen's, and
+a Section may read the Kernel and nothing else, so the two Sections cannot read
+each other's Tokens: whichever ticket lands the word has to decide how this
+length crosses — most likely by the Kernel publishing it, which is a decision
+rather than a convenience and is not made here on a guess. What #138 owes it is a
+named relationship rather than a number, and that is what these two are.
+
+## The palette crosses; it does not switch
+
+The five `-far` Tokens are what the Section **is** once the page has turned, and
+they are the same in both themes: the theme toggle chooses what the Panel crosses
+*from*, and nothing about where it ends up. The read halves are `color-mix`es
+against the Kernel's `--ground`, `--ink` and `--ink-soft`, weighted by `--turn`,
+so at the top of the page the Panel is as light as the page above it and it
+arrives black. The near end and the far end cannot share a name — a custom
+property that reads itself is a cycle and drops to unset — which is why there are
+ten declarations rather than five.
+
+`--projects-panel-rule-near` is the one value here that is not the live sheet's.
+Its near end there is `--rule-soft`, the CV's own hairline, and the Kernel
+publishes no hairline colour; it is stated as a share of `--ink-soft` until the
+Front Screen's port brings one.
+
+Two divergences from the live page, both deliberate:
+
+- **The crossing is not gated.** The live sheet only crosses inside its
+  one-screen band and paints the flat far end below it. That gate is about the
+  band, not about the Panel, and `/next`'s Turn is a Kernel property of the page
+  at every width.
+- **`data-turn` is not on this Section.** The crossing happens across the scroll
+  of the Section *above* this one — that is where the reader is while it happens
+  — and the Panel is where it arrives. Today that is the stub; when #136 lands
+  the Front Screen the mark moves there. Marking this Section instead would also
+  give the Turn a zero-length scroll to run in, because the Panel's own height is
+  one screen.
+
+## The Rail
+
+Three project names down the left edge, reading bottom to top, spread over the
+full height of the composition. `writing-mode` plus a half turn **on each item
+and not on the list**: rotating the list would rotate the order with it and put
+Record Engine at the top. Each item then measures as a tall narrow box in an
+ordinary column, so `space-between` still means what it says.
+
+**An entry is a route if it holds a link**, and that is the whole of the
+machinery — there is no attribute saying which Section an entry names, because
+the link's own fragment already does. So the other two projects become two more
+entries with an `href` on the day their Sections arrive, and nothing else
+changes. `selected` is derived the same way: the entry whose fragment names *this*
+Section is the one that is current.
+
+That is also what earns the `<nav>` and `aria-current` — a landmark announcing a
+set of links to nowhere would be worse than no landmark, and one of the three
+leads somewhere. `aria-current` goes on the `<a>`, where it is announced, rather
+than on the `<li>`, where screen readers are not obliged to say anything about
+it. The two that lead nowhere carry the visually-hidden qualifier instead: grey
+says "not selected" to anything looking, and the qualifier says "no page yet" to
+anything listening.
+
+`role="list"` on a list that already is one, because the items carry
+`list-style: none` and VoiceOver drops list semantics from a list with no
+markers.
+
+## The words
+
+All of them are Content, including the two the Rail speaks and never prints.
+
+The copy is the Career Record's `projects/photos.md`, "Page intro" — its first
+sentence, the head of its second, and its last. **Cut, and cut rather than
+re-written**: every word is the record's own, in the record's own order, with the
+tail of the second sentence and the whole of the third lifted out. What went is
+what the four engineering points already carry — the 220 ms triage, the resumable
+build, the stacking rule and the threshold behind it are each a point with its
+figure attached, and saying them twice cost the paragraph three lines it does not
+have. The design render's own copy is generated filler and appears nowhere in the
+record.
+
+The points are the four the record ranks strongest, in its order, each carrying
+the figure that makes it checkable rather than atmospheric. An `<ol>`, because
+the order *is* the ranking; the markers are off, because the figures are the
+numbers the column is about.
+
+The subheading is **two authored lines, not one string left to wrap**. The second
+is the one the Frame will pass in front of, so where it breaks is part of the
+composition rather than a consequence of the column's width. `display: block` on
+the spans rather than a `<br>`, so the break is not a character a screen reader
+has to read around.
+
+`text-transform` and `font-feature-settings: 'case' 1` are listed against five
+selectors rather than hoisted onto the Section, and the list is the point: both
+properties inherit, so hoisting would be shorter and would also apply `case` to
+the body copy, which is lowercase running text. `case` is for punctuation
+standing among capitals — the hyphen in SELF-STACKING, the em dash in the
+figures. On the paragraph it would quietly raise every hyphen in
+"content-addressed" off its own baseline.
+
+## One column, outside the band
+
+Below 1100px the composition becomes a single column as tall as it needs to be:
+the Rail turned across the top, then the masthead, the copy, and the points.
+
+The gate is a **width** and only a width, which was measured rather than assumed.
+Taking the whole one-screen band negated is the tidier sentence and it is wrong:
+a short window makes a small drawing at any width, and 2560×650, 1920×650,
+1600×620 and 1280×660 all keep the composition. The height branch only pulls the
+drawing under the width the failures start at when the window is shorter than
+about 500px.
+
+What actually fails below it is measured too, and both failures come from the
+same place — the copy has no floor while the points and the Rail do, so the
+drawing stops being self-similar and the floored parts outgrow their space. The
+copy goes past reading (6.2px at 820×1000), and the Plinth lands on the
+engineering points (41px of slab over TRIAGE RULE ENGINE at 900px wide). The
+drawing stops eating itself at about 925px; 1100 is 175px above that, and it is
+where the paragraph is still worth reading rather than where the hard failure
+ends.
+
+`not all and (min-width: 1100px)` rather than a `max-width`, so it is that gate's
+exact complement at fractional widths too.
+
+Three things about the stack:
+
+- **The side margin is the page's horizontal one**, not `--projects-panel-inset`.
+  The inset is 9vh — a vertical measure, and one that reads as an error the
+  moment it is used across: on a 390×844 phone it is 76px a side. Top and bottom
+  keep it, where it is measuring what it was written for.
+- **The Rail wraps.** RECORD ENGINE at 0.22em of tracking is a long word, and 360
+  and 320 are real screens; without `wrap` the third project is simply not named,
+  which is not a Rail. The size and the gap are solved together against the three
+  names: at the floors they measure 299 and the row comes to 328, one line from
+  374px of window up.
+- **The points' internal gap becomes a multiple of their own size**, and the
+  number it has to beat is the 0.35em already inside each point: anything at or
+  under that spaces four points exactly as far apart as the two lines of one, and
+  the list reads as eight lines rather than four pairs.
+
+## What #139 and #140 take out of this file
+
+Both land here, and both have a hole named for them:
+
+- **Row two's right-hand side is empty.** The stage is `2 / 3 / 3 / 13` on the
+  live page — nine columns of twelve for the Frame, with the Plinth a column
+  wider on the left — and the row exists at the right height already, because
+  `--projects-panel-fit` counts both.
+- **The hanging second line is un-occluded.** The head's negative margin already
+  puts row two's top edge on that line's top edge; the Frame's drop is measured
+  from there.
+- **The stacked order changes.** #70 asks for masthead, copy, Frame, points, and
+  the points are at `grid-row: 3` here only because there are three blocks. The
+  Frame takes row 3 and the points move to row 4.
+- **The Panel's own motion is nobody's yet.** The live page's exit treatments —
+  the text lifting, the Frame receding, the Plinth sinking, mixable, five numbers
+  each — are what the rework session chooses between, and Variants are the shape
+  that choice now has.
+
+Two more things the live page does that are **not** ported, and neither is an
+omission here: the Effect Stack's `data-fx-no-text` lift, which keeps the print
+off the Section's type, has no mechanism in the Kernel yet and would be the
+Kernel's to add; and the print stylesheet hides the Panel outright, which belongs
+with whichever ticket gives `/next` a print sheet.
+
+## Where this does not match the live page yet, measured
+
+Three differences, all of them consequences of what has not landed rather than
+choices made here. The numbers are off `/next` and `/portfolio` served from the
+same `dist/`, at 1440×900.
+
+**The drawing is short, and it floats.** The composition measures 370px tall here
+against the live page's 720, because rows one and two are the masthead, the copy
+and the points and nothing else. `--projects-panel-fit` already counts the Frame
+and the Plinth, so the *width* is right and the height fills in when #139 and
+#140 arrive; until then `align-self: center` puts the short drawing in the middle
+of the screen instead of hanging it off the top.
+
+**This is the base regime, not the landing.** The live page at 1440×900 is inside
+its one-screen band, where the Cut Title stands in the masthead's slot — and that
+regime re-solves two of the numbers here: the Rail leaves the grid to stand in the
+page's own margin (so the width branch loses the 0.972), and the fit constant is
+re-derived to 0.5603 for the height the Section gives up to the landing. The
+masthead comes out 76.42px there against 74.28px here, 2.9% larger, and the Rail
+stands at x 0..81 rather than inside the composition at x 81..96. **Neither is
+portable without the Cut Title**, which is #136's, and both are one block of
+overrides when it lands. Everything else agrees: the type scale, the two-row
+grid, the hanging second line, the copy at four lines, and the Rail's 10px floor.
+
+**Below 1100px the two are the same drawing.** The stack was compared at 390×844
+and every size matches to the pixel — masthead 46.8, subheading 29.25, copy 14.82,
+Rail 11.31 — and the copy and the figures break on the same words.

--- a/src/sections/projects-panel/ProjectsPanel.astro
+++ b/src/sections/projects-panel/ProjectsPanel.astro
@@ -1,0 +1,422 @@
+---
+// The Projects Panel: the Rail, the masthead and its two authored lines, the
+// copy, and the engineering points. NOTES.md carries the reasoning — what each
+// share was measured from, what the Frame and the Plinth are going to take out
+// of this file, and the two relationships the Cut Title is cut to.
+import { content } from './content';
+import './tokens.css';
+// variants.css is deliberately NOT imported. NOTES.md, and check-source.mjs if
+// this is ever undone.
+
+/** The fragment the Rail's own entry names, and the Section's deep link. */
+const here = 'projects';
+const selected = (project: { href?: string }) => project.href === `#${here}`;
+---
+
+{/* data-section is the loader's handle. No data-turn: the crossing into dark
+    happens across the scroll of the Section ABOVE this one, which is where the
+    reader is when it happens — see NOTES.md. */}
+<section
+  class="projects-panel"
+  id={here}
+  data-section="projects-panel"
+  aria-labelledby="projects-panel-masthead"
+>
+  <nav class="projects-panel__rail" aria-label={content.rail.label}>
+    {/* role="list" on a list that already is one: `list-style: none` costs a
+        list its semantics in VoiceOver, and the Rail is meant to be announced
+        as a list of projects. */}
+    <ul class="projects-panel__rail-items" role="list">
+      {content.rail.projects.map((project) => (
+        <li class:list={['projects-panel__rail-item', { 'is-selected': selected(project) }]}>
+          {project.href ? (
+            <a href={project.href} aria-current={selected(project) ? 'true' : undefined}>
+              {project.name}
+            </a>
+          ) : (
+            <Fragment>
+              {project.name}
+              <span class="projects-panel__quiet">{content.rail.unbuilt}</span>
+            </Fragment>
+          )}
+        </li>
+      ))}
+    </ul>
+  </nav>
+  <div class="projects-panel__inner">
+    <header class="projects-panel__head">
+      <h2 class="projects-panel__masthead" id="projects-panel-masthead">{content.masthead}</h2>
+      <p class="projects-panel__sub">
+        {content.subheading.map((line) => (
+          <span>{line}</span>
+        ))}
+      </p>
+    </header>
+    <div class="projects-panel__copy">
+      {content.copy.map((paragraph) => (
+        <p>{paragraph}</p>
+      ))}
+    </div>
+    <ol class="projects-panel__points">
+      {content.points.map((point) => (
+        <li>
+          <h3>{point.title}</h3>
+          <p>{point.figure}</p>
+        </li>
+      ))}
+    </ol>
+  </div>
+</section>
+
+<style>
+  /* Scoped by the build: none of these selectors can match an element in another
+     Section. Every length is a share of one width — NOTES.md is the derivation. */
+
+  .projects-panel {
+    /* ---- the one length everything else is a share of --------------------- */
+    --projects-panel-fit-w: calc(
+      (var(--fold) - 2 * var(--projects-panel-inset)) / var(--projects-panel-fit)
+    );
+    --projects-panel-w: min(
+      calc(var(--projects-panel-across) * (100vw - 2 * var(--projects-panel-inset))),
+      var(--projects-panel-fit-w)
+    );
+
+    /* ---- the type scale, resolved ----------------------------------------- */
+    --projects-panel-masthead-size: calc(
+      var(--projects-panel-masthead-share) * var(--projects-panel-w)
+    );
+    --projects-panel-sub-size: calc(var(--projects-panel-sub-share) * var(--projects-panel-w));
+    --projects-panel-copy-size: calc(var(--projects-panel-copy-share) * var(--projects-panel-w));
+    --projects-panel-small-size: max(
+      var(--projects-panel-small-floor),
+      calc(var(--projects-panel-small-share) * var(--projects-panel-w))
+    );
+    --projects-panel-rail-size: max(
+      var(--projects-panel-rail-floor),
+      calc(var(--projects-panel-rail-share) * var(--projects-panel-w))
+    );
+
+    /* ---- the gutters, resolved -------------------------------------------- */
+    --projects-panel-gap: calc(var(--projects-panel-gap-share) * var(--projects-panel-w));
+    --projects-panel-gutter: calc(var(--projects-panel-gutter-share) * var(--projects-panel-w));
+    --projects-panel-copy-inset: calc(
+      var(--projects-panel-copy-inset-share) * var(--projects-panel-w)
+    );
+    --projects-panel-points-gap: calc(
+      var(--projects-panel-points-gap-share) * var(--projects-panel-w)
+    );
+    --projects-panel-points-air: calc(
+      var(--projects-panel-points-air-share) * var(--projects-panel-w)
+    );
+    --projects-panel-rail-w: calc(
+      var(--projects-panel-leading) * var(--projects-panel-rail-size)
+    );
+
+    /* ---- the two lengths the composition's height is built out of --------- */
+    --projects-panel-mast-line: calc(
+      var(--projects-panel-masthead-leading) * var(--projects-panel-masthead-size)
+    );
+    --projects-panel-sub-line: calc(
+      var(--projects-panel-sub-leading) * var(--projects-panel-sub-size)
+    );
+
+    /* ---- and the two the Cut Title is cut to ------------------------------ */
+    /* Face metrics rather than choices, which is why they are not Tokens. */
+    --projects-panel-masthead-cap: calc(0.7 * var(--projects-panel-masthead-size));
+    --projects-panel-mast-top: calc(0.08 * var(--projects-panel-masthead-size));
+
+    /* ---- the palette, as the far end of a crossing rather than a constant -- */
+    --projects-panel-bg: color-mix(
+      in oklab,
+      var(--projects-panel-bg-far) calc(var(--turn) * 100%),
+      var(--ground)
+    );
+    --projects-panel-ink: color-mix(
+      in oklab,
+      var(--projects-panel-ink-far) calc(var(--turn) * 100%),
+      var(--ink)
+    );
+    --projects-panel-ink-soft: color-mix(
+      in oklab,
+      var(--projects-panel-ink-soft-far) calc(var(--turn) * 100%),
+      var(--ink-soft)
+    );
+    --projects-panel-muted: color-mix(
+      in oklab,
+      var(--projects-panel-muted-far) calc(var(--turn) * 100%),
+      var(--ink-soft)
+    );
+    --projects-panel-rule: color-mix(
+      in oklab,
+      var(--projects-panel-rule-far) calc(var(--turn) * 100%),
+      var(--projects-panel-rule-near)
+    );
+
+    box-sizing: border-box;
+    position: relative;
+    display: grid;
+    grid-template-columns: var(--projects-panel-rail-w) minmax(0, var(--projects-panel-w));
+    justify-content: center;
+    align-items: center;
+    column-gap: var(--projects-panel-gap);
+    min-height: var(--fold);
+    padding: var(--projects-panel-inset);
+    /* Clip, not hidden, and only across: `hidden` would make the Section a
+       scroll container and break the Rail. */
+    overflow-x: clip;
+    background: var(--projects-panel-bg);
+    color: var(--projects-panel-ink);
+    font-family: var(--face-panel);
+    font-weight: 400;
+    line-height: var(--projects-panel-leading);
+    /* The landing, and the whole of the Cut Title relationship in use: the deep
+       link comes to rest on the masthead's cap top rather than on the Section's
+       own edge. */
+    scroll-margin-top: calc(var(--projects-panel-inset) - var(--projects-panel-mast-top));
+  }
+
+  /* ---- the Rail --------------------------------------------------------- */
+  .projects-panel__rail {
+    /* The one thing in the Section that answers to the SCREEN and not to the
+       composition. */
+    display: flex;
+    align-self: stretch;
+  }
+
+  .projects-panel__rail-items {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: center;
+  }
+
+  .projects-panel__rail-item {
+    /* Turned per ITEM and not on the list: rotating the list would rotate the
+       order with it. */
+    writing-mode: vertical-rl;
+    transform: rotate(180deg);
+    white-space: nowrap;
+    font-size: var(--projects-panel-rail-size);
+    letter-spacing: var(--projects-panel-rail-tracking);
+    color: var(--projects-panel-muted);
+  }
+
+  .projects-panel__rail-item.is-selected {
+    color: var(--projects-panel-ink);
+  }
+
+  .projects-panel__rail-item a {
+    color: inherit;
+    /* Three words in a margin: an underline across a rotated one reads as a
+       strikethrough. */
+    text-decoration: none;
+  }
+
+  .projects-panel__rail-item:not(.is-selected) a:hover {
+    color: var(--projects-panel-ink);
+  }
+
+  .projects-panel__rail-item a:focus-visible {
+    outline: 1px solid currentColor;
+    outline-offset: 3px;
+  }
+
+  .projects-panel__quiet {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    border: 0;
+    clip-path: inset(50%);
+    overflow: hidden;
+    white-space: nowrap;
+  }
+
+  /* ---- the composition: twelve columns, two rows ------------------------- */
+  .projects-panel__inner {
+    display: grid;
+    grid-template-columns: repeat(12, minmax(0, 1fr));
+    grid-template-rows: calc(var(--projects-panel-mast-line) + var(--projects-panel-sub-line)) 1fr;
+    column-gap: var(--projects-panel-gutter);
+    /* No row gap. The seam between the two rows IS the subheading's second
+       line's top edge — see NOTES.md. */
+    row-gap: 0;
+    align-self: center;
+  }
+
+  .projects-panel__head {
+    grid-area: 1 / 1 / 2 / 7;
+    align-self: end;
+    /* Exactly one subheading line, so the head's box ends after the FIRST line
+       and the second hangs into row two. */
+    margin-bottom: calc(-1 * var(--projects-panel-sub-line));
+  }
+
+  /* ---- how the five capitalised things are set --------------------------- */
+  /* Listed rather than hoisted onto the Section: `case` on the body copy would
+     raise the hyphen in "content-addressed" off its own baseline. */
+  .projects-panel__masthead,
+  .projects-panel__sub,
+  .projects-panel__rail-item,
+  .projects-panel__points h3,
+  .projects-panel__points p {
+    text-transform: uppercase;
+    font-feature-settings: 'case' 1;
+  }
+
+  .projects-panel__masthead {
+    margin: 0;
+    font-size: var(--projects-panel-masthead-size);
+    font-weight: var(--projects-panel-masthead-weight);
+    line-height: var(--projects-panel-masthead-leading);
+    letter-spacing: var(--projects-panel-masthead-tracking);
+    color: var(--projects-panel-ink);
+  }
+
+  .projects-panel__sub {
+    margin: 0;
+    font-size: var(--projects-panel-sub-size);
+    font-weight: 400;
+    line-height: var(--projects-panel-sub-leading);
+    color: var(--projects-panel-muted);
+  }
+
+  /* `block` on the spans rather than a <br>, so the break is a property of the
+     composition and not a character a screen reader has to read around. */
+  .projects-panel__sub span {
+    display: block;
+  }
+
+  .projects-panel__copy {
+    grid-area: 1 / 7 / 2 / 13;
+    align-self: start;
+    border-left: 1px solid var(--projects-panel-rule);
+    padding-left: var(--projects-panel-copy-inset);
+    font-size: var(--projects-panel-copy-size);
+    line-height: var(--projects-panel-copy-leading);
+    color: var(--projects-panel-ink-soft);
+  }
+
+  .projects-panel__copy p {
+    margin: 0;
+  }
+
+  .projects-panel__copy p + p {
+    margin-top: 1em;
+  }
+
+  /* An <ol> because the order IS the ranking; the numbers are off because the
+     figures are the numbers this column is about. */
+  .projects-panel__points {
+    grid-area: 2 / 1 / 3 / 4;
+    align-self: start;
+    /* One hanging subheading line, plus air. A longhand would be shorter and
+       would also reset the list-style and the padding below it. */
+    margin: calc(var(--projects-panel-sub-line) + var(--projects-panel-points-air)) 0 0;
+    list-style: none;
+    padding: 0;
+    display: grid;
+    row-gap: var(--projects-panel-points-gap);
+  }
+
+  .projects-panel__points h3 {
+    margin: 0;
+    font-size: var(--projects-panel-small-size);
+    font-weight: var(--projects-panel-point-weight);
+    line-height: var(--projects-panel-point-leading);
+    letter-spacing: var(--projects-panel-point-tracking);
+    color: var(--projects-panel-ink);
+  }
+
+  .projects-panel__points p {
+    margin: var(--projects-panel-figure-air) 0 0;
+    font-size: var(--projects-panel-small-size);
+    line-height: var(--projects-panel-figure-leading);
+    letter-spacing: var(--projects-panel-figure-tracking);
+    color: var(--projects-panel-muted);
+  }
+
+  /* ---- one column, outside the band the composition is fitted to ---------
+     The drawing stops being self-similar below about 925px — the floored parts
+     outgrow the space the shares left them — so it becomes a stack that is as
+     tall as it needs to be. NOTES.md has the sweep. */
+  @media not all and (min-width: 1100px) {
+    .projects-panel {
+      /* No height term and no fit to solve for: the stack takes the width it is
+         given. The side margin is the page's horizontal one, not --inset, which
+         is a vertical measure and reads as an error used across. */
+      --projects-panel-w: calc(100vw - 2 * var(--projects-panel-side));
+      --projects-panel-masthead-size: var(--projects-panel-masthead-stacked);
+      --projects-panel-sub-size: var(--projects-panel-sub-stacked);
+      --projects-panel-copy-size: var(--projects-panel-copy-stacked);
+      --projects-panel-small-size: var(--projects-panel-small-stacked);
+      --projects-panel-rail-size: var(--projects-panel-rail-stacked);
+
+      padding: var(--projects-panel-inset) var(--projects-panel-side);
+      grid-template-columns: minmax(0, 1fr);
+      row-gap: var(--projects-panel-stack-gap);
+    }
+
+    /* Three names across the top instead of three down an edge, and they wrap:
+       360 and 320 are real screens and RECORD ENGINE does not fit beside the
+       other two on either. */
+    .projects-panel__rail-items {
+      flex-direction: row;
+      flex-wrap: wrap;
+      justify-content: flex-start;
+      align-items: baseline;
+      column-gap: var(--projects-panel-stack-rail-gap);
+      row-gap: var(--projects-panel-stack-rail-rows);
+    }
+
+    .projects-panel__rail-item {
+      writing-mode: horizontal-tb;
+      transform: none;
+    }
+
+    .projects-panel__inner {
+      grid-template-columns: minmax(0, 1fr);
+      grid-template-rows: none;
+      align-self: stretch;
+      row-gap: var(--projects-panel-stack-gap);
+    }
+
+    .projects-panel__head,
+    .projects-panel__copy,
+    .projects-panel__points {
+      grid-column: 1;
+      align-self: auto;
+    }
+
+    /* The hanging second line goes back into its own box, and the occlusion the
+       Frame is going to make of it goes with it. */
+    .projects-panel__head {
+      grid-row: 1;
+      margin-bottom: 0;
+    }
+
+    /* The rule moves from the paragraph's left edge to its top, which is where a
+       divider goes when the thing it divides is above rather than beside. */
+    .projects-panel__copy {
+      grid-row: 2;
+      border-left: 0;
+      border-top: 1px solid var(--projects-panel-rule);
+      padding: var(--projects-panel-stack-gap) 0 0;
+      max-width: var(--projects-panel-stack-measure);
+    }
+
+    /* A multiple of the points' own size, and it has to beat the 0.35em inside
+       each point or the list reads as eight lines rather than four pairs. */
+    .projects-panel__points {
+      grid-row: 3;
+      margin-top: 0;
+      row-gap: calc(var(--projects-panel-stack-points-gap) * var(--projects-panel-small-size));
+    }
+  }
+</style>

--- a/src/sections/projects-panel/content.ts
+++ b/src/sections/projects-panel/content.ts
@@ -1,0 +1,91 @@
+import { defineContent, z } from '../../kernel/content';
+
+/**
+ * The Projects Panel's Content, and its schema.
+ *
+ * Every word the Section draws is here, and the two the Rail speaks without ever
+ * printing. NOTES.md says where each of them came from and what was cut.
+ */
+const schema = z.object({
+  /** The Section's accessible name, and the word the Cut Title stands in for. */
+  masthead: z.string().min(1),
+  /**
+   * Two authored lines, not one string left to wrap. Where the break falls is
+   * part of the composition — the second line is the one the Frame passes in
+   * front of — so it is authored rather than a consequence of the column's width.
+   */
+  subheading: z.tuple([z.string().min(1), z.string().min(1)]),
+  rail: z.object({
+    /** The landmark's name. Spoken, never drawn. */
+    label: z.string().min(1),
+    /**
+     * Said after a project with no Section of its own. Grey says it to anything
+     * looking; this says it to anything listening.
+     */
+    unbuilt: z.string().min(1),
+    /**
+     * An entry is a route if it holds a link, and that is the whole of the
+     * machinery — the fragment already names the Section, so no attribute has to.
+     * An entry with no `href` is one of the two that are not built yet.
+     */
+    projects: z
+      .array(
+        z.object({
+          name: z.string().min(1),
+          href: z.string().min(1).optional(),
+        }),
+      )
+      .min(1),
+  }),
+  copy: z.array(z.string().min(1)).min(1),
+  /** In the Career Record's own ranking, which is why the markup is an <ol>. */
+  points: z
+    .array(
+      z.object({
+        title: z.string().min(1),
+        figure: z.string().min(1),
+      }),
+    )
+    .min(1),
+});
+
+export type ProjectsPanelContent = z.output<typeof schema>;
+
+export const content = defineContent(schema, {
+  masthead: 'Projects',
+  subheading: ['Self-stacking', 'photo gallery'],
+  rail: {
+    label: 'Projects',
+    unbuilt: ' — no page yet',
+    projects: [
+      { name: 'Photo Vault', href: '#projects' },
+      { name: 'Eater Map' },
+      { name: 'Record Engine' },
+    ],
+  },
+  copy: [
+    'Twenty years of photographs had turned into 1,374,328 file paths across ' +
+      'overlapping backups. This is the system that turned them into one immutable ' +
+      'content-addressed vault and a website that browses it. When the shipped ' +
+      'result disagreed with what I actually wanted, the objective moved and the ' +
+      'reasoning that produced the old one stayed on the page.',
+  ],
+  points: [
+    {
+      title: 'Label-driven calibration',
+      figure: '96.5% precision, 85.6% recall — measured, not chosen',
+    },
+    {
+      title: 'Screen-then-verify matcher',
+      figure: '3,632,211 candidate pairs, screened to 566,522',
+    },
+    {
+      title: 'Ledger-backed delete gate',
+      figure: '435.6 GB re-hashed and reconciled both ways',
+    },
+    {
+      title: 'Triage rule engine',
+      figure: '1,374,328 paths re-costed in 220 ms',
+    },
+  ],
+});

--- a/src/sections/projects-panel/timeline.ts
+++ b/src/sections/projects-panel/timeline.ts
@@ -1,0 +1,14 @@
+/**
+ * The Projects Panel has no Timeline yet, and that is the ticket's own decision
+ * rather than an omission: the Panel's motion — how the composition arrives and
+ * how it comes apart when it is left — is reworked in a later session, once the
+ * Editor and Variants make it something to choose by eye instead of by
+ * description. Rebuilding it twice is what that ordering avoids. NOTES.md.
+ *
+ * The file exists because every Section holds one, and exporting no default is
+ * how the loader is told there is nothing to register: a Section with no motion
+ * still mounts. Nothing registered means nothing for the `moments` Check to ask
+ * for a moment, which is the honest state — a Timeline wired to nothing is a
+ * failure it exists to catch.
+ */
+export {};

--- a/src/sections/projects-panel/tokens.css
+++ b/src/sections/projects-panel/tokens.css
@@ -1,0 +1,72 @@
+/* The Projects Panel's Tokens: plain custom properties on the Section's own
+   root, and the only style file the Editor writes.
+
+   The composition is ONE DRAWING, and every length in it is a share of one
+   width. So the numbers here are mostly shares rather than sizes — that is what
+   lets the Section be solved to stand on one screen. NOTES.md derives every one
+   of them, and says which are measurements rather than choices. */
+.projects-panel {
+  /* ---- the palette, at the FAR END of the crossing ------------------------ */
+  --projects-panel-bg-far: #000000;
+  --projects-panel-ink-far: #f2f1ee;
+  --projects-panel-ink-soft-far: #dcdad5;
+  --projects-panel-muted-far: #8b8983;
+  --projects-panel-rule-far: rgba(242, 241, 238, 0.16);
+  /* The near end of the hairline, which the Kernel does not publish one of. */
+  --projects-panel-rule-near: color-mix(in oklab, var(--ink-soft), transparent 88%);
+
+  /* ---- the page's two margins, kept rather than invented ------------------ */
+  --projects-panel-inset: clamp(3rem, 9vh, 6.5rem);
+  --projects-panel-side: 1.35rem;
+
+  /* ---- the two constants the composition's width is solved from ----------- */
+  --projects-panel-fit: 0.5651;
+  --projects-panel-across: 0.972;
+
+  /* ---- the type scale: shares of the composition, not of the window ------- */
+  --projects-panel-masthead-share: 0.0598;
+  --projects-panel-sub-share: 0.038;
+  --projects-panel-copy-share: 0.01;
+  --projects-panel-small-share: 0.00668;
+  --projects-panel-rail-share: 0.00549;
+
+  /* Two of the five get a floor, and it is in px. NOTES.md says which and why. */
+  --projects-panel-small-floor: 11px;
+  --projects-panel-rail-floor: 10px;
+
+  /* ---- the same five, for the one column outside the band ----------------- */
+  --projects-panel-masthead-stacked: clamp(2.5rem, 12vw, 5rem);
+  --projects-panel-sub-stacked: calc(0.625 * var(--projects-panel-masthead-size));
+  --projects-panel-copy-stacked: clamp(0.85rem, 3.8vw, 1.05rem);
+  --projects-panel-small-stacked: clamp(0.8rem, 3.2vw, 0.95rem);
+  --projects-panel-rail-stacked: clamp(0.7rem, 2.9vw, 0.9rem);
+
+  /* ---- the gutters, as shares for the same reason ------------------------- */
+  --projects-panel-gap-share: 0.01935;
+  --projects-panel-gutter-share: 0.01231;
+  --projects-panel-copy-inset-share: 0.01407;
+  --projects-panel-points-gap-share: 0.01337;
+  --projects-panel-points-air-share: 0.01583;
+
+  /* ---- how it is set ------------------------------------------------------ */
+  --projects-panel-leading: 1.5;
+  --projects-panel-masthead-leading: 0.86;
+  --projects-panel-masthead-weight: 500;
+  --projects-panel-masthead-tracking: -0.005em;
+  --projects-panel-sub-leading: 1;
+  --projects-panel-copy-leading: 1.5;
+  --projects-panel-rail-tracking: 0.22em;
+  --projects-panel-point-weight: 500;
+  --projects-panel-point-leading: 1.25;
+  --projects-panel-point-tracking: 0.045em;
+  --projects-panel-figure-leading: 1.3;
+  --projects-panel-figure-tracking: 0.03em;
+  --projects-panel-figure-air: 0.35em;
+
+  /* ---- the one column outside the band ------------------------------------ */
+  --projects-panel-stack-gap: clamp(1.5rem, 5vw, 2.5rem);
+  --projects-panel-stack-rail-gap: clamp(0.9rem, 4vw, 2rem);
+  --projects-panel-stack-rail-rows: 0.5em;
+  --projects-panel-stack-points-gap: 1.35;
+  --projects-panel-stack-measure: 34em;
+}

--- a/src/sections/projects-panel/variants.css
+++ b/src/sections/projects-panel/variants.css
@@ -1,0 +1,15 @@
+/* The Projects Panel's Variants — none yet, deliberately.
+
+   This ticket is a port: the Panel reads on `/next` as it reads today, and every
+   number in `tokens.css` is the live sheet's own. Its text, its sizes, its
+   positioning and its motion are all due a rework, and that rework is a later
+   session by design — once the Editor exists, so the alternatives can be judged
+   by eye against the real page rather than argued in prose. A direction invented
+   here would be a guess standing in the record as though it had been compared.
+
+   `pnpm variants` still renders this Section: with nothing declared it shoots the
+   unselected direction alone, which is what `tokens.css` says on its own and the
+   thing every later Variant will be an argument against.
+
+   docs/agents/variants.md is the authority on writing one, and `NOTES.md` in the
+   stub Section is where the grammar `check-source.mjs` enforces is written out. */


### PR DESCRIPTION
The Panel's shell on the new foundation: a Section folder at
src/sections/projects-panel/ holding the Rail, the masthead and its two
authored lines, the copy and the four engineering points. The Frame (#139)
and the Plinth (#140) land in the same folder.

A port, not a redesign. Every share, colour and word is the live sheet's,
carried over unchanged; the Panel's text, sizes, positioning and motion are
reworked in a later session once the Editor makes that a matter of looking
rather than describing, which is why variants.css is empty and timeline.ts
registers nothing.

The composition is still one drawing solved to one width, and the fit
constant still counts the Frame and the Plinth so the drawing is already the
size it will be when they arrive. The masthead's relationship to the Cut
Title survives as two named relationships rather than coordinates — the
masthead's cap, which the word is cut to, and where that cap sits inside its
own line box, which the Section's scroll-margin-top spends. NOTES.md carries
every derivation, the three measured places this does not yet match
/portfolio, and what #139 and #140 take out of the file.
