### PR TITLE
Put the existing site in front of the dev server, not behind it

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,7 +1,7 @@
 import { createReadStream, statSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'astro/config';
-import { contentType, isStaticPath, resolveFile } from './scripts/static-tree.mjs';
+import { contentType, resolveFile, servedFromStaticTree } from './scripts/static-tree.mjs';
 
 const repoRoot = fileURLToPath(new URL('.', import.meta.url)).replace(/[\\/]+$/, '');
 
@@ -12,27 +12,74 @@ const repoRoot = fileURLToPath(new URL('.', import.meta.url)).replace(/[\\/]+$/,
  * under /portfolio/img/, and a built /next reaches them because the assemble
  * step puts both trees in one dist/. Without this the dev server is the only
  * place those URLs 404, which makes the dev server the one surface that cannot
- * be trusted. Registered after Astro's own middleware, so a real route always
- * wins and this only ever answers what Astro did not.
+ * be trusted.
+ *
+ * REGISTERED IN FRONT OF EVERYTHING, which is the opposite of what it used to
+ * say, and the reason is that neither of the two middlewares ahead of it calls
+ * next(). Astro's dev middleware answers an unmatched HTML request with its own
+ * 404, so /portfolio, /portfolio/ and / never reached this at all. Vite's
+ * transform middleware answers /portfolio/styles.css and /fonts/fonts.css by
+ * compiling them into JS modules, `content-type: text/javascript` and an
+ * `import` of /@vite/client at the top — which a <link rel="stylesheet"> will
+ * not apply, so the page came up unstyled the moment its HTML was reachable.
+ * Registered behind those, this middleware served nothing whatsoever; the assets
+ * that did work in dev were Vite's static serving, not this.
+ *
+ * `enforce: 'pre'` and a direct `server.middlewares.use` — rather than the use
+ * inside a returned function, which is Vite's post hook — put it ahead of both.
+ * The files under STATIC_ROOTS are the deployment's verbatim bytes and not Astro
+ * source, so passing them through a build pipeline was never right anyway: this
+ * now serves them exactly as scripts/serve-dist.mjs does, which is what makes
+ * `pnpm dev` and `pnpm preview` agree.
+ *
+ * A REAL ASTRO ROUTE STILL WINS. Running first, this could otherwise shadow a
+ * page somebody adds at src/pages/portfolio.astro, so the promise is kept
+ * explicitly now rather than by ordering: `astro:routes:resolved` hands over
+ * every route Astro has — at startup before the server listens, and again
+ * whenever a page is added or removed — and the middleware stands aside for any
+ * of them.
  */
 function servesTheExistingSite() {
+  // Filled in by the routes:resolved hook below, and read on every request.
+  let astroRoutes = [];
+
+  const middleware = {
+    name: 'portfolio:existing-site',
+    enforce: 'pre',
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        const pathname = (req.url ?? '/').split('?')[0];
+        if (!servedFromStaticTree(pathname, astroRoutes)) return next();
+        const file = resolveFile(repoRoot, pathname, { statSync });
+        if (!file) return next();
+        res.setHeader('content-type', contentType(file));
+        // A read that fails after the stat would otherwise take the dev
+        // server down on an unhandled 'error'.
+        createReadStream(file)
+          .on('error', () => res.destroy())
+          .pipe(res);
+      });
+    },
+  };
+
   return {
     name: 'portfolio:existing-site',
-    configureServer(server) {
-      return () => {
-        server.middlewares.use((req, res, next) => {
-          const pathname = (req.url ?? '/').split('?')[0];
-          if (!isStaticPath(pathname)) return next();
-          const file = resolveFile(repoRoot, pathname, { statSync });
-          if (!file) return next();
-          res.setHeader('content-type', contentType(file));
-          // A read that fails after the stat would otherwise take the dev
-          // server down on an unhandled 'error'.
-          createReadStream(file)
-            .on('error', () => res.destroy())
-            .pipe(res);
-        });
-      };
+    hooks: {
+      'astro:config:setup': ({ updateConfig }) => {
+        updateConfig({ vite: { plugins: [middleware] } });
+      },
+      'astro:routes:resolved': ({ routes }) => {
+        // Only routes somebody wrote under src/pages. Astro's own — /404,
+        // /_image, /_server-islands/[name] — come through as
+        // `origin: 'internal'`, and none of them is a page a static path could
+        // legitimately lose to. None of their patterns matches a static root
+        // today either, so this filter is a guard and not a fix: it is here so
+        // that an internal route with a broader pattern, in some later Astro,
+        // cannot quietly take the whole static tree away.
+        astroRoutes = routes
+          .filter((route) => route.origin === 'project')
+          .map((route) => route.patternRegex);
+      },
     },
   };
 }
@@ -60,5 +107,5 @@ export default defineConfig({
   // src/sections/stub/NOTES.md.
   scopedStyleStrategy: 'where',
   devToolbar: { enabled: false },
-  vite: { plugins: [servesTheExistingSite()] },
+  integrations: [servesTheExistingSite()],
 });

--- a/scripts/static-tree.mjs
+++ b/scripts/static-tree.mjs
@@ -84,6 +84,29 @@ export function resolveFile(baseDir, pathname, fs) {
   return null;
 }
 
+/**
+ * True when the static tree is the thing that should answer `pathname`.
+ *
+ * Two conditions, and the second exists only for the dev server. The path has to
+ * be one STATIC_ROOTS owns, AND no route Astro actually has may claim it.
+ *
+ * The second is what keeps `astro dev` honest. The middleware that serves this
+ * tree runs BEFORE Astro's own — it has to, because Astro answers an unmatched
+ * HTML request with its 404 instead of calling next(), so anything registered
+ * behind it is never reached — and running first means it would happily shadow a
+ * real page. Asking Astro which paths it has is what puts the route back in
+ * front. In a built dist/ the same guarantee is assemble-dist.mjs refusing to
+ * copy a static root over a path the build wrote.
+ *
+ * @param {string} pathname
+ * @param {RegExp[]} astroRoutes  patterns for the routes Astro's own pages have,
+ *   and only those — see astro.config.mjs for why its internal ones are dropped.
+ */
+export function servedFromStaticTree(pathname, astroRoutes = []) {
+  if (!isStaticPath(pathname)) return false;
+  return !astroRoutes.some((pattern) => pattern.test(pathname));
+}
+
 /** True when `pathname` is one of the paths STATIC_ROOTS owns. */
 export function isStaticPath(pathname) {
   const first = pathname.replace(/^\/+/, '').split('/')[0];

--- a/scripts/static-tree.test.mjs
+++ b/scripts/static-tree.test.mjs
@@ -1,0 +1,62 @@
+/**
+ * The static tree's own logic, without a server in front of it.
+ *
+ * `servedFromStaticTree` is the dev server's answer to a question the deployment
+ * never has to ask, so it is the part worth pinning: astro.config.mjs registers
+ * its middleware AHEAD of Astro's, and this predicate is the only thing standing
+ * between that and a real page being shadowed by a file of the same name.
+ */
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { isStaticPath, servedFromStaticTree } from './static-tree.mjs';
+
+/** As `astro:routes:resolved` gives them — the src/pages route that exists. */
+const NEXT = /^\/next\/?$/;
+/** Astro's internal fallback, which astro.config.mjs filters out by origin. */
+const FOUR_OH_FOUR = /^\/404\/?$/;
+
+test('the paths STATIC_ROOTS owns are the static tree to answer', () => {
+  for (const pathname of ['/', '/portfolio', '/portfolio/', '/portfolio/index.html', '/fonts/fonts.css', '/projects/og.jpg']) {
+    assert.equal(servedFromStaticTree(pathname, [NEXT]), true, pathname);
+  }
+});
+
+test("a path outside STATIC_ROOTS is not the static tree's", () => {
+  for (const pathname of ['/next', '/src/pages/next.astro', '/@vite/client', '/_astro/index.css']) {
+    assert.equal(servedFromStaticTree(pathname, [NEXT]), false, pathname);
+  }
+});
+
+test('a real Astro route takes its path back off the static tree', () => {
+  // What adding src/pages/portfolio.astro looks like from here. The file
+  // portfolio/index.html still exists — the point is that it stops being served.
+  const portfolio = /^\/portfolio\/?$/;
+  assert.equal(servedFromStaticTree('/portfolio', [NEXT, portfolio]), false);
+  assert.equal(servedFromStaticTree('/portfolio/', [NEXT, portfolio]), false);
+  // Only the route's own path, though. The assets under it are nobody else's.
+  assert.equal(servedFromStaticTree('/portfolio/styles.css', [NEXT, portfolio]), true);
+});
+
+test('no routes yet is the static tree answering, not nothing', () => {
+  // The hook has fired before the server listens every time it has been looked
+  // at, but a middleware that served 404s until it did would be a worse failure
+  // than one that briefly ignored a route nobody has added.
+  assert.equal(servedFromStaticTree('/portfolio', []), true);
+  assert.equal(servedFromStaticTree('/next', []), false);
+});
+
+test("Astro's internal 404 route does not claim the portal", () => {
+  // It cannot match `/` anyway; the assertion is that passing it in changes
+  // nothing, so filtering by origin at the call site stays a guard and not a fix.
+  assert.equal(servedFromStaticTree('/', [NEXT, FOUR_OH_FOUR]), true);
+  assert.equal(servedFromStaticTree('/portfolio', [NEXT, FOUR_OH_FOUR]), true);
+});
+
+test('isStaticPath is the whitelist and nothing more', () => {
+  assert.equal(isStaticPath('/'), true);
+  assert.equal(isStaticPath('/portfolio/img/tex/paper-512.webp'), true);
+  assert.equal(isStaticPath('/docs/agents/domain.md'), false);
+  assert.equal(isStaticPath('/README.md'), false);
+});


### PR DESCRIPTION
`pnpm dev` is documented as serving the existing static site beside `/next`, "so `/portfolio` and `/next` both answer on one origin". It did not.

## Before

| path | before | after |
| --- | --- | --- |
| `/next` | `200 text/html` | `200 text/html` |
| `/portfolio/styles.css` | `200 text/javascript` | `200 text/css` |
| `/portfolio` | `404` | `200 text/html` |
| `/portfolio/` | `404` | `200 text/html` |
| `/portfolio/index.html` | `404` | `200 text/html` |
| `/` (the portal) | `404` | `200 text/html` |

## The diagnosis

The middleware registered itself in Vite's **post** hook — the function returned from `configureServer` — on the reasoning that running behind Astro made a real route win.

**Nothing ever reached it.** Instrumented with a `console.error` on entry, the post hook was entered **zero times** for every path tried, `/portfolio/styles.css` and `/projects/og.jpg` included. Astro's dev middleware answers an unmatched HTML request with its own 404 rather than calling `next()`, so the four HTML paths stopped there; and every asset that appeared to work was Vite's own static serving, which also does not call `next()`.

So the working CSS was not evidence of the middleware working — and it was not actually working. Vite's transform middleware was compiling `/portfolio/styles.css` and `/fonts/fonts.css` into JS modules:

```
content-type: text/javascript
import { createHotContext as __vite__createHotContext } from "/@vite/client"; …
```

No `<link rel="stylesheet">` applies that. The page would have come up **unstyled** the moment its HTML became reachable, so fixing only the 404 would have swapped one broken surface for another.

## The fix

`enforce: 'pre'` plus a direct `server.middlewares.use` — rather than the `use` inside a returned function — puts the middleware ahead of both. The files under `STATIC_ROOTS` are the deployment's verbatim bytes and not Astro source, so a build pipeline in front of them was never right: they are now served exactly as `scripts/serve-dist.mjs` serves them.

**The comment's promise is kept, explicitly rather than by ordering.** Running first, the middleware could otherwise shadow a page added at `src/pages/portfolio.astro`. So the Vite plugin becomes an Astro integration, `astro:routes:resolved` reports every route Astro has, and `servedFromStaticTree` stands aside for any with `origin: 'project'`. Astro's internal routes (`/404`, `/_image`, `/_server-islands/[name]`) are filtered out — none of their patterns matches a static root today, so that filter is a guard, not a fix.

## Verification

- All five reported paths, plus `/`, `?v=` query forms, woff2, webp, jpg and the static site's own `.js`: `pnpm dev` and `pnpm preview` (built `dist/`) return **identical status and content-type** for every one. The only two differences are Astro's own `/next` omitting `charset` in dev, and `serve-dist` sending its 404 without a content-type.
- `/portfolio` rendered in a browser: `styles.css?v=37` is in `document.styleSheets` (it would be absent if the browser had refused it as `text/javascript`), fonts resolve to Vollkorn, images load, **no console errors**.
- **The route-wins promise, live**: dropping in a `src/pages/portfolio.astro` takes `/portfolio` over within a second while `/portfolio/styles.css` still comes from the static tree; removing the file hands the path back.
- `pnpm check` — 10 Checks and 144 unit tests pass, including 6 new ones for `servedFromStaticTree`.

Found while implementing #135 and unrelated to it. No issue was filed for this.